### PR TITLE
Replacing a vector of paths with PathMap in zipper excl. tracking

### DIFF
--- a/src/line_list_node.rs
+++ b/src/line_list_node.rs
@@ -1834,7 +1834,7 @@ impl<V: Clone + Send + Sync> TrieNode<V> for LineListNode<V> {
         }
         if key1.len() > key.len() && key1.starts_with(key) {
             let mut new_node = Self::new();
-            unsafe{ new_node.set_payload_0(&key0[key.len()..], self.is_child_ptr::<0>(), ValOrChildUnion{ _unused: () }) }
+            unsafe{ new_node.set_payload_0(&key1[key.len()..], self.is_child_ptr::<0>(), ValOrChildUnion{ _unused: () }) }
             new_node.val_or_child0 = self.take_payload::<1>().unwrap().into();
             debug_assert!(validate_node(&new_node));
             return Some(TrieNodeODRc::new(new_node));

--- a/src/trie_map.rs
+++ b/src/trie_map.rs
@@ -377,6 +377,12 @@ impl<V: Clone + Send + Sync> PartialQuantale for BytesTrieMap<V> {
     }
 }
 
+impl<V: Clone + Send + Sync> Default for BytesTrieMap<V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::trie_map::*;
@@ -587,7 +593,7 @@ mod tests {
 
         //Through ZipperHeads
         let map_head = map.zipper_head();
-        let mut z = map_head.write_zipper_at_exclusive_path([]);
+        let mut z = map_head.write_zipper_at_exclusive_path([]).unwrap();
         assert_eq!(z.get_value(), None);
         assert_eq!(z.set_value(1), None);
         assert_eq!(z.get_value(), Some(&1));

--- a/src/write_zipper.rs
+++ b/src/write_zipper.rs
@@ -181,7 +181,7 @@ pub trait WriteZipper<V>: Zipper {
 /// A [WriteZipper] for editing and adding paths and values in the trie
 pub struct WriteZipperTracked<'a, 'path, V> {
     z: WriteZipperCore<'a, 'path, V>,
-    _tracker: ZipperTracker<TrackingWrite>,
+    _tracker: Option<ZipperTracker<TrackingWrite>>,
 }
 
 //The Drop impl ensures the tracker gets dropped at the right time
@@ -239,7 +239,23 @@ impl<'a, 'path, V: Clone + Send + Sync> WriteZipperTracked<'a, 'path, V> {
     /// guarantee the path is within the supplied node.
     pub(crate) fn new_with_node_and_path_internal(root_node: &'a mut TrieNodeODRc<V>, root_val: Option<&'a mut Option<V>>, path: &'path [u8], tracker: ZipperTracker<TrackingWrite>) -> Self {
         let core = WriteZipperCore::<'a, 'path, V>::new_with_node_and_path_internal(root_node, root_val, path);
-        Self { z: core, _tracker: tracker, }
+        Self { z: core, _tracker: Some(tracker), }
+    }
+
+    /// Consumes the `WriteZipperTracked`, and returns a [ReadZipperTracked] in its place
+    ///
+    /// The returned read zipper will have the same root and focus as the the consumed write zipper.
+    pub fn into_read_zipper(mut self) -> ReadZipperTracked<'a, 'static, V> {
+        let tracker = self._tracker.take().unwrap().into_reader();
+        let root_node = self.z.focus_stack.take_root().unwrap().borrow();
+        let root_path = &self.z.key.prefix_buf[..self.z.key.root_key.len()];
+        let descended_path = &self.z.key.prefix_buf[self.z.key.root_key.len()..];
+        let root_val = core::mem::take(&mut self.z.root_val);
+        let root_val = root_val.and_then(|root_val| root_val.as_ref());
+
+        let mut new_zipper = ReadZipperTracked::new_with_node_and_cloned_path(root_node, root_path, None, root_val, tracker);
+        new_zipper.descend_to(descended_path);
+        new_zipper
     }
 }
 
@@ -347,6 +363,21 @@ impl <'a, 'k, V: Clone + Send + Sync> WriteZipperUntracked<'a, 'k, V> {
     pub(crate) fn new_with_node_and_path_internal(root_node: &'a mut TrieNodeODRc<V>, root_val: Option<&'a mut Option<V>>, path: &'k [u8]) -> Self {
         let core = WriteZipperCore::<'a, 'k, V>::new_with_node_and_path_internal(root_node, root_val, path);
         Self { z: core }
+    }
+    /// Consumes the `WriteZipperUntracked`, and returns a [ReadZipperUntracked] in its place
+    ///
+    /// The returned read zipper will have the same root and focus as the the consumed write zipper.
+    pub fn into_read_zipper(mut self) -> ReadZipperUntracked<'a, 'static, V> {
+        let tracker = self._tracker.take().map(|tracker| tracker.into_reader());
+        let root_node = self.z.focus_stack.take_root().unwrap().borrow();
+        let root_path = &self.z.key.prefix_buf[..self.z.key.root_key.len()];
+        let descended_path = &self.z.key.prefix_buf[self.z.key.root_key.len()..];
+        let root_val = core::mem::take(&mut self.z.root_val);
+        let root_val = root_val.and_then(|root_val| root_val.as_ref());
+
+        let mut new_zipper = ReadZipperUntracked::new_with_node_and_cloned_path(root_node, root_path, None, root_val, tracker);
+        new_zipper.descend_to(descended_path);
+        new_zipper
     }
 }
 
@@ -1865,4 +1896,52 @@ mod tests {
             "123:dog:Pam:Bandit",
             "123:owl:Sue:Cornelius"]);
     }
+    #[test]
+    fn write_zipper_test_zipper_conversion() {
+        let keys = [
+            "123:dog:Bob:Fido",
+            "123:cat:Jim:Felix",
+            "123:dog:Pam:Bandit",
+            "123:owl:Sue:Cornelius"];
+        let mut map: BytesTrieMap<u64> = keys.iter().enumerate().map(|(i, k)| (k, i as u64)).collect();
+
+        // Simplistic test where the WZ is untracker, created with a statically safe method
+        let mut wz = map.write_zipper_at_path(b"12");
+        assert_eq!(wz.path(), b"");
+        wz.descend_to(b"3:");
+        assert_eq!(wz.path(), b"3:");
+
+        let mut rz = wz.into_read_zipper();
+        assert_eq!(rz.path(), b"3:");
+        rz.reset();
+        assert_eq!(rz.descend_to(b"3:dog:"), true);
+        assert_eq!(rz.child_count(), 2);
+        drop(rz);
+
+        // ZipperHead test, to make sure the tracker is doing the right thing when converted
+        let zh = map.zipper_head();
+        let mut wz = zh.write_zipper_at_exclusive_path(b"12").unwrap();
+        assert_eq!(wz.path(), b"");
+        wz.descend_to(b"3:");
+        assert_eq!(wz.path(), b"3:");
+
+        let mut rz = wz.into_read_zipper();
+        assert_eq!(rz.path(), b"3:");
+        rz.reset();
+        assert_eq!(rz.descend_to(b"3:dog:"), true);
+        assert_eq!(rz.child_count(), 2);
+
+        assert!(zh.write_zipper_at_exclusive_path(b"1").is_err());
+        assert!(zh.write_zipper_at_exclusive_path(b"12").is_err());
+        assert!(zh.write_zipper_at_exclusive_path(b"123").is_err());
+
+        let mut rz2 = zh.read_zipper_at_borrowed_path(b"1").unwrap();
+        assert_eq!(rz2.path(), b"");
+        assert_eq!(rz2.descend_to(b"23:dog:"), true);
+        assert_eq!(rz.child_count(), 2);
+
+        let rz3 = zh.read_zipper_at_borrowed_path(b"123:").unwrap();
+        assert_eq!(rz3.child_count(), 3);
+    }
+
 }

--- a/src/write_zipper.rs
+++ b/src/write_zipper.rs
@@ -181,7 +181,7 @@ pub trait WriteZipper<V>: Zipper {
 /// A [WriteZipper] for editing and adding paths and values in the trie
 pub struct WriteZipperTracked<'a, 'path, V> {
     z: WriteZipperCore<'a, 'path, V>,
-    _tracker: ZipperTracker,
+    _tracker: ZipperTracker<TrackingWrite>,
 }
 
 //The Drop impl ensures the tracker gets dropped at the right time
@@ -237,7 +237,7 @@ impl<'a, 'path, V: Clone + Send + Sync> WriteZipperTracked<'a, 'path, V> {
     ///
     /// NOTE: This method currently doesn't descend subnodes.  Use [Self::new_with_node_and_path] if you can't
     /// guarantee the path is within the supplied node.
-    pub(crate) fn new_with_node_and_path_internal(root_node: &'a mut TrieNodeODRc<V>, root_val: Option<&'a mut Option<V>>, path: &'path [u8], tracker: ZipperTracker) -> Self {
+    pub(crate) fn new_with_node_and_path_internal(root_node: &'a mut TrieNodeODRc<V>, root_val: Option<&'a mut Option<V>>, path: &'path [u8], tracker: ZipperTracker<TrackingWrite>) -> Self {
         let core = WriteZipperCore::<'a, 'path, V>::new_with_node_and_path_internal(root_node, root_val, path);
         Self { z: core, _tracker: tracker, }
     }
@@ -280,7 +280,7 @@ pub struct WriteZipperUntracked<'a, 'k, V> {
     z: WriteZipperCore<'a, 'k, V>,
     /// We will still track the zipper in debug mode, because unsafe isn't permission to break the rules
     #[cfg(debug_assertions)]
-    _tracker: Option<ZipperTracker>,
+    _tracker: Option<ZipperTracker<TrackingWrite>>,
 }
 
 //We only want a custom drop when we have a tracker
@@ -328,7 +328,7 @@ impl<'a, 'k, V : Clone> zipper_priv::ZipperPriv for WriteZipperUntracked<'a, 'k,
 impl <'a, 'k, V: Clone + Send + Sync> WriteZipperUntracked<'a, 'k, V> {
     /// Creates a new zipper, with a path relative to a node
     #[cfg(debug_assertions)]
-    pub(crate) fn new_with_node_and_path(root_node: &'a mut TrieNodeODRc<V>, root_val: Option<&'a mut Option<V>>, path: &'k [u8], tracker: Option<ZipperTracker>) -> Self {
+    pub(crate) fn new_with_node_and_path(root_node: &'a mut TrieNodeODRc<V>, root_val: Option<&'a mut Option<V>>, path: &'k [u8], tracker: Option<ZipperTracker<TrackingWrite>>) -> Self {
         let core = WriteZipperCore::<'a, 'k, V>::new_with_node_and_path(root_node, root_val, path);
         Self { z: core, _tracker: tracker }
     }
@@ -339,7 +339,7 @@ impl <'a, 'k, V: Clone + Send + Sync> WriteZipperUntracked<'a, 'k, V> {
     }
     /// See [WriteZipper::new_with_node_and_path_internal]
     #[cfg(debug_assertions)]
-    pub(crate) fn new_with_node_and_path_internal(root_node: &'a mut TrieNodeODRc<V>, root_val: Option<&'a mut Option<V>>, path: &'k [u8], tracker: Option<ZipperTracker>) -> Self {
+    pub(crate) fn new_with_node_and_path_internal(root_node: &'a mut TrieNodeODRc<V>, root_val: Option<&'a mut Option<V>>, path: &'k [u8], tracker: Option<ZipperTracker<TrackingWrite>>) -> Self {
         let core = WriteZipperCore::<'a, 'k, V>::new_with_node_and_path_internal(root_node, root_val, path);
         Self { z: core, _tracker: tracker }
     }

--- a/src/zipper.rs
+++ b/src/zipper.rs
@@ -222,7 +222,7 @@ use zipper_priv::*;
 #[derive(Clone)]
 pub struct ReadZipperTracked<'a, 'path, V> {
     z: ReadZipperCore<'a, 'path, V>,
-    _tracker: ZipperTracker,
+    _tracker: ZipperTracker<TrackingRead>,
 }
 
 //The Drop impl ensures the tracker gets dropped at the right time
@@ -284,7 +284,7 @@ impl<V: Clone + Send + Sync> ZipperAbsolutePath for ReadZipperTracked<'_, '_, V>
 
 impl<'a, 'path, V: Clone + Send + Sync> ReadZipperTracked<'a, 'path, V> {
     /// See [ReadZipperCore::new_with_node_and_path]
-    pub(crate) fn new_with_node_and_path(root_node: &'a dyn TrieNode<V>, path: &'path [u8], root_key_offset: Option<usize>, root_val: Option<&'a V>, tracker: ZipperTracker) -> Self {
+    pub(crate) fn new_with_node_and_path(root_node: &'a dyn TrieNode<V>, path: &'path [u8], root_key_offset: Option<usize>, root_val: Option<&'a V>, tracker: ZipperTracker<TrackingRead>) -> Self {
         let core = ReadZipperCore::new_with_node_and_path(root_node, path, root_key_offset, root_val);
         Self { z: core, _tracker: tracker }
     }
@@ -295,7 +295,7 @@ impl<'a, 'path, V: Clone + Send + Sync> ReadZipperTracked<'a, 'path, V> {
     //     Self { z: core, _tracker: tracker }
     // }
     /// See [ReadZipperCore::new_with_node_and_cloned_path]
-    pub(crate) fn new_with_node_and_cloned_path(root_node: &'a dyn TrieNode<V>, path: &[u8], root_key_offset: Option<usize>, root_val: Option<&'a V>, tracker: ZipperTracker) -> Self {
+    pub(crate) fn new_with_node_and_cloned_path(root_node: &'a dyn TrieNode<V>, path: &[u8], root_key_offset: Option<usize>, root_val: Option<&'a V>, tracker: ZipperTracker<TrackingRead>) -> Self {
         let core = ReadZipperCore::new_with_node_and_cloned_path(root_node, path, root_key_offset, root_val);
         Self { z: core, _tracker: tracker }
     }
@@ -321,7 +321,7 @@ pub struct ReadZipperUntracked<'a, 'path, V> {
     z: ReadZipperCore<'a, 'path, V>,
     /// We will still track the zipper in debug mode, because unsafe isn't permission to break the rules
     #[cfg(debug_assertions)]
-    _tracker: Option<ZipperTracker>,
+    _tracker: Option<ZipperTracker<TrackingRead>>,
 }
 
 #[cfg(debug_assertions)]
@@ -385,7 +385,7 @@ impl<V: Clone + Send + Sync> ZipperAbsolutePath for ReadZipperUntracked<'_, '_, 
 impl<'a, 'path, V: Clone + Send + Sync> ReadZipperUntracked<'a, 'path, V> {
     /// See [ReadZipperCore::new_with_node_and_path]
     #[cfg(debug_assertions)]
-    pub(crate) fn new_with_node_and_path(root_node: &'a dyn TrieNode<V>, path: &'path [u8], root_key_offset: Option<usize>, root_val: Option<&'a V>, tracker: Option<ZipperTracker>) -> Self {
+    pub(crate) fn new_with_node_and_path(root_node: &'a dyn TrieNode<V>, path: &'path [u8], root_key_offset: Option<usize>, root_val: Option<&'a V>, tracker: Option<ZipperTracker<TrackingRead>>) -> Self {
         let core = ReadZipperCore::new_with_node_and_path(root_node, path, root_key_offset, root_val);
         Self { z: core, _tracker: tracker }
     }
@@ -396,7 +396,7 @@ impl<'a, 'path, V: Clone + Send + Sync> ReadZipperUntracked<'a, 'path, V> {
     }
     /// See [ReadZipperCore::new_with_node_and_path_internal]
     #[cfg(debug_assertions)]
-    pub(crate) fn new_with_node_and_path_internal(root_node: TaggedNodeRef<'a, V>, path: &'path [u8], root_key_offset: Option<usize>, root_val: Option<&'a V>, tracker: Option<ZipperTracker>) -> Self {
+    pub(crate) fn new_with_node_and_path_internal(root_node: TaggedNodeRef<'a, V>, path: &'path [u8], root_key_offset: Option<usize>, root_val: Option<&'a V>, tracker: Option<ZipperTracker<TrackingRead>>) -> Self {
         let core = ReadZipperCore::new_with_node_and_path_internal(root_node, path, root_key_offset, root_val);
         Self { z: core, _tracker: tracker }
     }
@@ -407,7 +407,7 @@ impl<'a, 'path, V: Clone + Send + Sync> ReadZipperUntracked<'a, 'path, V> {
     }
     /// See [ReadZipperCore::new_with_node_and_cloned_path]
     #[cfg(debug_assertions)]
-    pub(crate) fn new_with_node_and_cloned_path(root_node: &'a dyn TrieNode<V>, path: &[u8], root_key_offset: Option<usize>, root_val: Option<&'a V>, tracker: Option<ZipperTracker>) -> Self {
+    pub(crate) fn new_with_node_and_cloned_path(root_node: &'a dyn TrieNode<V>, path: &[u8], root_key_offset: Option<usize>, root_val: Option<&'a V>, tracker: Option<ZipperTracker<TrackingRead>>) -> Self {
         let core = ReadZipperCore::new_with_node_and_cloned_path(root_node, path, root_key_offset, root_val);
         Self { z: core, _tracker: tracker }
     }

--- a/src/zipper.rs
+++ b/src/zipper.rs
@@ -110,7 +110,29 @@ pub trait Zipper: zipper_priv::ZipperPriv {
     /// focus moved upwards, otherwise returns `false` if the zipper was already at the root
     fn ascend_until(&mut self) -> bool;
 
-//GOAT, this should be deprecated in favor of to_next_sibling_byte and to_prev_sibling_byte
+    /// Ascends the zipper to the nearest upstream value.  Returns `true` if the zipper
+    /// focus moved upwards, otherwise returns `false` if the zipper was already at the root or at a value
+    fn ascend_until_value(&mut self) -> bool {
+        if self.is_value() {
+            return false;
+        }
+        let at_root = !self.ascend_until();
+        if at_root {
+            return false;
+        }
+        loop {
+            if self.is_value() {
+                break;
+            };
+            let done = !self.ascend_until();
+            if done {
+                break;
+            };
+        }
+        return true;
+    }
+
+    //GOAT, this should be deprecated in favor of to_next_sibling_byte and to_prev_sibling_byte
     /// Moves the zipper's focus to a sibling at the same level.  Returns `true` if the focus was changed,
     /// otherwise returns `false`
     ///

--- a/src/zipper_head.rs
+++ b/src/zipper_head.rs
@@ -89,7 +89,7 @@ impl<'parent, 'trie: 'parent, V: Clone + Send + Sync> ZipperHead<'parent, 'trie,
         }
         #[cfg(not(debug_assertions))]
         {
-            ReadZipperUntracked::new_with_node_and_cloned_path(root_node, path.as_ref(), Some(path.len()), root_val, Some(zipper_tracker))
+            ReadZipperUntracked::new_with_node_and_cloned_path(root_node, path.as_ref(), Some(path.len()), root_val)
         }
     }
 

--- a/src/zipper_tracking.rs
+++ b/src/zipper_tracking.rs
@@ -1,120 +1,299 @@
+use std::marker::PhantomData;
+use std::num::NonZero;
+use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::sync::RwLock;
 
-/// Tracks the root path of each zipper, to check for violations against all other outstanding zipper paths.
-/// See [ZipperHead::write_zipper_at_exclusive_path_unchecked].
-pub(crate) struct ZipperTracker {
-    all_paths: SharedTrackerPaths,
-    this_path: Vec<u8>,
-    is_tracking: IsTracking,
-}
+use crate::trie_map::BytesTrieMap;
+use crate::write_zipper::WriteZipper;
+use crate::zipper::WriteZipperUntracked;
+use crate::zipper::Zipper;
+use crate::zipper::ZipperIteration;
 
-impl Clone for ZipperTracker {
-    fn clone(&self) -> Self {
-        match self.is_tracking {
-            IsTracking::ReadZipper => {
-                Self::new_read_tracker_no_check(self.all_paths.clone(), &self.this_path[..])
-            },
-            IsTracking::WriteZipper => { unreachable!() } //Write Zipper should *never* be cloned
-        }
+pub(crate) struct TrackingRead;
+pub(crate) struct TrackingWrite;
+
+pub(crate) trait TrackingMode {
+    fn as_str() -> &'static str;
+}
+impl TrackingMode for TrackingRead {
+    fn as_str() -> &'static str {
+        "read"
+    }
+}
+impl TrackingMode for TrackingWrite {
+    fn as_str() -> &'static str {
+        "write"
     }
 }
 
-#[derive(Clone, Default)]
-pub(crate) struct SharedTrackerPaths(Arc<RwLock<ZipperPaths>>);
+/// Tracks the root path of each zipper, to check for violations against all other outstanding zipper paths.
+/// See [ZipperHead::write_zipper_at_exclusive_path_unchecked].
+pub(crate) struct ZipperTracker<M: TrackingMode> {
+    all_paths: SharedTrackerPaths,
+    this_path: Vec<u8>,
+    _is_tracking: PhantomData<M>,
+}
 
-/// A shared registry of every outstanding zipper
-#[derive(Default)]
-pub(crate) struct ZipperPaths {
-    read_zippers: Vec<Vec<u8>>,
-    write_zippers: Vec<Vec<u8>>
+impl Clone for ZipperTracker<TrackingRead> {
+    fn clone(&self) -> Self {
+        Self::new_no_check(self.all_paths.clone(), &self.this_path[..])
+    }
 }
 
 #[derive(Debug)]
-enum IsTracking {
-    WriteZipper,
-    ReadZipper,
+pub struct Conflict {
+    with: IsTracking,
+    at: Vec<u8>,
 }
 
-impl core::fmt::Debug for ZipperTracker {
+impl std::fmt::Display for Conflict {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let _ = write!(f, "conflicts with existing zipper: ");
+        let _ = match self.with {
+            IsTracking::WriteZipper => write!(f, "write zipper"),
+            IsTracking::ReadZipper(cnt) => write!(f, "read zipper (arity: {cnt:?})"),
+        };
+        let path = &self.at;
+        writeln!(f, " @ {path:?}")
+    }
+}
+
+impl std::error::Error for Conflict {}
+
+impl Conflict {
+    fn write_conflict(path: &[u8]) -> Conflict {
+        Conflict {
+            with: IsTracking::WriteZipper,
+            at: path.to_vec(),
+        }
+    }
+
+    fn read_conflict(cnt: NonZeroU32, path: &[u8]) -> Conflict {
+        Conflict {
+            with: IsTracking::ReadZipper(cnt),
+            at: path.to_vec(),
+        }
+    }
+
+    fn check_for_write_conflict_at(
+        zipper: &WriteZipperUntracked<IsTracking>,
+    ) -> Result<(), Conflict> {
+        if let Some(lock) = zipper.get_value() {
+            return Err(Conflict {
+                with: lock.clone(),
+                at: zipper.path().to_vec(),
+            });
+        }
+        Ok(())
+    }
+
+    fn check_subtree_for_conflict<P>(
+        zipper: &WriteZipperUntracked<IsTracking>,
+        pred: P,
+    ) -> Result<(), Conflict>
+    where
+        P: Fn(&IsTracking) -> bool,
+    {
+        let origin = zipper.path();
+        let mut subtree = zipper.fork_read_zipper();
+        loop {
+            let next_val_in_subtree = subtree.to_next_val();
+            match next_val_in_subtree {
+                Some(lock) => {
+                    if pred(lock) {
+                        let path = subtree.path();
+                        let mut v = Vec::with_capacity(origin.len() + path.len());
+                        v.extend_from_slice(origin);
+                        v.extend_from_slice(path);
+                        return Err(Conflict {
+                            with: lock.clone(),
+                            at: v,
+                        });
+                    }
+                }
+                None => break,
+            }
+        }
+        Ok(())
+    }
+}
+
+/// A shared registry of every outstanding zipper
+#[derive(Clone, Default)]
+pub(crate) struct SharedTrackerPaths(Arc<RwLock<BytesTrieMap<IsTracking>>>);
+
+impl SharedTrackerPaths {
+    fn modify_at<F, R>(&self, path: &[u8], f: F) -> R
+    where
+        F: FnOnce(&mut WriteZipperUntracked<IsTracking>) -> R,
+    {
+        let mut guard = self.0.write().unwrap();
+        let mut write_zipper = guard.write_zipper_at_path(path);
+        let r = f(&mut write_zipper);
+        drop(write_zipper);
+        r
+    }
+
+    fn try_add_writer(&self, path: &[u8]) -> Result<(), Conflict> {
+        let try_add_writer_internal = |write_zipper: &mut WriteZipperUntracked<IsTracking>| {
+            if write_zipper.path_exists() {
+                // check for dangling paths
+                Conflict::check_subtree_for_conflict(
+                    write_zipper,
+                    |_| true, /* any lock causes conflict */
+                )
+            } else {
+                write_zipper.ascend_until();
+
+                Conflict::check_for_write_conflict_at(write_zipper)?;
+
+                let prefix_len = write_zipper.path().len();
+                let suffix = &path[prefix_len..];
+                write_zipper.descend_to(suffix);
+                write_zipper.set_value(IsTracking::WriteZipper);
+                Ok(())
+            }
+        };
+
+        self.modify_at(path, try_add_writer_internal)
+    }
+
+    fn try_add_reader(&self, path: &[u8]) -> Result<(), Conflict> {
+        let try_add_reader_internal = |write_zipper: &mut WriteZipperUntracked<IsTracking>| {
+            let value = write_zipper.get_value_mut();
+            match value {
+                Some(IsTracking::WriteZipper) => Err(Conflict::write_conflict(path)),
+                Some(IsTracking::ReadZipper(cnt)) => match cnt.checked_add(1) {
+                    Some(new_cnt) => {
+                        *cnt = new_cnt;
+                        Ok(())
+                    }
+                    None => Err(Conflict::read_conflict(NonZero::<u32>::MAX, path)),
+                },
+                None => {
+                    // check for the presence of a writer below
+                    Conflict::check_subtree_for_conflict(write_zipper, |lock| {
+                        *lock == IsTracking::WriteZipper
+                    })?;
+                    // check above
+                    write_zipper.ascend_until();
+                    if let Some(IsTracking::WriteZipper) = write_zipper.get_value() {
+                        Err(Conflict::write_conflict(write_zipper.path()))
+                    } else {
+                        let prefix_len = write_zipper.path().len();
+                        let suffix = &path[prefix_len..];
+                        write_zipper.descend_to(suffix);
+                        write_zipper.set_value(IsTracking::ReadZipper(NonZero::<u32>::MIN));
+                        Ok(())
+                    }
+                }
+            }
+        };
+
+        self.modify_at(path, try_add_reader_internal)
+    }
+
+    fn add_reader_unchecked(&self, path: &[u8]) {
+        let add_reader = |write_zipper: &mut WriteZipperUntracked<IsTracking>| {
+            let value = write_zipper.get_value_mut();
+            match value {
+                Some(IsTracking::WriteZipper) => (),
+                Some(IsTracking::ReadZipper(cnt)) => {
+                    *cnt = unsafe { NonZero::new_unchecked(cnt.get() + 1) }
+                }
+                None => {
+                    write_zipper.set_value(IsTracking::ReadZipper(NonZero::<u32>::MIN));
+                }
+            }
+        };
+
+        self.modify_at(path, add_reader)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum IsTracking {
+    WriteZipper,
+    ReadZipper(NonZeroU32),
+}
+
+impl<M: TrackingMode> core::fmt::Debug for ZipperTracker<M> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let all_paths = self.all_paths.0.read().unwrap();
-        let _ = writeln!(f, "ZipperTracker {{ type = {:?}, path = {:?}", self.is_tracking, self.this_path);
+        let (read_zippers, write_zippers): (Vec<_>, Vec<_>) =
+            all_paths
+                .iter()
+                .partition(|(_, is_tracking)| match is_tracking {
+                    IsTracking::ReadZipper(_) => true,
+                    IsTracking::WriteZipper => false,
+                });
+        let _ = writeln!(
+            f,
+            "ZipperTracker {{ type = {:?}, path = {:?}",
+            M::as_str(),
+            self.this_path
+        );
         let _ = writeln!(f, "\tRead Zippers:");
-        for rz in all_paths.read_zippers.iter() {
+        for (rz, _) in read_zippers.iter() {
             let _ = writeln!(f, "\t\t{rz:?}");
         }
         let _ = writeln!(f, "\tWrite Zippers:");
-        for wz in all_paths.write_zippers.iter() {
+        for (wz, _) in write_zippers.iter() {
             let _ = writeln!(f, "\t\t{wz:?}");
         }
         write!(f, "}}")
     }
 }
 
-impl ZipperTracker {
-    pub fn new_write_tracker(shared_paths: SharedTrackerPaths, path: &[u8]) -> Self {
-        let mut shared_paths_guard = shared_paths.0.write().unwrap();
-        for existing_path in shared_paths_guard.read_zippers.iter().chain(shared_paths_guard.write_zippers.iter()) {
-            if existing_path.starts_with(path) || existing_path.len() == 0 {
-                panic!("Illegal WriteZipper at {path:?} conflicts with existing zipper at {existing_path:?}");
-            }
-        }
-        shared_paths_guard.write_zippers.push(path.to_vec());
-        drop(shared_paths_guard);
-        Self{
+impl ZipperTracker<TrackingRead> {
+    pub fn new(shared_paths: SharedTrackerPaths, path: &[u8]) -> Result<Self, Conflict> {
+        shared_paths.try_add_reader(path)?;
+        Ok(Self {
             all_paths: shared_paths,
             this_path: path.to_vec(),
-            is_tracking: IsTracking::WriteZipper,
-        }
+            _is_tracking: PhantomData,
+        })
     }
-    pub fn new_read_tracker(shared_paths: SharedTrackerPaths, path: &[u8]) -> Self {
-        let mut shared_paths_guard = shared_paths.0.write().unwrap();
-        for existing_path in shared_paths_guard.write_zippers.iter() {
-            if existing_path.starts_with(path) || existing_path.len() == 0 {
-                panic!("Illegal ReadZipper at {path:?} conflicts with existing WriteZipper at {existing_path:?}");
-            }
-        }
-        shared_paths_guard.read_zippers.push(path.to_vec());
-        drop(shared_paths_guard);
-        Self{
+
+    pub fn new_no_check(shared_paths: SharedTrackerPaths, path: &[u8]) -> Self {
+        shared_paths.add_reader_unchecked(path);
+        Self {
             all_paths: shared_paths,
             this_path: path.to_vec(),
-            is_tracking: IsTracking::ReadZipper,
+            _is_tracking: PhantomData,
         }
     }
-    pub fn new_read_tracker_no_check(shared_paths: SharedTrackerPaths, path: &[u8]) -> Self {
-        let mut shared_paths_guard = shared_paths.0.write().unwrap();
-        shared_paths_guard.read_zippers.push(path.to_vec());
-        drop(shared_paths_guard);
-        Self{
-            all_paths: shared_paths,
-            this_path: path.to_vec(),
-            is_tracking: IsTracking::ReadZipper,
-        }
-    }
-    //GOAT, it seems we may not need this method after all, because forked ReadZippers never need to be
-    // tracked, because they always exist within the footprint of their parent's permissions
-    // /// Makes a ReadTracker from an existing tracker.  The source can be a WriteTracker or a ReadTracker
-    // pub fn clone_read_tracker(&self, path: &[u8]) -> Self {
-    //     debug_assert!(path.starts_with(&self.this_path));
-    //     Self::new_read_tracker_no_check(self.all_paths.clone(), path)
-    // }
 }
 
-impl Drop for ZipperTracker {
+impl ZipperTracker<TrackingWrite> {
+    pub fn new(shared_paths: SharedTrackerPaths, path: &[u8]) -> Result<Self, Conflict> {
+        shared_paths.try_add_writer(path)?;
+        Ok(Self {
+            all_paths: shared_paths,
+            this_path: path.to_vec(),
+            _is_tracking: PhantomData,
+        })
+    }
+}
+
+impl<M: TrackingMode> Drop for ZipperTracker<M> {
     fn drop(&mut self) {
-        match self.is_tracking {
-            IsTracking::WriteZipper => {
-                let mut guard = self.all_paths.0.write().unwrap();
-                let idx = guard.write_zippers.iter().position(|path| *path == self.this_path).unwrap();
-                guard.write_zippers.remove(idx);
-            },
-            IsTracking::ReadZipper => {
-                let mut guard = self.all_paths.0.write().unwrap();
-                let idx = guard.read_zippers.iter().position(|path| *path == self.this_path).unwrap();
-                guard.read_zippers.remove(idx);
-            }
-        }
+        self.all_paths.modify_at(&self.this_path, |write_zipper| {
+            let value = write_zipper.get_value_mut();
+            match value {
+                Some(IsTracking::WriteZipper) => {
+                    write_zipper.remove_value();
+                }
+                Some(IsTracking::ReadZipper(cnt)) => {
+                    if *cnt == NonZero::<u32>::MIN {
+                        write_zipper.remove_value();
+                    } else {
+                        *cnt = unsafe { NonZero::new_unchecked(cnt.get() - 1) }
+                    }
+                }
+                _ => unreachable!(),
+            };
+        });
     }
 }

--- a/src/zipper_tracking.rs
+++ b/src/zipper_tracking.rs
@@ -49,7 +49,13 @@ pub(crate) struct ZipperTracker<M: TrackingMode> {
 
 impl Clone for ZipperTracker<TrackingRead> {
     fn clone(&self) -> Self {
-        Self::new_no_check(self.all_paths.clone(), &self.this_path[..])
+        self.all_paths
+            .add_reader_unchecked(self.this_path.as_slice());
+        Self {
+            all_paths: self.all_paths.clone(),
+            this_path: self.this_path.clone(),
+            _is_tracking: PhantomData,
+        }
     }
 }
 
@@ -256,15 +262,6 @@ impl ZipperTracker<TrackingRead> {
             this_path: path.to_vec(),
             _is_tracking: PhantomData,
         })
-    }
-
-    pub fn new_no_check(shared_paths: SharedTrackerPaths, path: &[u8]) -> Self {
-        shared_paths.add_reader_unchecked(path);
-        Self {
-            all_paths: shared_paths,
-            this_path: path.to_vec(),
-            _is_tracking: PhantomData,
-        }
     }
 }
 


### PR DESCRIPTION
Plus a couple of related changes:
- replacing panic with error,
- more precise types.

## Changes

### `ZipperTracker` is now parametrized by `TrackingMode`

`TrackingMode` serves as a type-level indicator whether we're tracking writes or reads. In Rust you cannot do much with this - but at the very least we don't need to panic at runtime e.g. in `Clone`. Also various constructors throughout the code are aware of what mode they expect, which may be helpful in further development as there is no way to mix read-tracking zippers with write-tracking zippers.

### `BytesTrieMap` is used instad of `Vec` to track locked paths (`SharedTrackerPaths`)

This helps the complexity as checking no longer needs traversing all of the `n` paths and checking their prefixes. 
The replacement uses `BytesTrieMap` as a prefix tree annotated with `IsTracking` values that designate the subtree as locked for writing, or reading (unsigned non-zero counter)

### Replacing panic with error

The `Conflict` type is implemented, serving as a structured error info, and methods that previously panicked (and were poisoning the locks) now return `Result<(), Conflict>` allowing the caller to graciously handle read/write conflicts

## What does not work?

Tests - I have not finished adapting them - they don't eve compile currently. Will fix in a subsequent PR

## Things to scrutinize

Usage of zippers may be imprecise. Please check methods that rely on certain zipper/trie behavior e.g. `Conflict::check_subtree_for_conflict`, `SharedTrackPaths::try_add_writer`, `SharedTrackPaths::try_add_reader`

## I am sorry for

Reformatting a lot of code which makes the PR much bigger. This is my lack of tooling knowledge showing up (I don't know how to turn it off :smile: ). Perhaps we could have some kind of project-wide formatting config to avoid this stylistic inconsistency?