### PR TITLE
Zipper root nodes

### DIFF
--- a/benches/parallel.rs
+++ b/benches/parallel.rs
@@ -198,7 +198,7 @@ fn parallel_copy_known_path(bencher: Bencher, (elements, thread_cnt): (usize, &s
 
     thread::scope(|scope| {
 
-        let mut zipper_senders: Vec<mpsc::Sender<(ReadZipperUntracked<'_, '_, usize>, WriteZipperUntracked<'_, '_, usize>)>> = Vec::with_capacity(thread_cnt);
+        let mut zipper_senders: Vec<mpsc::Sender<(ReadZipperTracked<'_, '_, usize>, WriteZipperUntracked<'_, '_, usize>)>> = Vec::with_capacity(thread_cnt);
         let mut signal_receivers: Vec<mpsc::Receiver<bool>> = Vec::with_capacity(thread_cnt);
 
         //Spawn all the threads
@@ -214,10 +214,11 @@ fn parallel_copy_known_path(bencher: Bencher, (elements, thread_cnt): (usize, &s
                     match zipper_rx.recv() {
                         Ok((mut reader_z, mut writer_z)) => {
                             //We got the zippers, do the stuff
+                            let witness = reader_z.witness();
                             for i in (n * elements_per_thread)..((n+1) * elements_per_thread) {
                                 let buf = i.to_be_bytes();
                                 reader_z.move_to_path(&buf);
-                                let val = reader_z.get_val().unwrap();
+                                let val = reader_z.get_val_with_witness(&witness).unwrap();
 
                                 writer_z.move_to_path(&buf);
                                 writer_z.set_val(*val);
@@ -260,9 +261,10 @@ fn parallel_copy_known_path(bencher: Bencher, (elements, thread_cnt): (usize, &s
                 //No-thread case, to measure overhead of sync vs. 1-thread case
                 let mut writer_z = unsafe{ zipper_head.write_zipper_at_exclusive_path_unchecked(&[b'o', b'u', b't', 0]) };
                 let mut reader_z = unsafe{ zipper_head.read_zipper_at_path_unchecked(&[b'i', b'n', 0]) };
+                let witness = reader_z.witness();
                 for i in 0..elements {
                     reader_z.move_to_path(i.to_be_bytes());
-                    let val = reader_z.get_val().unwrap();
+                    let val = reader_z.get_val_with_witness(&witness).unwrap();
 
                     writer_z.move_to_path(i.to_be_bytes());
                     writer_z.set_val(*val);
@@ -294,7 +296,7 @@ fn parallel_copy_traverse(bencher: Bencher, (elements, thread_cnt): (usize, &str
 
     thread::scope(|scope| {
 
-        let mut zipper_senders: Vec<mpsc::Sender<(ReadZipperUntracked<'_, '_, usize>, WriteZipperUntracked<'_, '_, usize>)>> = Vec::with_capacity(thread_cnt);
+        let mut zipper_senders: Vec<mpsc::Sender<(ReadZipperTracked<'_, '_, usize>, WriteZipperUntracked<'_, '_, usize>)>> = Vec::with_capacity(thread_cnt);
         let mut signal_receivers: Vec<mpsc::Receiver<bool>> = Vec::with_capacity(thread_cnt);
 
         //Spawn all the threads
@@ -312,7 +314,8 @@ fn parallel_copy_traverse(bencher: Bencher, (elements, thread_cnt): (usize, &str
                     match zipper_rx.recv() {
                         Ok((mut reader_z, mut writer_z)) => {
                             //We got the zippers, do the stuff
-                            while let Some(val) = reader_z.to_next_get_val() {
+                            let witness = reader_z.witness();
+                            while let Some(val) = reader_z.to_next_get_val_with_witness(&witness) {
                                 writer_z.move_to_path(reader_z.path());
                                 writer_z.set_val(*val);
 
@@ -359,7 +362,8 @@ fn parallel_copy_traverse(bencher: Bencher, (elements, thread_cnt): (usize, &str
                 let mut sanity_counter = 0;
                 let mut writer_z = unsafe{ zipper_head.write_zipper_at_exclusive_path_unchecked(&[b'o', b'u', b't', 0]) };
                 let mut reader_z = unsafe{ zipper_head.read_zipper_at_path_unchecked(&[b'i', b'n', 0]) };
-                while let Some(val) = reader_z.to_next_get_val() {
+                let witness = reader_z.witness();
+                while let Some(val) = reader_z.to_next_get_val_with_witness(&witness) {
                     writer_z.move_to_path(reader_z.path());
                     writer_z.set_val(*val);
                     sanity_counter += 1;

--- a/src/dense_byte_node.rs
+++ b/src/dense_byte_node.rs
@@ -483,6 +483,7 @@ impl<V: Clone + Send + Sync, A: Allocator, Cf: CoFree<V=V, A=A>> ByteNode<Cf, A>
 
     /// Merges the entries in the ListNode into the ByteNode
     pub fn merge_from_list_node(&mut self, list_node: &LineListNode<V, A>) -> AlgebraicStatus where V: Clone + Lattice {
+        let self_was_empty = self.is_empty();
         self.reserve_capacity(2);
 
         let slot0_status = if list_node.is_used::<0>() {
@@ -496,7 +497,11 @@ impl<V: Clone + Send + Sync, A: Allocator, Cf: CoFree<V=V, A=A>> ByteNode<Cf, A>
                 self.join_payload_into(key[0], payload)
             }
         } else {
-            AlgebraicStatus::None
+            if self_was_empty {
+                AlgebraicStatus::None
+            } else {
+                AlgebraicStatus::Identity
+            }
         };
 
         let slot1_status = if list_node.is_used::<1>() {
@@ -510,7 +515,11 @@ impl<V: Clone + Send + Sync, A: Allocator, Cf: CoFree<V=V, A=A>> ByteNode<Cf, A>
                 self.join_payload_into(key[0], payload)
             }
         } else {
-            AlgebraicStatus::None
+            if self_was_empty {
+                AlgebraicStatus::None
+            } else {
+                AlgebraicStatus::Identity
+            }
         };
 
         //Note: (true, true) makes sense in the context of a join implementation because when the rec_status or

--- a/src/product_zipper.rs
+++ b/src/product_zipper.rs
@@ -324,7 +324,7 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> zipper_priv::ZipperPriv for P
     type V = V;
     type A = A;
     fn get_focus(&self) -> AbstractNodeRef<'_, Self::V, Self::A> { self.z.get_focus() }
-    fn try_borrow_focus(&self) -> Option<TaggedNodeRef<'_, Self::V, Self::A>> { self.z.try_borrow_focus() }
+    fn try_borrow_focus(&self) -> Option<&TrieNodeODRc<Self::V, Self::A>> { self.z.try_borrow_focus() }
 }
 
 impl<'trie, V: Clone + Send + Sync + Unpin + 'trie, A: Allocator + 'trie> ZipperPathBuffer for ProductZipper<'_, 'trie, V, A> {

--- a/src/trie_map.rs
+++ b/src/trie_map.rs
@@ -192,7 +192,7 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> PathMap<V, A> {
     pub fn trie_ref_at_path<K: AsRef<[u8]>>(&self, path: K) -> TrieRef<'_, V, A> {
         self.ensure_root();
         let path = path.as_ref();
-        trie_ref_at_path_in(self.root().unwrap().as_tagged(), self.root_val(), &[], path, self.alloc.clone())
+        trie_ref_at_path_in(self.root().unwrap(), self.root_val(), &[], path, self.alloc.clone())
     }
 
     /// Creates a new read-only [Zipper], starting at the root of a `PathMap`
@@ -201,11 +201,11 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> PathMap<V, A> {
         let root_val = unsafe{ &*self.root_val.get() }.as_ref();
         #[cfg(debug_assertions)]
         {
-            ReadZipperUntracked::new_with_node_and_path_internal_in(self.root().unwrap().as_tagged(), &[], 0, root_val, self.alloc.clone(), None)
+            ReadZipperUntracked::new_with_node_and_path_internal_in(self.root().unwrap(), &[], 0, root_val, self.alloc.clone(), None)
         }
         #[cfg(not(debug_assertions))]
         {
-            ReadZipperUntracked::new_with_node_and_path_internal_in(self.root().unwrap().as_tagged(), &[], 0, root_val, self.alloc.clone())
+            ReadZipperUntracked::new_with_node_and_path_internal_in(self.root().unwrap(), &[], 0, root_val, self.alloc.clone())
         }
     }
 
@@ -220,11 +220,11 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> PathMap<V, A> {
         };
         #[cfg(debug_assertions)]
         {
-            ReadZipperUntracked::new_with_node_and_path_in(self.root().unwrap().as_tagged(), path.as_ref(), path.len(), 0, root_val, self.alloc.clone(), None)
+            ReadZipperUntracked::new_with_node_and_path_in(self.root().unwrap(), path.as_ref(), path.len(), 0, root_val, self.alloc.clone(), None)
         }
         #[cfg(not(debug_assertions))]
         {
-            ReadZipperUntracked::new_with_node_and_path_in(self.root().unwrap().as_tagged(), path.as_ref(), path.len(), 0, root_val, self.alloc.clone())
+            ReadZipperUntracked::new_with_node_and_path_in(self.root().unwrap(), path.as_ref(), path.len(), 0, root_val, self.alloc.clone())
         }
     }
 
@@ -238,11 +238,11 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> PathMap<V, A> {
         };
         #[cfg(debug_assertions)]
         {
-            ReadZipperUntracked::new_with_node_and_cloned_path_in(self.root().unwrap().as_tagged(), path, path.len(), 0, root_val, self.alloc.clone(), None)
+            ReadZipperUntracked::new_with_node_and_cloned_path_in(self.root().unwrap(), path, path.len(), 0, root_val, self.alloc.clone(), None)
         }
         #[cfg(not(debug_assertions))]
         {
-            ReadZipperUntracked::new_with_node_and_cloned_path_in(self.root().unwrap().as_tagged(), path, path.len(), 0, root_val, self.alloc.clone())
+            ReadZipperUntracked::new_with_node_and_cloned_path_in(self.root().unwrap(), path, path.len(), 0, root_val, self.alloc.clone())
         }
     }
 

--- a/src/trie_map.rs
+++ b/src/trie_map.rs
@@ -116,7 +116,7 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> PathMap<V, A> {
     /// Internal method to ensure there is a valid node at the root of the map
     #[inline]
     pub(crate) fn ensure_root(&self) {
-        let root_ref = unsafe{ &mut *self.root.get() };
+        let root_ref = unsafe{ &*self.root.get() };
         if root_ref.is_some() {
             return
         }
@@ -189,10 +189,10 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> PathMap<V, A> {
     }
 
     /// Creates a new [TrieRef], referring to a position from the root of the `PathMap`
-    pub fn trie_ref_at_path<K: AsRef<[u8]>>(&self, path: K) -> TrieRef<'_, V, A> {
+    pub fn trie_ref_at_path<K: AsRef<[u8]>>(&self, path: K) -> TrieRefBorrowed<'_, V, A> {
         self.ensure_root();
         let path = path.as_ref();
-        trie_ref_at_path_in(self.root().unwrap(), self.root_val(), &[], path, self.alloc.clone())
+        TrieRefBorrowed::new_with_key_and_path_in(self.root().unwrap(), self.root_val(), &[], path, self.alloc.clone())
     }
 
     /// Creates a new read-only [Zipper], starting at the root of a `PathMap`
@@ -220,11 +220,11 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> PathMap<V, A> {
         };
         #[cfg(debug_assertions)]
         {
-            ReadZipperUntracked::new_with_node_and_path_in(self.root().unwrap(), path.as_ref(), path.len(), 0, root_val, self.alloc.clone(), None)
+            ReadZipperUntracked::new_with_node_and_path_in(self.root().unwrap(), false, path.as_ref(), path.len(), 0, root_val, self.alloc.clone(), None)
         }
         #[cfg(not(debug_assertions))]
         {
-            ReadZipperUntracked::new_with_node_and_path_in(self.root().unwrap(), path.as_ref(), path.len(), 0, root_val, self.alloc.clone())
+            ReadZipperUntracked::new_with_node_and_path_in(self.root().unwrap(), false, path.as_ref(), path.len(), 0, root_val, self.alloc.clone())
         }
     }
 

--- a/src/trie_map.rs
+++ b/src/trie_map.rs
@@ -199,14 +199,7 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> PathMap<V, A> {
     pub fn read_zipper<'a>(&'a self) -> ReadZipperUntracked<'a, 'static, V, A> {
         self.ensure_root();
         let root_val = unsafe{ &*self.root_val.get() }.as_ref();
-        #[cfg(debug_assertions)]
-        {
-            ReadZipperUntracked::new_with_node_and_path_internal_in(self.root().unwrap(), &[], 0, root_val, self.alloc.clone(), None)
-        }
-        #[cfg(not(debug_assertions))]
-        {
-            ReadZipperUntracked::new_with_node_and_path_internal_in(self.root().unwrap(), &[], 0, root_val, self.alloc.clone())
-        }
+        ReadZipperUntracked::new_with_node_and_path_internal_in(self.root().unwrap(), &[], 0, root_val, self.alloc.clone())
     }
 
     /// Creates a new read-only [Zipper], with the specified path from the root of the map; This method is much more
@@ -218,14 +211,7 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> PathMap<V, A> {
             true => unsafe{ &*self.root_val.get() }.as_ref(),
             false => None
         };
-        #[cfg(debug_assertions)]
-        {
-            ReadZipperUntracked::new_with_node_and_path_in(self.root().unwrap(), path.as_ref(), path.len(), 0, root_val, self.alloc.clone(), None)
-        }
-        #[cfg(not(debug_assertions))]
-        {
-            ReadZipperUntracked::new_with_node_and_path_in(self.root().unwrap(), path.as_ref(), path.len(), 0, root_val, self.alloc.clone())
-        }
+        ReadZipperUntracked::new_with_node_and_path_in(self.root().unwrap(), path.as_ref(), path.len(), 0, root_val, self.alloc.clone())
     }
 
     /// Creates a new read-only [Zipper], with the `path` specified from the root of the map
@@ -236,14 +222,7 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> PathMap<V, A> {
             true => unsafe{ &*self.root_val.get() }.as_ref(),
             false => None
         };
-        #[cfg(debug_assertions)]
-        {
-            ReadZipperUntracked::new_with_node_and_cloned_path_in(self.root().unwrap(), path, path.len(), 0, root_val, self.alloc.clone(), None)
-        }
-        #[cfg(not(debug_assertions))]
-        {
-            ReadZipperUntracked::new_with_node_and_cloned_path_in(self.root().unwrap(), path, path.len(), 0, root_val, self.alloc.clone())
-        }
+        ReadZipperUntracked::new_with_node_and_cloned_path_in(self.root().unwrap(), path, path.len(), 0, root_val, self.alloc.clone())
     }
 
     /// Creates a new [write zipper](ZipperWriting) starting at the root of the `PathMap`

--- a/src/trie_map.rs
+++ b/src/trie_map.rs
@@ -220,11 +220,11 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> PathMap<V, A> {
         };
         #[cfg(debug_assertions)]
         {
-            ReadZipperUntracked::new_with_node_and_path_in(self.root().unwrap(), false, path.as_ref(), path.len(), 0, root_val, self.alloc.clone(), None)
+            ReadZipperUntracked::new_with_node_and_path_in(self.root().unwrap(), path.as_ref(), path.len(), 0, root_val, self.alloc.clone(), None)
         }
         #[cfg(not(debug_assertions))]
         {
-            ReadZipperUntracked::new_with_node_and_path_in(self.root().unwrap(), false, path.as_ref(), path.len(), 0, root_val, self.alloc.clone())
+            ReadZipperUntracked::new_with_node_and_path_in(self.root().unwrap(), path.as_ref(), path.len(), 0, root_val, self.alloc.clone())
         }
     }
 
@@ -1198,7 +1198,8 @@ mod tests {
 
         let expected = [3, 5, 4];
         let mut i = 0;
-        while let Some(val) = zipper.to_next_get_val() {
+        let witness = zipper.witness();
+        while let Some(val) = zipper.to_next_get_val_with_witness(&witness) {
             assert_eq!(*val, expected[i]);
             i += 1;
         }

--- a/src/trie_node.rs
+++ b/src/trie_node.rs
@@ -2943,6 +2943,9 @@ impl<V: DistributiveLattice + Clone + Send + Sync, A: Allocator> DistributiveLat
 /// Test to make sure slim_ptrs are good with provenance under miri
 #[cfg(test)]
 mod tests {
+    use crate::alloc::{GlobalAlloc, global_alloc};
+    use crate::line_list_node::LineListNode;
+    use crate::trie_node::TrieNodeODRc;
     use crate::PathMap;
     use crate::zipper::*;
 
@@ -2955,7 +2958,6 @@ mod tests {
         drop(z2);
     }
 
-    ///GOAT, This fails in miri!  Fix it!
     #[test]
     fn slim_ptrs_test2() {
         let mut map = PathMap::<()>::new();
@@ -2965,5 +2967,15 @@ mod tests {
         drop(rz);
         drop(wz);
         drop(zh);
+    }
+
+    /// A very basic test of TrieNodeODRc, that doesn't involve the complexity of Zippers or ZipperHead
+    #[test]
+    fn slim_ptrs_test3() {
+        let node = LineListNode::<(), GlobalAlloc>::new_in(global_alloc());
+        let mut node_ref = TrieNodeODRc::new_in(node, global_alloc());
+        let cloned = node_ref.clone();
+        node_ref.make_unique();
+        drop(cloned);
     }
 }

--- a/src/trie_ref.rs
+++ b/src/trie_ref.rs
@@ -626,6 +626,7 @@ impl<V: Clone + Send + Sync, A: Allocator> zipper_priv::ZipperPriv for TrieRefOw
     }
 }
 
+/// A [`witness`](ZipperReadOnlyConditionalValues::witness) type used by [`TrieRefOwned`]
 pub struct TrieRefWitness<V: Clone + Send + Sync, A: Allocator>(TrieRefOwned<V, A>);
 
 impl<'a, V: Clone + Send + Sync + Unpin + 'a, A: Allocator + 'a> ZipperReadOnlyConditionalValues<'a, V> for TrieRefOwned<V, A> {

--- a/src/trie_ref.rs
+++ b/src/trie_ref.rs
@@ -392,8 +392,12 @@ impl<V> ValOrKey<V> {
     /// Returns `true` if the union contains a val, otherwise `false`
     #[inline]
     fn is_val(&self) -> bool {
-        let self_sentinel = unsafe{ self.val.0 };
-        self_sentinel == VAL_SENTINEL
+        if unsafe{ self.node_key.0 } == 0xFF {
+            debug_assert_eq!(VAL_SENTINEL, unsafe{ self.val.0 });
+            true
+        } else {
+            false
+        }
     }
 }
 

--- a/src/trie_ref.rs
+++ b/src/trie_ref.rs
@@ -1,15 +1,14 @@
 
 use core::slice;
 use core::mem::MaybeUninit;
-use std::sync::Arc;
 
 use crate::alloc::{global_alloc, Allocator, GlobalAlloc};
 use crate::utils::ByteMask;
 use crate::PathMap;
 use crate::trie_node::*;
 use crate::zipper::*;
+use crate::zipper::read_zipper_core::*;
 use crate::zipper::zipper_priv::*;
-use crate::zipper_tracking::*;
 
 /// A borrowed read-only reference to a location in a trie
 ///
@@ -49,13 +48,13 @@ use crate::zipper_tracking::*;
 //   Because currently `TinyRefNode` targets a special case, so we need a fallback for when
 //   that case doesn't apply.
 //
-pub struct TrieRef<'a, V: Clone + Send + Sync, A: Allocator = GlobalAlloc> {
+pub struct TrieRefBorrowed<'a, V: Clone + Send + Sync, A: Allocator = GlobalAlloc> {
     focus_node: Option<&'a TrieNodeODRc<V, A>>,
     val_or_key: ValRefOrKey<'a, V>,
     alloc: A
 }
 
-impl<V: Clone + Send + Sync> Default for TrieRef<'_, V> {
+impl<V: Clone + Send + Sync> Default for TrieRefBorrowed<'_, V> {
     fn default() -> Self {
         Self::new_invalid_in(global_alloc())
     }
@@ -66,15 +65,15 @@ impl<V: Clone + Send + Sync> Default for TrieRef<'_, V> {
 union ValRefOrKey<'a, V> {
     /// A length byte, followed by the key bytes themselves
     node_key: (u8, [MaybeUninit<u8>; MAX_NODE_KEY_BYTES]),
-    /// VAL_REF_SENTINEL, followed by the reference to the value
+    /// [`VAL_SENTINEL`], followed by the reference to the value
     val_ref: (u64, Option<&'a V>)
 }
 
 /// Marks the first part of the `val_ref` variant of the [ValRefOrKey] enum.  This will never occur
 /// by accident because the length byte at the beginning of the `node_key` variant has limited range
-const VAL_REF_SENTINEL: u64 = 0xFFFFFFFFFFFFFFFF;
+const VAL_SENTINEL: u64 = 0xFFFFFFFFFFFFFFFF;
 
-/// Marks a [TrieRef] that is invalid.  Same logic as VAL_REF_SENTINEL regarding accidental collision
+/// Marks a [TrieRef] that is invalid.  Same logic as [VAL_SENTINEL] regarding accidental collision
 const BAD_SENTINEL: u64 = 0xFEFEFEFEFEFEFEFE;
 
 impl<V> Clone for ValRefOrKey<'_, V> {
@@ -85,7 +84,7 @@ impl<V> Clone for ValRefOrKey<'_, V> {
 }
 impl<V> Copy for ValRefOrKey<'_, V> {}
 
-impl<V: Clone + Send + Sync, A: Allocator> Clone for TrieRef<'_, V, A> {
+impl<V: Clone + Send + Sync, A: Allocator> Clone for TrieRefBorrowed<'_, V, A> {
     #[inline]
     fn clone(&self) -> Self {
         Self{
@@ -95,16 +94,16 @@ impl<V: Clone + Send + Sync, A: Allocator> Clone for TrieRef<'_, V, A> {
         }
     }
 }
-impl<V: Clone + Send + Sync, A: Allocator + Copy> Copy for TrieRef<'_, V, A> {}
+impl<V: Clone + Send + Sync, A: Allocator + Copy> Copy for TrieRefBorrowed<'_, V, A> {}
 
-impl<'a, V: Clone + Send + Sync + 'a, A: Allocator + 'a> TrieRef<'a, V, A> {
+impl<'a, V: Clone + Send + Sync + 'a, A: Allocator + 'a> TrieRefBorrowed<'a, V, A> {
     /// Makes a new sentinel that points to nothing.  THe allocator is just to keep the type system happy
     pub(crate) fn new_invalid_in(alloc: A) -> Self {
         Self { focus_node: None, val_or_key: ValRefOrKey { val_ref: (BAD_SENTINEL, None) }, alloc }
     }
     /// Internal constructor
     pub(crate) fn new_with_node_and_path_in(root_node: &'a TrieNodeODRc<V, A>, root_val: Option<&'a V>, path: &[u8], alloc: A) -> Self {
-        let (node, key, val) = node_along_path(root_node, path, root_val);
+        let (node, key, val) = node_along_path(root_node, path, root_val, false);
         let node_key_len = key.len();
         let val_or_key = if node_key_len > 0 && node_key_len <= MAX_NODE_KEY_BYTES {
             let mut node_key_bytes = [MaybeUninit::uninit(); MAX_NODE_KEY_BYTES];
@@ -116,7 +115,7 @@ impl<'a, V: Clone + Send + Sync + 'a, A: Allocator + 'a> TrieRef<'a, V, A> {
             ValRefOrKey { node_key: (node_key_len as u8, node_key_bytes) }
         } else {
             if node_key_len <= MAX_NODE_KEY_BYTES {
-                ValRefOrKey { val_ref: (VAL_REF_SENTINEL, val) }
+                ValRefOrKey { val_ref: (VAL_SENTINEL, val) }
             } else {
                 ValRefOrKey { val_ref: (BAD_SENTINEL, None) }
             }
@@ -124,6 +123,52 @@ impl<'a, V: Clone + Send + Sync + 'a, A: Allocator + 'a> TrieRef<'a, V, A> {
 
         Self { focus_node: Some(node), val_or_key, alloc }
     }
+
+    /// Internal function to implement [ZipperReadOnlySubtries::trie_ref_at_path] for all the types that need it
+    pub(crate) fn new_with_key_and_path_in<'paths>(mut node: &'a TrieNodeODRc<V, A>, root_val: Option<&'a V>, node_key: &'paths [u8], mut path: &'paths [u8], alloc: A) -> Self {
+
+        // A temporary buffer on the stack, if we need to assemble a combined key from both the `node_key` and `path`
+        let mut temp_key_buf: [MaybeUninit<u8>; MAX_NODE_KEY_BYTES] = [MaybeUninit::uninit(); MAX_NODE_KEY_BYTES];
+
+        let node_key_len = node_key.len();
+        let path_len = path.len();
+
+        //Copy the existing node key and the first chunk of the path into the temp buffer, and try to
+        // descend one step
+        if node_key_len > 0 && path_len > 0 {
+            let next_node_path = unsafe {
+                let src_ptr = node_key.as_ptr();
+                let dst_ptr = temp_key_buf.as_mut_ptr().cast::<u8>();
+                core::ptr::copy_nonoverlapping(src_ptr, dst_ptr, node_key_len);
+
+                let remaining_len = (MAX_NODE_KEY_BYTES - node_key_len).min(path_len);
+                let src_ptr = path.as_ptr();
+                let dst_ptr = temp_key_buf.as_mut_ptr().cast::<u8>().add(node_key_len);
+                core::ptr::copy_nonoverlapping(src_ptr, dst_ptr, remaining_len);
+
+                let total_buf_len = node_key_len + remaining_len;
+                core::slice::from_raw_parts(temp_key_buf.as_mut_ptr().cast::<u8>(), total_buf_len)
+            };
+
+            if let Some((consumed_byte_cnt, next_node)) = node.as_tagged().node_get_child(next_node_path) {
+                debug_assert!(consumed_byte_cnt >= node_key_len);
+                node = next_node;
+                path = &path[consumed_byte_cnt-node_key_len..];
+            } else {
+                path = next_node_path;
+            }
+        } else {
+            if path_len == 0 {
+                path = node_key;
+            }
+        }
+
+        //Descend the rest of the way along the path
+        let (node, key, val) = node_along_path(node, path, root_val, true);
+
+        TrieRefBorrowed::new_with_node_and_path_in(node, val, key, alloc)
+    }
+
     /// Internal.  Checks if the `TrieRef` is valid, which is a prerequisite to see if it's pointing
     /// at an existing path
     #[inline]
@@ -140,18 +185,18 @@ impl<'a, V: Clone + Send + Sync + 'a, A: Allocator + 'a> TrieRef<'a, V, A> {
             unsafe{ slice::from_raw_parts(self.val_or_key.node_key.1.as_ptr().cast(), key_len) }
         }
     }
-    /// Internal.  Gets the root val from the `TrieRef`, which is `None` if the `TrieRef` has a [Self::node_key]
-    #[inline]
-    fn root_val(&self) -> Option<&'a V> {
-        if unsafe{ self.val_or_key.val_ref.0 } == VAL_REF_SENTINEL {
-            unsafe{ self.val_or_key.val_ref.1 }
-        } else {
-            None
-        }
-    }
+    // /// Internal.  Gets the root val from the `TrieRef`, which is `None` if the `TrieRef` has a [Self::node_key]
+    // #[inline]
+    // fn root_val(&self) -> Option<&'a V> {
+    //     if unsafe{ self.val_or_key.val_ref.0 } == VAL_SENTINEL {
+    //         unsafe{ self.val_or_key.val_ref.1 }
+    //     } else {
+    //         None
+    //     }
+    // }
 }
 
-impl<V: Clone + Send + Sync + Unpin, A: Allocator> Zipper for TrieRef<'_, V, A> {
+impl<V: Clone + Send + Sync + Unpin, A: Allocator> Zipper for TrieRefBorrowed<'_, V, A> {
     fn path_exists(&self) -> bool {
         if self.is_valid() {
             let key = self.node_key();
@@ -183,26 +228,26 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> Zipper for TrieRef<'_, V, A> 
     }
 }
 
-impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperValues<V> for TrieRef<'_, V, A> {
+impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperValues<V> for TrieRefBorrowed<'_, V, A> {
     fn val(&self) -> Option<&V> {
         self.get_val()
     }
 }
 
-impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperForking<V> for TrieRef<'_, V, A> {
+impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperForking<V> for TrieRefBorrowed<'_, V, A> {
     type ReadZipperT<'a> = ReadZipperUntracked<'a, 'a, V, A> where Self: 'a;
     fn fork_read_zipper<'a>(&'a self) -> Self::ReadZipperT<'a> {
-        let core_z = read_zipper_core::ReadZipperCore::new_with_node_and_path_internal_in(self.focus_node.clone(), self.node_key(), 0, self.get_val(), self.alloc.clone());
+        let core_z = read_zipper_core::ReadZipperCore::new_with_node_and_path_internal_in(OwnedOrBorrowed::Borrowed(self.focus_node.unwrap()), self.node_key(), 0, self.val(), self.alloc.clone());
         Self::ReadZipperT::new_forked_with_inner_zipper(core_z)
     }
 }
 
-impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperSubtries<V, A> for TrieRef<'_, V, A> {
+impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperSubtries<V, A> for TrieRefBorrowed<'_, V, A> {
     fn make_map(&self) -> Option<PathMap<Self::V, A>> {
         #[cfg(not(feature = "graft_root_vals"))]
         let root_val = None;
         #[cfg(feature = "graft_root_vals")]
-        let root_val = self.get_val().cloned();
+        let root_val = self.val().cloned();
 
         let root_node = self.get_focus().into_option();
         if root_node.is_some() || root_val.is_some() {
@@ -213,12 +258,17 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperSubtries<V, A> for Trie
     }
 }
 
-impl<V: Clone + Send + Sync, A: Allocator> zipper_priv::ZipperPriv for TrieRef<'_, V, A> {
+impl<V: Clone + Send + Sync, A: Allocator> zipper_priv::ZipperPriv for TrieRefBorrowed<'_, V, A> {
     type V = V;
     type A = A;
     fn get_focus(&self) -> AbstractNodeRef<'_, Self::V, Self::A> {
         if self.is_valid() {
-            self.focus_node.unwrap().as_tagged().get_node_at_key(self.node_key())
+            let node_key = self.node_key();
+            if node_key.len() > 0 {
+                self.focus_node.unwrap().as_tagged().get_node_at_key(self.node_key())
+            } else {
+                AbstractNodeRef::BorrowedRc(&self.focus_node.as_ref().unwrap())
+            }
         } else {
             AbstractNodeRef::None
         }
@@ -243,7 +293,7 @@ impl<V: Clone + Send + Sync, A: Allocator> zipper_priv::ZipperPriv for TrieRef<'
     }
 }
 
-impl<'a, V: Clone + Send + Sync + Unpin + 'a, A: Allocator + 'a> ZipperReadOnlyValues<'a, V> for TrieRef<'a, V, A> {
+impl<'a, V: Clone + Send + Sync + Unpin + 'a, A: Allocator + 'a> ZipperReadOnlyValues<'a, V> for TrieRefBorrowed<'a, V, A> {
     #[inline]
     fn get_val(&self) -> Option<&'a V> {
         if self.is_valid() {
@@ -252,7 +302,7 @@ impl<'a, V: Clone + Send + Sync + Unpin + 'a, A: Allocator + 'a> ZipperReadOnlyV
                 self.focus_node.unwrap().as_tagged().node_get_val(key)
             } else {
                 unsafe{
-                    debug_assert_eq!(self.val_or_key.val_ref.0, VAL_REF_SENTINEL);
+                    debug_assert_eq!(self.val_or_key.val_ref.0, VAL_SENTINEL);
                     self.val_or_key.val_ref.1
                 }
             }
@@ -262,19 +312,485 @@ impl<'a, V: Clone + Send + Sync + Unpin + 'a, A: Allocator + 'a> ZipperReadOnlyV
     }
 }
 
-impl<'a, V: Clone + Send + Sync + Unpin + 'a, A: Allocator + 'a> ZipperReadOnlySubtries<'a, V, A> for TrieRef<'a, V, A> {
-    type TrieRefT = TrieRef<'a, V, A>;
-    fn trie_ref_at_path<K: AsRef<[u8]>>(&self, path: K) -> TrieRef<'a, V, A> {
+impl<'a, V: Clone + Send + Sync + Unpin + 'a, A: Allocator + 'a> ZipperReadOnlySubtries<'a, V, A> for TrieRefBorrowed<'a, V, A> {
+    type TrieRefT = TrieRefBorrowed<'a, V, A>;
+    fn trie_ref_at_path<K: AsRef<[u8]>>(&self, path: K) -> TrieRefBorrowed<'a, V, A> {
         if self.is_valid() {
             let path = path.as_ref();
             let node_key = self.node_key();
             if node_key.len() > 0 {
-                trie_ref_at_path_in(self.focus_node.unwrap(), None, node_key, path, self.alloc.clone())
+                Self::new_with_key_and_path_in(self.focus_node.unwrap(), None, node_key, path, self.alloc.clone())
             } else {
-                trie_ref_at_path_in(self.focus_node.unwrap(), self.root_val(), &[], path, self.alloc.clone())
+                Self::new_with_key_and_path_in(self.focus_node.unwrap(), self.get_val(), &[], path, self.alloc.clone())
             }
         } else {
-            TrieRef::new_invalid_in(self.alloc.clone())
+            Self::new_invalid_in(self.alloc.clone())
+        }
+    }
+    unsafe fn trie_ref_at_path_unchecked<K: AsRef<[u8]>>(&self, path: K) -> TrieRefBorrowed<'a, V, A> {
+        self.trie_ref_at_path(path)
+    }
+}
+
+impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperConcrete for TrieRefBorrowed<'_, V, A> {
+    fn is_shared(&self) -> bool {
+        false //We don't have enough info in the TrieRef to get back to the parent node.  This will change in the future when we move values at zero-length paths into the nodes themselves 
+    }
+}
+
+impl<'a, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> ZipperReadOnlyPriv<'a, V, A> for TrieRefBorrowed<'a, V, A> {
+    fn borrow_raw_parts<'z>(&'z self) -> (TaggedNodeRef<'a, V, A>, &'z [u8], Option<&'a V>) {
+        (self.focus_node.unwrap().as_tagged(), self.node_key(), self.get_val())
+    }
+    fn take_core(&mut self) -> Option<read_zipper_core::ReadZipperCore<'a, 'static, V, A>> {
+        None
+    }
+}
+
+impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperConcretePriv for TrieRefBorrowed<'_, V, A> {
+    fn shared_node_id(&self) -> Option<u64> { read_zipper_core::read_zipper_shared_node_id(self) }
+}
+
+/// An owned read-only reference to a location in a trie.  See [TrieRef]
+///
+#[derive(Clone)]
+pub struct TrieRefOwned<V: Clone + Send + Sync, A: Allocator = GlobalAlloc> {
+    focus_node: Option<TrieNodeODRc<V, A>>,
+    val_or_key: ValOrKey<V>,
+    alloc: A,
+}
+
+/// A TrieRef will never have both a non-zero-len node_key and a non-None value
+#[repr(C)]
+union ValOrKey<V> {
+    /// A length byte, followed by the key bytes themselves
+    node_key: (u8, [MaybeUninit<u8>; MAX_NODE_KEY_BYTES]),
+    /// [`VAL_SENTINEL`], followed by the reference to the value
+    val: (u64, core::mem::ManuallyDrop<Option<V>>)
+}
+
+impl<V> Drop for ValOrKey<V> {
+    fn drop(&mut self) {
+        if self.is_val() {
+            unsafe{ core::mem::ManuallyDrop::drop(&mut self.val.1) }
+        }
+    }
+}
+
+impl<V: Clone> Clone for ValOrKey<V> {
+    fn clone(&self) -> Self {
+        if self.is_val() {
+            let val_ref = unsafe{ &self.val.1 } as &Option<V>;
+            ValOrKey { val: (VAL_SENTINEL, core::mem::ManuallyDrop::new(val_ref.clone())) }
+        } else {
+            ValOrKey { node_key: unsafe{ self.node_key } }
+        }
+    }
+}
+
+impl<V> ValOrKey<V> {
+    /// Returns `true` if the union contains a val, otherwise `false`
+    #[inline]
+    fn is_val(&self) -> bool {
+        let self_sentinel = unsafe{ self.val.0 };
+        self_sentinel == VAL_SENTINEL
+    }
+}
+
+impl<V: Clone + Send + Sync, A: Allocator> TrieRefOwned<V, A> {
+    /// Makes a new sentinel that points to nothing.  THe allocator is just to keep the type system happy
+    pub(crate) fn new_invalid_in(alloc: A) -> Self {
+        Self { focus_node: None, val_or_key: ValOrKey { val: (BAD_SENTINEL, core::mem::ManuallyDrop::new(None)) }, alloc }
+    }
+    /// Internal constructor
+    pub(crate) fn new_with_node_and_path_in(parent_node: &TrieNodeODRc<V, A>, root_val: Option<&V>, path: &[u8], alloc: A) -> Self {
+        let (node, key, val) = node_along_path(parent_node, path, root_val, false);
+        let node_key_len = key.len();
+        let val_or_key = if node_key_len > 0 && node_key_len <= MAX_NODE_KEY_BYTES {
+            let mut node_key_bytes = [MaybeUninit::uninit(); MAX_NODE_KEY_BYTES];
+            unsafe {
+                let src_ptr = key.as_ptr();
+                let dst_ptr = node_key_bytes.as_mut_ptr().cast::<u8>();
+                core::ptr::copy_nonoverlapping(src_ptr, dst_ptr, node_key_len);
+            }
+            ValOrKey { node_key: (node_key_len as u8, node_key_bytes) }
+        } else {
+            if node_key_len <= MAX_NODE_KEY_BYTES {
+                let val = val.cloned();
+                ValOrKey { val: (VAL_SENTINEL, core::mem::ManuallyDrop::new(val)) }
+            } else {
+                ValOrKey { val: (BAD_SENTINEL, core::mem::ManuallyDrop::new(None)) }
+            }
+        };
+
+        Self { focus_node: Some(node.clone()), val_or_key, alloc }
+    }
+
+    /// Internal function to implement [ZipperReadOnlySubtries::trie_ref_at_path] for all the types that need it
+    pub(crate) fn new_with_key_and_path_in<'a, 'paths>(mut node: &TrieNodeODRc<V, A>, root_val: Option<&'a V>, node_key: &'paths [u8], mut path: &'paths [u8], alloc: A) -> Self {
+
+        // A temporary buffer on the stack, if we need to assemble a combined key from both the `node_key` and `path`
+        let mut temp_key_buf: [MaybeUninit<u8>; MAX_NODE_KEY_BYTES] = [MaybeUninit::uninit(); MAX_NODE_KEY_BYTES];
+
+        let node_key_len = node_key.len();
+        let path_len = path.len();
+
+        //Copy the existing node key and the first chunk of the path into the temp buffer, and try to
+        // descend one step
+        if node_key_len > 0 && path_len > 0 {
+            let next_node_path = unsafe {
+                let src_ptr = node_key.as_ptr();
+                let dst_ptr = temp_key_buf.as_mut_ptr().cast::<u8>();
+                core::ptr::copy_nonoverlapping(src_ptr, dst_ptr, node_key_len);
+
+                let remaining_len = (MAX_NODE_KEY_BYTES - node_key_len).min(path_len);
+                let src_ptr = path.as_ptr();
+                let dst_ptr = temp_key_buf.as_mut_ptr().cast::<u8>().add(node_key_len);
+                core::ptr::copy_nonoverlapping(src_ptr, dst_ptr, remaining_len);
+
+                let total_buf_len = node_key_len + remaining_len;
+                core::slice::from_raw_parts(temp_key_buf.as_mut_ptr().cast::<u8>(), total_buf_len)
+            };
+
+            if let Some((consumed_byte_cnt, next_node)) = node.as_tagged().node_get_child(next_node_path) {
+                debug_assert!(consumed_byte_cnt >= node_key_len);
+                node = next_node;
+                path = &path[consumed_byte_cnt-node_key_len..];
+            } else {
+                path = next_node_path;
+            }
+        } else {
+            if path_len == 0 {
+                path = node_key;
+            }
+        }
+
+        //Descend the rest of the way along the path
+        let (node, key, val) = node_along_path(node, path, root_val, true);
+
+        TrieRefOwned::new_with_node_and_path_in(node, val, key, alloc)
+    }
+
+    /// Internal.  Checks if the `TrieRef` is valid, which is a prerequisite to see if it's pointing
+    /// at an existing path
+    #[inline]
+    fn is_valid(&self) -> bool {
+        (unsafe{ self.val_or_key.node_key.0 } != 0xFE)
+    }
+    //GOAT, maybe trash
+    // /// Internal.  Resolves the focus_node from an "unregularized" node_ptr (see the discussion about)
+    // /// the meaning of a "regularized" ReadZipper in zipper.rs.
+    // ///
+    // /// The reason unregularized TrieRefs exist at all is because TrieRefs based off ZipperHeads can't
+    // /// safely store references to parent nodes (and thus to values), so we need to take an owned clone of
+    // /// the parent node's ODRc pointer.
+    // #[inline]
+    // fn focus_node_and_key(&self) -> (&TrieNodeODRc<V, A>, &[u8]) {
+    //     debug_assert!(self.is_valid());
+
+    //     let key = self.node_key();
+    //     let node = self.node.as_ref();
+    //     if key.len() == 0 {
+    //         (node, &[])
+    //     } else {
+    //         if let Some((consumed_bytes, next_node)) = node.as_tagged().node_get_child(key) {
+    //             (next_node, &key[consumed_bytes..])
+    //         } else {
+    //             (node, key)
+    //         }
+    //     }
+    // }
+    /// Internal.  Gets the node key from the `TrieRef`
+    #[inline]
+    fn node_key(&self) -> &[u8] {
+        if self.val_or_key.is_val() {
+            &[]
+        } else {
+            let key_len = unsafe{ self.val_or_key.node_key.0 } as usize;
+            unsafe{ slice::from_raw_parts(self.val_or_key.node_key.1.as_ptr().cast(), key_len) }
+        }
+    }
+}
+
+impl<V: Clone + Send + Sync + Unpin, A: Allocator> Zipper for TrieRefOwned<V, A> {
+    fn path_exists(&self) -> bool {
+        if self.is_valid() {
+            let key = self.node_key();
+            if key.len() > 0 {
+                self.focus_node.as_ref().unwrap().as_tagged().node_contains_partial_key(key)
+            } else {
+                true
+            }
+        } else {
+            false
+        }
+    }
+    fn is_val(&self) -> bool {
+        self.val().is_some()
+    }
+    fn child_count(&self) -> usize {
+        if self.is_valid() {
+            self.focus_node.as_ref().unwrap().as_tagged().count_branches(self.node_key())
+        } else {
+            0
+        }
+    }
+    fn child_mask(&self) -> ByteMask {
+        if self.is_valid() {
+            self.focus_node.as_ref().unwrap().as_tagged().node_branches_mask(self.node_key())
+        } else {
+            ByteMask::EMPTY
+        }
+    }
+}
+
+impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperValues<V> for TrieRefOwned<V, A> {
+    fn val(&self) -> Option<&V> {
+        if self.is_valid() {
+            let key = self.node_key();
+            if key.len() > 0 {
+                self.focus_node.as_ref().unwrap().as_tagged().node_get_val(key)
+            } else {
+                unsafe{
+                    debug_assert_eq!(self.val_or_key.val.0, VAL_SENTINEL);
+                    let option_ref: &Option<V> = &self.val_or_key.val.1;
+                    option_ref.as_ref()
+                }
+            }
+        } else {
+            None
+        }
+    }
+}
+
+impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperForking<V> for TrieRefOwned<V, A> {
+    type ReadZipperT<'a> = ReadZipperUntracked<'a, 'a, V, A> where Self: 'a;
+    fn fork_read_zipper<'a>(&'a self) -> Self::ReadZipperT<'a> {
+        let core_z = read_zipper_core::ReadZipperCore::new_with_node_and_path_internal_in(OwnedOrBorrowed::Borrowed(self.focus_node.as_ref().unwrap()), self.node_key(), 0, self.val(), self.alloc.clone());
+        Self::ReadZipperT::new_forked_with_inner_zipper(core_z)
+    }
+}
+
+impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperSubtries<V, A> for TrieRefOwned<V, A> {
+    fn make_map(&self) -> Option<PathMap<Self::V, A>> {
+        #[cfg(not(feature = "graft_root_vals"))]
+        let root_val = None;
+        #[cfg(feature = "graft_root_vals")]
+        let root_val = self.val().cloned();
+
+        let root_node = self.get_focus().into_option();
+        if root_node.is_some() || root_val.is_some() {
+            Some(PathMap::new_with_root_in(root_node, root_val, self.alloc.clone()))
+        } else {
+            None
+        }
+    }
+}
+
+impl<V: Clone + Send + Sync, A: Allocator> zipper_priv::ZipperPriv for TrieRefOwned<V, A> {
+    type V = V;
+    type A = A;
+    fn get_focus(&self) -> AbstractNodeRef<'_, Self::V, Self::A> {
+        if self.is_valid() {
+            let node_key = self.node_key();
+            if node_key.len() > 0 {
+                self.focus_node.as_ref().unwrap().as_tagged().get_node_at_key(self.node_key())
+            } else {
+                AbstractNodeRef::BorrowedRc(&self.focus_node.as_ref().unwrap())
+            }
+        } else {
+            AbstractNodeRef::None
+        }
+    }
+    fn try_borrow_focus(&self) -> Option<&TrieNodeODRc<Self::V, Self::A>> {
+        if self.is_valid() {
+            let node_key = self.node_key();
+            if node_key.len() == 0 {
+                self.focus_node.as_ref()
+            } else {
+                match self.focus_node.as_ref().unwrap().as_tagged().node_get_child(node_key) {
+                    Some((consumed_bytes, child_node)) => {
+                        debug_assert_eq!(consumed_bytes, node_key.len());
+                        Some(child_node)
+                    },
+                    None => None
+                }
+            }
+        } else {
+            None
+        }
+    }
+}
+
+pub struct TrieRefWitness<V: Clone + Send + Sync, A: Allocator>(TrieRefOwned<V, A>);
+
+impl<'a, V: Clone + Send + Sync + Unpin + 'a, A: Allocator + 'a> ZipperReadOnlyConditionalValues<'a, V> for TrieRefOwned<V, A> {
+    type WitnessT = TrieRefWitness<V, A>;
+    fn witness<'w>(&self) -> Self::WitnessT {
+        TrieRefWitness(self.clone())
+    }
+    #[inline]
+    fn get_val_with_witness<'w>(&self, witness: &'w TrieRefWitness<V, A>) -> Option<&'w V> where 'a: 'w {
+        if self.is_valid() {
+            debug_assert_eq!(witness.0.focus_node, self.focus_node);
+            witness.0.val()
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a, V: Clone + Send + Sync + Unpin + 'a, A: Allocator + 'a> ZipperReadOnlySubtries<'a, V, A> for TrieRefOwned<V, A> {
+    type TrieRefT = TrieRefOwned<V, A>;
+    fn trie_ref_at_path<K: AsRef<[u8]>>(&self, path: K) -> TrieRefOwned<V, A> {
+        if self.is_valid() {
+            let path = path.as_ref();
+            let node_key = self.node_key();
+            Self::new_with_key_and_path_in(self.focus_node.as_ref().unwrap(), self.val(), node_key, path, self.alloc.clone())
+        } else {
+            Self::new_invalid_in(self.alloc.clone())
+        }
+    }
+    unsafe fn trie_ref_at_path_unchecked<K: AsRef<[u8]>>(&self, path: K) -> TrieRefOwned<V, A> {
+        self.trie_ref_at_path(path)
+    }
+}
+
+impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperConcrete for TrieRefOwned<V, A> {
+    fn is_shared(&self) -> bool {
+        false //We don't have enough info in the TrieRef to get back to the parent node.  This will change in the future when we move values at zero-length paths into the nodes themselves 
+    }
+}
+
+impl<'a, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> ZipperReadOnlyPriv<'a, V, A> for TrieRefOwned<V, A> {
+    fn borrow_raw_parts<'z>(&'z self) -> (TaggedNodeRef<'z, V, A>, &'z [u8], Option<&'z V>) {
+        let node = self.focus_node.as_ref().unwrap().as_tagged();
+        (node, self.node_key(), self.val())
+    }
+    fn take_core(&mut self) -> Option<read_zipper_core::ReadZipperCore<'a, 'static, V, A>> {
+        None
+    }
+}
+
+impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperConcretePriv for TrieRefOwned<V, A> {
+    fn shared_node_id(&self) -> Option<u64> { read_zipper_core::read_zipper_shared_node_id(self) }
+}
+
+/// An abstract wrapper type over [TrieRefBorrowed] and [TrieRefOwned], with capabilities that are the intersection
+/// of the two
+#[derive(Clone)]
+pub enum TrieRef<'a, V: Clone + Send + Sync, A: Allocator = GlobalAlloc> {
+    Borrowed(TrieRefBorrowed<'a, V, A>),
+    Owned(TrieRefOwned<V, A>)
+}
+
+impl<'a, V: Clone + Send + Sync, A: Allocator> From<TrieRefBorrowed<'a, V, A>> for TrieRef<'a, V, A> {
+    fn from(src: TrieRefBorrowed<'a, V, A>) -> Self {
+        TrieRef::Borrowed(src)
+    }
+}
+
+impl<V: Clone + Send + Sync, A: Allocator> From<TrieRefOwned<V, A>> for TrieRef<'_, V, A> {
+    fn from(src: TrieRefOwned<V, A>) -> Self {
+        TrieRef::Owned(src)
+    }
+}
+
+impl<V: Clone + Send + Sync + Unpin, A: Allocator> Zipper for TrieRef<'_, V, A> {
+    fn path_exists(&self) -> bool {
+        match self {
+            TrieRef::Borrowed(trie_ref) => trie_ref.path_exists(),
+            TrieRef::Owned(trie_ref) => trie_ref.path_exists(),
+        }
+    }
+    fn is_val(&self) -> bool {
+        match self {
+            TrieRef::Borrowed(trie_ref) => trie_ref.is_val(),
+            TrieRef::Owned(trie_ref) => trie_ref.is_val(),
+        }
+    }
+    fn child_count(&self) -> usize {
+        match self {
+            TrieRef::Borrowed(trie_ref) => trie_ref.child_count(),
+            TrieRef::Owned(trie_ref) => trie_ref.child_count(),
+        }
+    }
+    fn child_mask(&self) -> ByteMask {
+        match self {
+            TrieRef::Borrowed(trie_ref) => trie_ref.child_mask(),
+            TrieRef::Owned(trie_ref) => trie_ref.child_mask(),
+        }
+    }
+}
+
+impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperValues<V> for TrieRef<'_, V, A> {
+    fn val(&self) -> Option<&V> {
+        match self {
+            TrieRef::Borrowed(trie_ref) => trie_ref.val(),
+            TrieRef::Owned(trie_ref) => trie_ref.val(),
+        }
+    }
+}
+
+impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperForking<V> for TrieRef<'_, V, A> {
+    type ReadZipperT<'a> = ReadZipperUntracked<'a, 'a, V, A> where Self: 'a;
+    fn fork_read_zipper<'a>(&'a self) -> Self::ReadZipperT<'a> {
+        match self {
+            TrieRef::Borrowed(trie_ref) => trie_ref.fork_read_zipper(),
+            TrieRef::Owned(trie_ref) => trie_ref.fork_read_zipper(),
+        }
+    }
+}
+
+impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperSubtries<V, A> for TrieRef<'_, V, A> {
+    fn make_map(&self) -> Option<PathMap<Self::V, A>> {
+        match self {
+            TrieRef::Borrowed(trie_ref) => trie_ref.make_map(),
+            TrieRef::Owned(trie_ref) => trie_ref.make_map(),
+        }
+    }
+}
+
+impl<V: Clone + Send + Sync, A: Allocator> zipper_priv::ZipperPriv for TrieRef<'_, V, A> {
+    type V = V;
+    type A = A;
+    fn get_focus(&self) -> AbstractNodeRef<'_, Self::V, Self::A> {
+        match self {
+            TrieRef::Borrowed(trie_ref) => trie_ref.get_focus(),
+            TrieRef::Owned(trie_ref) => trie_ref.get_focus(),
+        }
+    }
+    fn try_borrow_focus(&self) -> Option<&TrieNodeODRc<Self::V, Self::A>> {
+        match self {
+            TrieRef::Borrowed(trie_ref) => trie_ref.try_borrow_focus(),
+            TrieRef::Owned(trie_ref) => trie_ref.try_borrow_focus(),
+        }
+    }
+}
+
+impl<'a, V: Clone + Send + Sync + Unpin + 'a, A: Allocator + 'a> ZipperReadOnlyConditionalValues<'a, V> for TrieRef<'a, V, A> {
+    type WitnessT = TrieRefWitness<V, A>;
+    fn witness<'w>(&self) -> Self::WitnessT {
+        match self {
+            TrieRef::Borrowed(trie_ref) => TrieRefWitness(TrieRefOwned::new_invalid_in(trie_ref.alloc.clone())),
+            TrieRef::Owned(trie_ref) => trie_ref.witness(),
+        }
+    }
+    #[inline]
+    fn get_val_with_witness<'w>(&self, witness: &'w TrieRefWitness<V, A>) -> Option<&'w V> where 'a: 'w {
+        match self {
+            TrieRef::Borrowed(trie_ref) => trie_ref.get_val(),
+            TrieRef::Owned(trie_ref) => trie_ref.get_val_with_witness(witness),
+        }
+    }
+}
+
+impl<'a, V: Clone + Send + Sync + Unpin + 'a, A: Allocator + 'a> ZipperReadOnlySubtries<'a, V, A> for TrieRef<'a, V, A> {
+    type TrieRefT = TrieRef<'a, V, A>;
+    fn trie_ref_at_path<K: AsRef<[u8]>>(&self, path: K) -> TrieRef<'a, V, A> {
+        match self {
+            TrieRef::Borrowed(trie_ref) => TrieRef::Borrowed(trie_ref.trie_ref_at_path(path)),
+            TrieRef::Owned(trie_ref) => TrieRef::Owned(trie_ref.trie_ref_at_path(path)),
         }
     }
     unsafe fn trie_ref_at_path_unchecked<K: AsRef<[u8]>>(&self, path: K) -> TrieRef<'a, V, A> {
@@ -284,13 +800,19 @@ impl<'a, V: Clone + Send + Sync + Unpin + 'a, A: Allocator + 'a> ZipperReadOnlyS
 
 impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperConcrete for TrieRef<'_, V, A> {
     fn is_shared(&self) -> bool {
-        false //We don't have enough info in the TrieRef to get back to the Rc header.  This may change in the future
+        match self {
+            TrieRef::Borrowed(trie_ref) => trie_ref.is_shared(),
+            TrieRef::Owned(trie_ref) => trie_ref.is_shared(),
+        }
     }
 }
 
 impl<'a, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> ZipperReadOnlyPriv<'a, V, A> for TrieRef<'a, V, A> {
-    fn borrow_raw_parts<'z>(&'z self) -> (TaggedNodeRef<'a, V, A>, &'z [u8], Option<&'a V>) {
-        (self.focus_node.unwrap().as_tagged(), self.node_key(), self.root_val())
+    fn borrow_raw_parts<'z>(&'z self) -> (TaggedNodeRef<'z, V, A>, &'z [u8], Option<&'z V>) {
+        match self {
+            TrieRef::Borrowed(trie_ref) => trie_ref.borrow_raw_parts(),
+            TrieRef::Owned(trie_ref) => trie_ref.borrow_raw_parts(),
+        }
     }
     fn take_core(&mut self) -> Option<read_zipper_core::ReadZipperCore<'a, 'static, V, A>> {
         None
@@ -298,122 +820,17 @@ impl<'a, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> ZipperReadOnlyPriv<'
 }
 
 impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperConcretePriv for TrieRef<'_, V, A> {
-    fn shared_node_id(&self) -> Option<u64> { read_zipper_core::read_zipper_shared_node_id(self) }
-}
-
-/// Internal function to implement [ZipperReadOnlySubtries::trie_ref_at_path] for all the types that need it
-pub(crate) fn trie_ref_at_path_in<'a, 'paths, V: Clone + Send + Sync, A: Allocator + 'a>(mut node: &'a TrieNodeODRc<V, A>, root_val: Option<&'a V>, node_key: &'paths [u8], mut path: &'paths [u8], alloc: A) -> TrieRef<'a, V, A> {
-
-    // A temporary buffer on the stack, if we need to assemble a combined key from both the `node_key` and `path`
-    let mut temp_key_buf: [MaybeUninit<u8>; MAX_NODE_KEY_BYTES] = [MaybeUninit::uninit(); MAX_NODE_KEY_BYTES];
-
-    let node_key_len = node_key.len();
-    let path_len = path.len();
-
-    //Copy the existing node key and the first chunk of the path into the temp buffer, and try to
-    // descend one step
-    if node_key_len > 0 && path_len > 0 {
-        let next_node_path = unsafe {
-            let src_ptr = node_key.as_ptr();
-            let dst_ptr = temp_key_buf.as_mut_ptr().cast::<u8>();
-            core::ptr::copy_nonoverlapping(src_ptr, dst_ptr, node_key_len);
-
-            let remaining_len = (MAX_NODE_KEY_BYTES - node_key_len).min(path_len);
-            let src_ptr = path.as_ptr();
-            let dst_ptr = temp_key_buf.as_mut_ptr().cast::<u8>().add(node_key_len);
-            core::ptr::copy_nonoverlapping(src_ptr, dst_ptr, remaining_len);
-
-            let total_buf_len = node_key_len + remaining_len;
-            core::slice::from_raw_parts(temp_key_buf.as_mut_ptr().cast::<u8>(), total_buf_len)
-        };
-
-        if let Some((consumed_byte_cnt, next_node)) = node.as_tagged().node_get_child(next_node_path) {
-            debug_assert!(consumed_byte_cnt >= node_key_len);
-            node = next_node;
-            path = &path[consumed_byte_cnt-node_key_len..];
-        } else {
-            path = next_node_path;
-        }
-    } else {
-        if path_len == 0 {
-            path = node_key;
+    fn shared_node_id(&self) -> Option<u64> {
+        match self {
+            TrieRef::Borrowed(trie_ref) => trie_ref.shared_node_id(),
+            TrieRef::Owned(trie_ref) => trie_ref.shared_node_id(),
         }
     }
-
-    //Descend the rest of the way along the path
-    let (node, key, val) = node_along_path(node, path, root_val);
-
-    TrieRef::new_with_node_and_path_in(node, val, key, alloc)
-}
-
-/// A borrowed read-only reference to a location in a trie.  See [TrieRef]
-///
-#[derive(Clone)]
-pub struct TrieRefTracked<'a, V: Clone + Send + Sync, A: Allocator = GlobalAlloc> {
-    pub(crate) trie_ref: TrieRef<'a, V, A>,
-    pub(crate) tracker: Arc<ZipperTracker<TrackingRead>>,
-}
-
-impl<'a, V: Clone + Send + Sync, A: Allocator> Drop for TrieRefTracked<'a, V, A> {
-    fn drop(&mut self) { }
-}
-
-impl<V: Clone + Send + Sync + Unpin, A: Allocator> Zipper for TrieRefTracked<'_, V, A> {
-    fn path_exists(&self) -> bool { self.trie_ref.path_exists() }
-    fn is_val(&self) -> bool { self.trie_ref.is_val() }
-    fn child_count(&self) -> usize { self.trie_ref.child_count() }
-    fn child_mask(&self) -> ByteMask { self.trie_ref.child_mask() }
-}
-
-impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperValues<V> for TrieRefTracked<'_, V, A> {
-    fn val(&self) -> Option<&V> { self.trie_ref.val() }
-}
-
-impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperForking<V> for TrieRefTracked<'_, V, A> {
-    type ReadZipperT<'a> = ReadZipperUntracked<'a, 'a, V, A> where Self: 'a;
-    fn fork_read_zipper<'a>(&'a self) -> Self::ReadZipperT<'a> { self.trie_ref.fork_read_zipper() }
-}
-
-impl<V: Clone + Send + Sync, A: Allocator> zipper_priv::ZipperPriv for TrieRefTracked<'_, V, A> {
-    type V = V;
-    type A = A;
-    fn get_focus(&self) -> AbstractNodeRef<'_, Self::V, Self::A> { self.trie_ref.get_focus() }
-    fn try_borrow_focus(&self) -> Option<&TrieNodeODRc<Self::V, Self::A>> { self.trie_ref.try_borrow_focus() }
-}
-
-impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperSubtries<V, A> for TrieRefTracked<'_, V, A> {
-    fn make_map(&self) -> Option<PathMap<Self::V, A>> { self.trie_ref.make_map() }
-}
-
-impl<'a, V: Clone + Send + Sync + Unpin + 'a, A: Allocator + 'a> ZipperReadOnlySubtries<'a, V, A> for TrieRefTracked<'a, V, A> {
-    type TrieRefT = TrieRefTracked<'a, V, A>;
-    fn trie_ref_at_path<K: AsRef<[u8]>>(&self, path: K) -> TrieRefTracked<'a, V, A> {
-        let inner = self.trie_ref.trie_ref_at_path(path);
-        TrieRefTracked{ trie_ref: inner, tracker: self.tracker.clone() }
-    }
-    unsafe fn trie_ref_at_path_unchecked<K: AsRef<[u8]>>(&self, path: K) -> TrieRef<'a, V, A> {
-        self.trie_ref.trie_ref_at_path(path)
-    }
-}
-
-impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperConcrete for TrieRefTracked<'_, V, A> {
-    fn is_shared(&self) -> bool {
-        false //We don't have enough info in the TrieRef to get back to the Rc header.  This may change in the future
-    }
-}
-
-impl<'a, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> ZipperReadOnlyPriv<'a, V, A> for TrieRefTracked<'a, V, A> {
-    fn borrow_raw_parts<'z>(&'z self) -> (TaggedNodeRef<'a, V, A>, &'z [u8], Option<&'a V>) { self.trie_ref.borrow_raw_parts() }
-    fn take_core(&mut self) -> Option<read_zipper_core::ReadZipperCore<'a, 'static, V, A>> { None }
-}
-
-impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperConcretePriv for TrieRefTracked<'_, V, A> {
-    fn shared_node_id(&self) -> Option<u64> { self.trie_ref.shared_node_id() }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{alloc::global_alloc, PathMap, utils::ByteMask, zipper::*};
+    use crate::{trie_node::AbstractNodeRef, utils::ByteMask, zipper::{zipper_priv::ZipperPriv, *}, PathMap};
 
     #[test]
     fn trie_ref_test1() {
@@ -422,72 +839,73 @@ mod tests {
         let map: PathMap<()> = keys.iter().map(|k| (k, ())).collect();
 
         // With the current node types, there likely isn't any reason the node would be split at "He"
-        let trie_ref = TrieRef::new_with_node_and_path_in(map.root().unwrap(), map.root_val(), b"He", global_alloc());
+        let trie_ref = map.trie_ref_at_path(b"He");
         #[cfg(not(feature = "all_dense_nodes"))]
         assert_eq!(trie_ref.node_key(), b"He");
-        assert_eq!(trie_ref.get_val(), None);
+        assert_eq!(trie_ref.val(), None);
         assert_eq!(trie_ref.path_exists(), true);
 
         // "Hel" on the other hand was likely split into its own node
-        let trie_ref = TrieRef::new_with_node_and_path_in(map.root().unwrap(), map.root_val(), b"Hel", global_alloc());
-        assert_eq!(trie_ref.node_key().len(), 0);
-        assert_eq!(trie_ref.get_val(), None);
+        let trie_ref = map.trie_ref_at_path(b"Hel");
+        let node = trie_ref.get_focus();
+        assert!(matches!(node, AbstractNodeRef::BorrowedRc(_)));
+        assert_eq!(trie_ref.val(), None);
         assert_eq!(trie_ref.path_exists(), true);
 
         // Make sure we get a value at a leaf
-        let trie_ref = TrieRef::new_with_node_and_path_in(map.root().unwrap(), map.root_val(), b"Help", global_alloc());
-        assert_eq!(trie_ref.get_val(), Some(&()));
+        let trie_ref = map.trie_ref_at_path(b"Help");
+        assert_eq!(trie_ref.val(), Some(&()));
         assert_eq!(trie_ref.path_exists(), true);
 
         // Make sure we get a value in the middle of a path
-        let trie_ref = TrieRef::new_with_node_and_path_in(map.root().unwrap(), map.root_val(), b"Hell", global_alloc());
-        assert_eq!(trie_ref.get_val(), Some(&()));
+        let trie_ref = map.trie_ref_at_path(b"Hell");
+        assert_eq!(trie_ref.val(), Some(&()));
         assert_eq!(trie_ref.path_exists(), true);
 
         // Try a path that doesn't exist
-        let trie_ref = TrieRef::new_with_node_and_path_in(map.root().unwrap(), map.root_val(), b"Hi", global_alloc());
-        assert_eq!(trie_ref.get_val(), None);
+        let trie_ref = map.trie_ref_at_path(b"Hi");
+        assert_eq!(trie_ref.val(), None);
         assert_eq!(trie_ref.path_exists(), false);
 
         // Try a very long path that doesn't exist but is sure to blow the single-node path buffer
-        let trie_ref = TrieRef::new_with_node_and_path_in(map.root().unwrap(), map.root_val(), b"Hello Mr. Washington, my name is John, but sometimes people call me Jack.  I live in Springfield.", global_alloc());
-        assert_eq!(trie_ref.get_val(), None);
+        let trie_ref = map.trie_ref_at_path(b"Hello Mr. Washington, my name is John, but sometimes people call me Jack.  I live in Springfield.");
+        assert_eq!(trie_ref.val(), None);
         assert_eq!(trie_ref.path_exists(), false);
 
         //Try using TrieRefs to descend a trie
-        let trie_ref0 = TrieRef::new_with_node_and_path_in(map.root().unwrap(), map.root_val(), b"H", global_alloc());
-        assert_eq!(trie_ref0.get_val(), None);
+        let trie_ref0 = map.trie_ref_at_path(b"H");
+        assert_eq!(trie_ref0.val(), None);
         assert_eq!(trie_ref0.path_exists(), true);
         assert_eq!(trie_ref0.child_count(), 1);
         assert_eq!(trie_ref0.child_mask(), ByteMask::from(b'e'));
 
         //"Hel"
         let trie_ref1 = trie_ref0.trie_ref_at_path(b"el");
-        assert_eq!(trie_ref1.get_val(), None);
+        assert_eq!(trie_ref1.val(), None);
         assert_eq!(trie_ref1.path_exists(), true);
         assert_eq!(trie_ref1.child_count(), 3);
 
         //"Hello"
         let trie_ref2 = trie_ref1.trie_ref_at_path(b"lo");
-        assert_eq!(trie_ref2.get_val(), Some(&()));
+        assert_eq!(trie_ref2.val(), Some(&()));
         assert_eq!(trie_ref2.path_exists(), true);
         assert_eq!(trie_ref2.child_count(), 0);
 
         //"HelloOperator"
         let trie_ref3 = trie_ref2.trie_ref_at_path(b"Operator");
-        assert_eq!(trie_ref3.get_val(), None);
+        assert_eq!(trie_ref3.val(), None);
         assert_eq!(trie_ref3.path_exists(), false);
         assert_eq!(trie_ref3.child_count(), 0);
 
         //"HelloOperator, give me number 9"
         let trie_ref4 = trie_ref3.trie_ref_at_path(b", give me number 9");
-        assert_eq!(trie_ref4.get_val(), None);
+        assert_eq!(trie_ref4.val(), None);
         assert_eq!(trie_ref4.path_exists(), false);
         assert_eq!(trie_ref4.child_count(), 0);
 
         //"Hell"
         let trie_ref2 = trie_ref1.trie_ref_at_path(b"l");
-        assert_eq!(trie_ref2.get_val(), Some(&()));
+        assert_eq!(trie_ref2.val(), Some(&()));
         assert_eq!(trie_ref2.path_exists(), true);
         assert_eq!(trie_ref2.child_count(), 1);
     }
@@ -498,12 +916,12 @@ mod tests {
         let btm: PathMap<usize> = rs.into_iter().enumerate().map(|(i, r)| (r.as_bytes(), i) ).collect();
 
         let trie_ref = btm.trie_ref_at_path([]);
-        assert_eq!(trie_ref.get_val(), None);
+        assert_eq!(trie_ref.val(), None);
         assert_eq!(trie_ref.path_exists(), true);
         assert_eq!(trie_ref.child_count(), 4);
 
         let trie_ref = trie_ref.trie_ref_at_path([b'a']);
-        assert_eq!(trie_ref.get_val(), None);
+        assert_eq!(trie_ref.val(), None);
         assert_eq!(trie_ref.path_exists(), true);
         assert_eq!(trie_ref.child_count(), 1);
 
@@ -527,20 +945,36 @@ mod tests {
         let zh = map.zipper_head();
         let rz = zh.read_zipper_at_borrowed_path(b"path").unwrap();
         let tr = rz.trie_ref_at_path(b"");
-
         assert_eq!(tr.val(), Some(&42));
+
+        //Ensure the TrieRef is still intact after the RZ that it came from is gone
         drop(rz);
-
         assert_eq!(tr.val(), Some(&42));
-        assert!(zh.write_zipper_at_exclusive_path(b"path").is_err());
 
+        //Ensure the TrieRef is intact after path in the trie is overwritten (the TrieRef holds its own node pointer)
+        let mut wz = zh.write_zipper_at_exclusive_path(b"path").unwrap();
+        wz.set_val(24);
+        assert_eq!(wz.val(), Some(&24));
         assert_eq!(tr.val(), Some(&42));
-        drop(tr);
+        drop(wz);
 
+        //Ensure the TrieRef didn't interfere with new ReadZippers created from the ZipperHead
+        let rz = zh.read_zipper_at_path(b"path").unwrap();
+        assert_eq!(rz.val(), Some(&24));
+        drop(rz);
+        let mut rz = zh.read_zipper_at_path(b"").unwrap();
+        assert_eq!(rz.descend_to(b"path"), true);
+        assert_eq!(rz.val(), Some(&24));
+        drop(rz);
+        assert_eq!(tr.val(), Some(&42));
+
+        //Lastly, check that the TrieRef didn't mess up the map
         let mut wz = zh.write_zipper_at_exclusive_path(b"path").unwrap();
         wz.remove_val();
         drop(wz);
         drop(zh);
         assert_eq!(map.get_val_at(b"path"), None);
+
+        assert_eq!(tr.val(), Some(&42));
     }
 }

--- a/src/write_zipper.rs
+++ b/src/write_zipper.rs
@@ -354,7 +354,7 @@ impl<'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperTr
         let root_val = core::mem::take(&mut self.z.root_val);
         let root_val = root_val.and_then(|root_val| unsafe{ (&*root_val).as_ref() });
 
-        let mut new_zipper = ReadZipperTracked::new_with_node_and_cloned_path_in(root_node, root_path, root_path.len(), self.z.key.root_key_start, root_val, self.z.alloc.clone(), tracker);
+        let mut new_zipper = ReadZipperTracked::new_with_node_and_cloned_path_in(root_node, false, root_path, root_path.len(), self.z.key.root_key_start, root_val, self.z.alloc.clone(), tracker);
         new_zipper.descend_to(descended_path);
         new_zipper
     }

--- a/src/zipper.rs
+++ b/src/zipper.rs
@@ -324,8 +324,7 @@ pub trait ZipperMoving: Zipper {
                 true
             },
             None => {
-                let descended = self.descend_to_byte(cur_byte);
-                debug_assert!(descended);
+                self.descend_to_byte(cur_byte);
                 false
             }
         }

--- a/src/zipper_head.rs
+++ b/src/zipper_head.rs
@@ -206,7 +206,7 @@ impl<'trie, Z, V: 'trie + Clone + Send + Sync + Unpin, A: Allocator + 'trie> Zip
             // lifetime.  We need to do this because the ZipperHead internally uses a WriteZipper, which must
             // remain &mut accessible.  Safety is upheld by the fact that the ZipperHead exclusivity runtime
             // logic makes sure conflicting paths aren't permitted, so we should not get aliased &mut borrows
-            let root_node: TaggedNodeRef<'trie, V, A> = unsafe{ core::mem::transmute(root_node) };
+            let root_node: &'trie TrieNodeODRc<V, A> = unsafe{ core::mem::transmute(root_node) };
             let root_val: Option<&'trie V> = root_val.map(|v| unsafe{ &*(v as *const _) } );
             Ok(ReadZipperTracked::new_with_node_and_path_in(root_node, path.as_ref(), path.len(), 0, root_val, z.alloc.clone(), zipper_tracker))
         })
@@ -218,7 +218,7 @@ impl<'trie, Z, V: 'trie + Clone + Send + Sync + Unpin, A: Allocator + 'trie> Zip
             let (root_node, root_val) = z.splitting_borrow_focus();
             //SAFETY: The user is asserting that the paths won't conflict.
             // See identical code in `read_zipper_at_borrowed_path` for more discussion
-            let root_node: TaggedNodeRef<'trie, V, A> = unsafe{ core::mem::transmute(root_node) };
+            let root_node: &'trie TrieNodeODRc<V, A> = unsafe{ core::mem::transmute(root_node) };
             let root_val: Option<&'trie V> = root_val.map(|v| unsafe{ &*(v as *const _) } );
 
             #[cfg(debug_assertions)]
@@ -241,7 +241,7 @@ impl<'trie, Z, V: 'trie + Clone + Send + Sync + Unpin, A: Allocator + 'trie> Zip
 
             let (root_node, root_val) = z.splitting_borrow_focus();
             //SAFETY: See identical code in `read_zipper_at_borrowed_path` for more discussion
-            let root_node: TaggedNodeRef<'trie, V, A> = unsafe{ core::mem::transmute(root_node) };
+            let root_node: &'trie TrieNodeODRc<V, A> = unsafe{ core::mem::transmute(root_node) };
             let root_val: Option<&'trie V> = root_val.map(|v| unsafe{ &*(v as *const _) } );
 
             Ok(ReadZipperTracked::new_with_node_and_cloned_path_in(root_node, path.as_ref(), path.len(), 0, root_val, z.alloc.clone(), zipper_tracker))
@@ -255,7 +255,7 @@ impl<'trie, Z, V: 'trie + Clone + Send + Sync + Unpin, A: Allocator + 'trie> Zip
             let (root_node, root_val) = z.splitting_borrow_focus();
             //SAFETY: The user is asserting that the paths won't conflict.
             // See identical code in `read_zipper_at_borrowed_path` for more discussion
-            let root_node: TaggedNodeRef<'trie, V, A> = unsafe{ core::mem::transmute(root_node) };
+            let root_node: &'trie TrieNodeODRc<V, A> = unsafe{ core::mem::transmute(root_node) };
             let root_val: Option<&'trie V> = root_val.map(|v| unsafe{ &*(v as *const _) } );
 
             #[cfg(debug_assertions)]
@@ -311,7 +311,7 @@ impl<'trie, Z, V: 'trie + Clone + Send + Sync + Unpin, A: Allocator + 'trie> Zip
             // has already been dismantled... So we are checking here in order to handle that situation gracefully
             if inner_z.focus_stack.top().is_some() {
                 inner_z.move_to_path(origin_path);
-                if inner_z.try_borrow_focus().unwrap().node_is_empty() {
+                if inner_z.try_borrow_focus().unwrap().as_tagged().node_is_empty() {
                     if !inner_z.is_val() && inner_z.child_count() == 0 {
                         inner_z.prune_path();
                     }

--- a/src/zipper_tracking.rs
+++ b/src/zipper_tracking.rs
@@ -63,6 +63,7 @@ impl Clone for ZipperTracker<TrackingRead> {
     }
 }
 
+#[cfg(feature = "zipper_tracking")]
 impl<M: TrackingMode> ZipperTracker<M> {
     /// Returns the path that the tracker is guarding
     pub fn path(&self) -> &[u8] {


### PR DESCRIPTION
Merging`zipper_root_nodes` into `master`

This does 2 things
1. Fixes bug (potential UB) in ZipperHead when an outstanding ReadZipper's root node is replaced by another node in the process of creating a WriteZipper.
2. Ensures graft sources are as high in the trie as possible, and avoiding unnecessary node copying in many situations.