### PR TITLE
Dangling paths

### DIFF
--- a/benches/parallel.rs
+++ b/benches/parallel.rs
@@ -238,7 +238,7 @@ fn parallel_copy_known_path(bencher: Bencher, (elements, thread_cnt): (usize, &s
 
         bencher.with_inputs(|| {
             let mut writer_z = zipper_head.write_zipper_at_exclusive_path(b"out").unwrap();
-            writer_z.remove_branches();
+            writer_z.remove_branches(true);
         }).bench_local_values(|()| {
             if thread_cnt > 0 {
 
@@ -338,7 +338,7 @@ fn parallel_copy_traverse(bencher: Bencher, (elements, thread_cnt): (usize, &str
 
         bencher.with_inputs(|| {
             let mut writer_z = zipper_head.write_zipper_at_exclusive_path(b"out").unwrap();
-            writer_z.remove_branches();
+            writer_z.remove_branches(true);
         }).bench_local_values(|()| {
             if thread_cnt > 0 {
 

--- a/benches/pointcloud.rs
+++ b/benches/pointcloud.rs
@@ -313,7 +313,7 @@ impl BTMOctree {
             if points.len() < LEAF_CAPACITY || depth >= MAX_DEPTH {
                 points.push(p);
             } else {
-                let ps = wz.remove_val().unwrap();
+                let ps = wz.remove_val(true).unwrap();
                 for &old_p in ps.iter() {
                     let idx = Octree::child_index(bounds.center(), old_p);
                     let child_bounds = Octree::child(&bounds, idx);

--- a/benches/serde.rs
+++ b/benches/serde.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 use std::io::Read;
 use divan::{Divan, Bencher, black_box};
 use pathmap::PathMap;
-use pathmap::path_serialization::{deserialize_paths, serialize_paths};
+use pathmap::paths_serialization::{deserialize_paths, serialize_paths};
 
 #[divan::bench()]
 fn big_logic_serialize_paths(bencher: Bencher) {
@@ -21,7 +21,7 @@ fn big_logic_serialize_paths(bencher: Bencher) {
   bencher.bench_local(|| {
     let rz = map.read_zipper();
     unsafe { out_buffer.set_len(0) }
-    let pathmap::path_serialization::SerializationStats { path_count : total_paths , .. }=
+    let pathmap::paths_serialization::SerializationStats { path_count : total_paths , .. }=
       serialize_paths(rz, &mut out_buffer).expect("serialization error");
     assert_eq!(total_paths, 91692);
   });
@@ -39,7 +39,7 @@ fn big_logic_deserialize_paths(bencher: Bencher) {
   file.read_to_end(&mut in_buffer).unwrap();
   bencher.bench_local(|| {
     let wz = map.write_zipper();
-    let pathmap::path_serialization::DeserializationStats { path_count : total_paths , .. }=
+    let pathmap::paths_serialization::DeserializationStats { path_count : total_paths , .. }=
       deserialize_paths(wz, &in_buffer[..], ()).expect("deserialization error");
     assert_eq!(total_paths, 91692);
   });

--- a/benches/sparse_keys.rs
+++ b/benches/sparse_keys.rs
@@ -199,7 +199,7 @@ fn sparse_cursor(bencher: Bencher, n: u64) {
     });
 }
 
-#[cfg(feature = "all_dense_nodes")]
+#[cfg(all(feature = "all_dense_nodes", feature = "old_cursor"))]
 #[divan::bench(args = [50, 100, 200, 400, 800, 1600])]
 fn sparse_all_dense_cursor(bencher: Bencher, n: u64) {
 

--- a/benches/superdense_keys.rs
+++ b/benches/superdense_keys.rs
@@ -192,7 +192,7 @@ fn superdense_k_path_iter(bencher: Bencher, n: u64) {
     });
 }
 
-#[cfg(feature = "all_dense_nodes")]
+#[cfg(all(feature = "all_dense_nodes", feature = "old_cursor"))]
 #[divan::bench(args = [100, 200, 400, 800, 1600, 3200])]
 fn superdense_all_dense_cursor(bencher: Bencher, n: u64) {
 

--- a/src/empty_node.rs
+++ b/src/empty_node.rs
@@ -38,6 +38,9 @@ impl<V: Clone + Send + Sync, A: Allocator> TrieNode<V, A> for EmptyNode {
     fn node_remove_val(&mut self, _key: &[u8], _prune: bool) -> Option<V> {
         unreachable!()
     }
+    fn node_create_dangling(&mut self, _key: &[u8]) -> Result<(bool, bool), TrieNodeODRc<V, A>> {
+        unreachable!()
+    }
     fn node_remove_dangling(&mut self, _key: &[u8]) -> usize {
         unreachable!()
     }

--- a/src/empty_node.rs
+++ b/src/empty_node.rs
@@ -50,10 +50,10 @@ impl<V: Clone + Send + Sync, A: Allocator> TrieNode<V, A> for EmptyNode {
     fn node_set_branch(&mut self, _key: &[u8], _new_node: TrieNodeODRc<V, A>) -> Result<bool, TrieNodeODRc<V, A>> {
         unreachable!() //we should head this off upstream
     }
-    fn node_remove_all_branches(&mut self, _key: &[u8]) -> bool {
+    fn node_remove_all_branches(&mut self, _key: &[u8], _prune: bool) -> bool {
         false
     }
-    fn node_remove_unmasked_branches(&mut self, _key: &[u8], _mask: ByteMask) {}
+    fn node_remove_unmasked_branches(&mut self, _key: &[u8], _mask: ByteMask, _prune: bool) {}
     fn node_is_empty(&self) -> bool { true }
     fn new_iter_token(&self) -> u128 {
         0
@@ -95,7 +95,7 @@ impl<V: Clone + Send + Sync, A: Allocator> TrieNode<V, A> for EmptyNode {
     fn get_node_at_key(&self, _key: &[u8]) -> AbstractNodeRef<'_, V, A> {
         AbstractNodeRef::None
     }
-    fn take_node_at_key(&mut self, _key: &[u8]) -> Option<TrieNodeODRc<V, A>> {
+    fn take_node_at_key(&mut self, _key: &[u8], _prune: bool) -> Option<TrieNodeODRc<V, A>> {
         None
     }
     fn pjoin_dyn(&self, other: TaggedNodeRef<V, A>) -> AlgebraicResult<TrieNodeODRc<V, A>> where V: Lattice {

--- a/src/empty_node.rs
+++ b/src/empty_node.rs
@@ -35,8 +35,11 @@ impl<V: Clone + Send + Sync, A: Allocator> TrieNode<V, A> for EmptyNode {
     fn node_get_val(&self, _key: &[u8]) -> Option<&V> {
         None
     }
-    fn node_remove_val(&mut self, _key: &[u8]) -> Option<V> {
-        None
+    fn node_remove_val(&mut self, _key: &[u8], _prune: bool) -> Option<V> {
+        unreachable!()
+    }
+    fn node_remove_dangling(&mut self, _key: &[u8]) -> usize {
+        unreachable!()
     }
     fn node_get_val_mut(&mut self, _key: &[u8]) -> Option<&mut V> {
         None

--- a/src/experimental.rs
+++ b/src/experimental.rs
@@ -138,4 +138,5 @@ impl <V: TrieValue, A: Allocator> ZipperWriting<V, A> for NullZipper {
     fn take_map(&mut self, prune: bool) -> Option<PathMap<V, A>> { None }
     fn remove_unmasked_branches(&mut self, _mask: ByteMask, prune: bool) {}
     fn prune(&mut self) -> usize { 0 }
+    fn prune_ascend(&mut self) -> usize { 0 }
 }

--- a/src/experimental.rs
+++ b/src/experimental.rs
@@ -101,7 +101,7 @@ impl FullZipper {
 struct NullZipper {}
 
 impl<V: TrieValue, A: Allocator> WriteZipperPriv<V, A> for NullZipper {
-    fn take_focus(&mut self) -> Option<TrieNodeODRc<V, A>> {
+    fn take_focus(&mut self, prune: bool) -> Option<TrieNodeODRc<V, A>> {
         None
     }
     fn take_root_prefix_path(&mut self) -> Vec<u8> {
@@ -125,7 +125,7 @@ impl <V: TrieValue, A: Allocator> ZipperWriting<V, A> for NullZipper {
     fn graft_map(&mut self, _map: PathMap<V, A>) {}
     fn join<Z: ZipperSubtries<V, A>>(&mut self, _read_zipper: &Z) -> AlgebraicStatus where V: Lattice { AlgebraicStatus::Element }
     fn join_map(&mut self, _map: PathMap<V, A>) -> AlgebraicStatus where V: Lattice { AlgebraicStatus::Element }
-    fn join_into<Z: ZipperSubtries<V, A> + ZipperWriting<V, A>>(&mut self, _src_zipper: &mut Z) -> AlgebraicStatus where V: Lattice { AlgebraicStatus::Element }
+    fn join_into<Z: ZipperSubtries<V, A> + ZipperWriting<V, A>>(&mut self, _src_zipper: &mut Z, prune: bool) -> AlgebraicStatus where V: Lattice { AlgebraicStatus::Element }
     fn drop_head(&mut self, _byte_cnt: usize) -> bool where V: Lattice { false }
     fn insert_prefix<K: AsRef<[u8]>>(&mut self, _prefix: K) -> bool { false }
     fn remove_prefix(&mut self, _n: usize) -> bool { false }
@@ -134,8 +134,8 @@ impl <V: TrieValue, A: Allocator> ZipperWriting<V, A> for NullZipper {
     fn subtract<Z: ZipperSubtries<V, A>>(&mut self, _read_zipper: &Z) -> AlgebraicStatus where V: DistributiveLattice { AlgebraicStatus::Element }
     fn restrict<Z: ZipperSubtries<V, A>>(&mut self, _read_zipper: &Z) -> AlgebraicStatus { AlgebraicStatus::Element }
     fn restricting<Z: ZipperSubtries<V, A>>(&mut self, _read_zipper: &Z) -> bool { false }
-    fn remove_branches(&mut self) -> bool { false }
-    fn take_map(&mut self) -> Option<PathMap<V, A>> { None }
-    fn remove_unmasked_branches(&mut self, _mask: ByteMask) {}
+    fn remove_branches(&mut self, prune: bool) -> bool { false }
+    fn take_map(&mut self, prune: bool) -> Option<PathMap<V, A>> { None }
+    fn remove_unmasked_branches(&mut self, _mask: ByteMask, prune: bool) {}
     fn prune(&mut self) -> usize { 0 }
 }

--- a/src/experimental.rs
+++ b/src/experimental.rs
@@ -119,7 +119,7 @@ impl <V: TrieValue, A: Allocator> ZipperWriting<V, A> for NullZipper {
     fn get_val_or_set_mut(&mut self, default: V) -> &mut V { Box::leak(Box::new(default)) }
     fn get_val_or_set_mut_with<F>(&mut self, func: F) -> &mut V where F: FnOnce() -> V { Box::leak(Box::new(func())) }
     fn set_val(&mut self, _val: V) -> Option<V> { None }
-    fn remove_val(&mut self) -> Option<V> { None }
+    fn remove_val(&mut self, _prune: bool) -> Option<V> { None }
     fn zipper_head<'z>(&'z mut self) -> Self::ZipperHead<'z> { todo!() }
     fn graft<Z: ZipperSubtries<V, A>>(&mut self, _read_zipper: &Z) {}
     fn graft_map(&mut self, _map: PathMap<V, A>) {}
@@ -137,4 +137,5 @@ impl <V: TrieValue, A: Allocator> ZipperWriting<V, A> for NullZipper {
     fn remove_branches(&mut self) -> bool { false }
     fn take_map(&mut self) -> Option<PathMap<V, A>> { None }
     fn remove_unmasked_branches(&mut self, _mask: ByteMask) {}
+    fn prune(&mut self) -> usize { 0 }
 }

--- a/src/experimental.rs
+++ b/src/experimental.rs
@@ -137,6 +137,7 @@ impl <V: TrieValue, A: Allocator> ZipperWriting<V, A> for NullZipper {
     fn remove_branches(&mut self, prune: bool) -> bool { false }
     fn take_map(&mut self, prune: bool) -> Option<PathMap<V, A>> { None }
     fn remove_unmasked_branches(&mut self, _mask: ByteMask, prune: bool) {}
-    fn prune(&mut self) -> usize { 0 }
+    fn create_path(&mut self) -> bool { false }
+    fn prune_path(&mut self) -> usize { 0 }
     fn prune_ascend(&mut self) -> usize { 0 }
 }

--- a/src/fuzzer.rs
+++ b/src/fuzzer.rs
@@ -492,7 +492,7 @@ mod tests {
       // println!("let mut btm = PathMap::from_iter({:?}.iter().map(|(p, v)| (p.as_bytes(), v)));", trie.iter().map(|(p, v)| (String::from_utf8(p).unwrap(), v)).collect::<Vec<_>>());
       path_fuzzer.clone().sample_iter(rng.clone()).take(N_REMOVES).for_each(|path| {
         // println!("btm.remove_val_at({:?}.as_bytes());", String::from_utf8(path.clone()).unwrap());
-        trie.remove_val_at(path);
+        trie.remove_val_at(path, true);
       });
       black_box(trie);
     })

--- a/src/line_list_node.rs
+++ b/src/line_list_node.rs
@@ -1787,6 +1787,19 @@ impl<V: Clone + Send + Sync, A: Allocator> TrieNode<V, A> for LineListNode<V, A>
     }
 
     #[inline]
+    fn node_create_dangling(&mut self, key: &[u8]) -> Result<(bool, bool), TrieNodeODRc<V, A>> {
+        debug_assert!(key.len() > 0);
+        if !self.node_contains_partial_key(key) {
+            self.set_payload_abstract::<true>(key, ValOrChildUnion::from(TrieNodeODRc::new_empty())).map(|(result, created_subnode)| {
+                debug_assert!(result.is_none());
+                (true, created_subnode)
+            })
+        } else {
+            Ok((false, false))
+        }
+    }
+
+    #[inline]
     fn node_remove_dangling(&mut self, key: &[u8]) -> usize {
         debug_assert!(key.len() > 0);
         let (key0, key1) = self.get_both_keys();

--- a/src/old_cursor.rs
+++ b/src/old_cursor.rs
@@ -5,7 +5,7 @@
 use crate::PathMap;
 use crate::trie_node::{TaggedNodeRef, NODE_ITER_FINISHED};
 use crate::dense_byte_node::{DenseByteNode, OrdinaryCoFree, CoFree};
-use crate::GlobalAlloc;
+use crate::alloc::GlobalAlloc;
 
 /// An iterator-like object that traverses key-value pairs in a [PathMap], however only one
 /// returned reference may exist at a given time

--- a/src/product_zipper.rs
+++ b/src/product_zipper.rs
@@ -445,9 +445,9 @@ impl<'trie, PrimaryZ, SecondaryZ, V> ProductZipperG<'trie, PrimaryZ, SecondaryZ,
 
     fn is_bottom_val(&self) -> bool {
         if let Some(idx) = self.factor_idx(false) {
-            self.secondary[idx].is_val()
+            self.secondary[idx].child_count() == 0
         } else {
-            self.primary.is_val()
+            self.primary.child_count() == 0
         }
     }
 
@@ -692,10 +692,10 @@ impl<'trie, PrimaryZ, SecondaryZ, V> ZipperMoving for ProductZipperG<'trie, Prim
             // NOTE: descend_to_val here is used to take priority descending
             // into factors, instead of continuing deeper into the trie.
             if let Some(idx) = self.factor_idx(false) {
-                good = self.secondary[idx].descend_to_val(path);
+                good = self.secondary[idx].descend_to_existing(path);
                 self.primary.descend_to(&path[..good]);
             } else {
-                good = self.primary.descend_to_val(path);
+                good = self.primary.descend_to_existing(path);
             };
             if good == 0 {
                 break 'descend;
@@ -1242,7 +1242,7 @@ mod tests {
 
         assert!(pz.descend_to(b"nopqrstuvwxyz"));
 
-        assert_eq!(pz.focus_factor(), 1);
+        assert_eq!(pz.focus_factor(), 0);
         assert_eq!(pz.path(), b"nopqrstuvwxyz");
         assert_eq!(pz.origin_path(), b"abcdefghijklmnopqrstuvwxyz");
 

--- a/src/tiny_node.rs
+++ b/src/tiny_node.rs
@@ -195,6 +195,7 @@ impl<'a, V: Clone + Send + Sync, A: Allocator> TrieNode<V, A> for TinyRefNode<'a
         None
     }
     fn node_remove_val(&mut self, _key: &[u8], _prune: bool) -> Option<V> { unreachable!() }
+    fn node_create_dangling(&mut self, _key: &[u8]) -> Result<(bool, bool), TrieNodeODRc<V, A>> { unreachable!() }
     fn node_remove_dangling(&mut self, _key: &[u8]) -> usize { unreachable!() }
     fn node_get_val_mut(&mut self, _key: &[u8]) -> Option<&mut V> { unreachable!() }
     fn node_set_val(&mut self, key: &[u8], val: V) -> Result<(Option<V>, bool), TrieNodeODRc<V, A>> {

--- a/src/tiny_node.rs
+++ b/src/tiny_node.rs
@@ -194,7 +194,8 @@ impl<'a, V: Clone + Send + Sync, A: Allocator> TrieNode<V, A> for TinyRefNode<'a
         }
         None
     }
-    fn node_remove_val(&mut self, _key: &[u8]) -> Option<V> { unreachable!() }
+    fn node_remove_val(&mut self, _key: &[u8], _prune: bool) -> Option<V> { unreachable!() }
+    fn node_remove_dangling(&mut self, _key: &[u8]) -> usize { unreachable!() }
     fn node_get_val_mut(&mut self, _key: &[u8]) -> Option<&mut V> { unreachable!() }
     fn node_set_val(&mut self, key: &[u8], val: V) -> Result<(Option<V>, bool), TrieNodeODRc<V, A>> {
         let mut replacement_node = self.into_full().unwrap();

--- a/src/tiny_node.rs
+++ b/src/tiny_node.rs
@@ -207,8 +207,8 @@ impl<'a, V: Clone + Send + Sync, A: Allocator> TrieNode<V, A> for TinyRefNode<'a
         replacement_node.node_set_branch(key, new_node).unwrap_or_else(|_| panic!());
         Err(TrieNodeODRc::new_in(replacement_node, self.alloc.clone()))
     }
-    fn node_remove_all_branches(&mut self, _key: &[u8]) -> bool { unreachable!() }
-    fn node_remove_unmasked_branches(&mut self, _key: &[u8], _mask: ByteMask) { unreachable!() }
+    fn node_remove_all_branches(&mut self, _key: &[u8], _prune: bool) -> bool { unreachable!() }
+    fn node_remove_unmasked_branches(&mut self, _key: &[u8], _mask: ByteMask, _prune: bool) { unreachable!() }
     fn node_is_empty(&self) -> bool {
         self.header & (1 << 7) == 0
     }
@@ -275,7 +275,7 @@ impl<'a, V: Clone + Send + Sync, A: Allocator> TrieNode<V, A> for TinyRefNode<'a
         //The key must specify a path the node doesn't contains
         AbstractNodeRef::None
     }
-    fn take_node_at_key(&mut self, _key: &[u8]) -> Option<TrieNodeODRc<V, A>> { unreachable!() }
+    fn take_node_at_key(&mut self, _key: &[u8], _prune: bool) -> Option<TrieNodeODRc<V, A>> { unreachable!() }
     fn pjoin_dyn(&self, other: TaggedNodeRef<V, A>) -> AlgebraicResult<TrieNodeODRc<V, A>> where V: Lattice {
         //TODO, I can streamline this quite a lot, but for now I'll just up-convert to a ListNode to test
         // the basic premise of the TinyRefNode

--- a/src/trie_node.rs
+++ b/src/trie_node.rs
@@ -163,14 +163,14 @@ pub(crate) trait TrieNode<V: Clone + Send + Sync, A: Allocator>: TrieNodeDowncas
     ///
     /// WARNING: This method may leave the node empty.  If eager pruning of branches is desired then the
     /// node should subsequently be checked to see if it is empty
-    fn node_remove_all_branches(&mut self, key: &[u8]) -> bool;
+    fn node_remove_all_branches(&mut self, key: &[u8], prune: bool) -> bool;
 
     /// Uses a 256-bit mask to filter down children and values from the specified `key`.  Does not affect
     /// the value at the `key`
     ///
     /// WARNING: This method may leave the node empty.  If eager pruning of branches is desired then the
     /// node should subsequently be checked to see if it is empty
-    fn node_remove_unmasked_branches(&mut self, key: &[u8], mask: ByteMask);
+    fn node_remove_unmasked_branches(&mut self, key: &[u8], mask: ByteMask, prune: bool);
 
     /// Returns `true` if the node contains no children nor values, otherwise false
     fn node_is_empty(&self) -> bool;
@@ -275,7 +275,7 @@ pub(crate) trait TrieNode<V: Clone + Send + Sync, A: Allocator>: TrieNodeDowncas
     /// WARNING: This method may leave the node empty
     ///
     /// This method should never be called with `key.len() == 0`
-    fn take_node_at_key(&mut self, key: &[u8]) -> Option<TrieNodeODRc<V, A>>;
+    fn take_node_at_key(&mut self, key: &[u8], prune: bool) -> Option<TrieNodeODRc<V, A>>;
 
     /// Allows for the implementation of the Lattice trait on different node implementations, and
     /// the logic to promote nodes to other node types
@@ -1483,26 +1483,26 @@ mod tagged_node_ref {
             }
         }
 
-        pub fn node_remove_all_branches(&mut self, key: &[u8]) -> bool {
+        pub fn node_remove_all_branches(&mut self, key: &[u8], prune: bool) -> bool {
             match self {
-                Self::DenseByteNode(node) => node.node_remove_all_branches(key),
-                Self::LineListNode(node) => node.node_remove_all_branches(key),
-                Self::CellByteNode(node) => node.node_remove_all_branches(key),
+                Self::DenseByteNode(node) => node.node_remove_all_branches(key, prune),
+                Self::LineListNode(node) => node.node_remove_all_branches(key, prune),
+                Self::CellByteNode(node) => node.node_remove_all_branches(key, prune),
             }
         }
 
-        pub fn node_remove_unmasked_branches(&mut self, key: &[u8], mask: ByteMask) {
+        pub fn node_remove_unmasked_branches(&mut self, key: &[u8], mask: ByteMask, prune: bool) {
             match self {
-                Self::DenseByteNode(node) => node.node_remove_unmasked_branches(key, mask),
-                Self::LineListNode(node) => node.node_remove_unmasked_branches(key, mask),
-                Self::CellByteNode(node) => node.node_remove_unmasked_branches(key, mask),
+                Self::DenseByteNode(node) => node.node_remove_unmasked_branches(key, mask, prune),
+                Self::LineListNode(node) => node.node_remove_unmasked_branches(key, mask, prune),
+                Self::CellByteNode(node) => node.node_remove_unmasked_branches(key, mask, prune),
             }
         }
-        pub fn take_node_at_key(&mut self, key: &[u8]) -> Option<TrieNodeODRc<V, A>> {
+        pub fn take_node_at_key(&mut self, key: &[u8], prune: bool) -> Option<TrieNodeODRc<V, A>> {
             match self {
-                Self::DenseByteNode(node) => node.take_node_at_key(key),
-                Self::LineListNode(node) => node.take_node_at_key(key),
-                Self::CellByteNode(node) => node.take_node_at_key(key),
+                Self::DenseByteNode(node) => node.take_node_at_key(key, prune),
+                Self::LineListNode(node) => node.take_node_at_key(key, prune),
+                Self::CellByteNode(node) => node.take_node_at_key(key, prune),
             }
         }
         pub fn join_into_dyn(&mut self, other: TrieNodeODRc<V, A>) -> (AlgebraicStatus, Result<(), TrieNodeODRc<V, A>>) where V: Lattice {

--- a/src/trie_node.rs
+++ b/src/trie_node.rs
@@ -2225,6 +2225,9 @@ pub(crate) fn val_count_below_root<V: Clone + Send + Sync, A: Allocator>(node: T
 }
 
 pub(crate) fn val_count_below_node<V: Clone + Send + Sync, A: Allocator>(node: &TrieNodeODRc<V, A>, cache: &mut HashMap<u64, usize>) -> usize {
+    if node.is_empty() {
+        return 0
+    }
     if node.refcount() > 1 {
         let hash = node.shared_node_id();
         match cache.get(&hash) {

--- a/src/trie_ref.rs
+++ b/src/trie_ref.rs
@@ -975,7 +975,7 @@ mod tests {
 
         //Lastly, check that the TrieRef didn't mess up the map
         let mut wz = zh.write_zipper_at_exclusive_path(b"path").unwrap();
-        wz.remove_val();
+        wz.remove_val(true);
         drop(wz);
         drop(zh);
         assert_eq!(map.get_val_at(b"path"), None);

--- a/src/utils/debug/diff_zipper.rs
+++ b/src/utils/debug/diff_zipper.rs
@@ -1,0 +1,269 @@
+
+use crate::alloc::Allocator;
+use crate::zipper::*;
+use crate::utils::ByteMask;
+
+/// A [Zipper] type that wraps two other zippers that are expected to behave identically,
+/// and panics when they don't.  Useful to debug a Zipper implementation.
+pub struct DiffZipper<A: Zipper, B: Zipper> {
+    a: A,
+    b: B,
+    log_moves: bool,
+}
+
+impl<A: Zipper, B: Zipper> DiffZipper<A, B> {
+    pub fn new(a: A, b: B, log_moves: bool) -> Self {
+        Self{a, b, log_moves}
+    }
+}
+
+impl<A: Zipper, B: Zipper> Zipper for DiffZipper<A, B>
+{
+    fn path_exists(&self) -> bool {
+        let a = self.a.path_exists();
+        let b = self.b.path_exists();
+        assert_eq!(a, b);
+        a
+    }
+    fn is_val(&self) -> bool {
+        let a = self.a.is_val();
+        let b = self.b.is_val();
+        assert_eq!(a, b);
+        a
+    }
+    fn child_count(&self) -> usize {
+        let a = self.a.child_count();
+        let b = self.b.child_count();
+        assert_eq!(a, b);
+        a
+    }
+    fn child_mask(&self) -> ByteMask {
+        let a = self.a.child_mask();
+        let b = self.b.child_mask();
+        assert_eq!(a, b);
+        a
+    }
+}
+
+impl<A: Zipper + ZipperMoving, B: Zipper + ZipperMoving> ZipperMoving for DiffZipper<A, B>
+{
+    fn at_root(&self) -> bool {
+        let a = self.a.at_root();
+        let b = self.b.at_root();
+        assert_eq!(a, b);
+        a
+    }
+    fn reset(&mut self) {
+        self.a.reset();
+        self.b.reset();
+        if self.log_moves {
+            println!("DiffZipper: reset")
+        }
+    }
+    fn path(&self) -> &[u8] {
+        let a = self.a.path();
+        let b = self.b.path();
+        assert_eq!(a, b);
+        a
+    }
+    fn val_count(&self) -> usize {
+        let a = self.a.val_count();
+        let b = self.b.val_count();
+        assert_eq!(a, b);
+        a
+    }
+    fn descend_to<P: AsRef<[u8]>>(&mut self, path: P) -> bool {
+        let path = path.as_ref();
+        let a = self.a.descend_to(path);
+        let b = self.b.descend_to(path);
+        if self.log_moves {
+            println!("DiffZipper: descend_to path={path:?}")
+        }
+        assert_eq!(a, b);
+        a
+    }
+    fn descend_to_existing<P: AsRef<[u8]>>(&mut self, path: P) -> usize {
+        let path = path.as_ref();
+        let a = self.a.descend_to_existing(path);
+        let b = self.b.descend_to_existing(path);
+        if self.log_moves {
+            println!("DiffZipper: descend_to_existing path={path:?}")
+        }
+        assert_eq!(a, b);
+        a
+    }
+    fn descend_to_val<K: AsRef<[u8]>>(&mut self, path: K) -> usize {
+        let path = path.as_ref();
+        let a = self.a.descend_to_val(path);
+        let b = self.b.descend_to_val(path);
+        if self.log_moves {
+            println!("DiffZipper: descend_to_val path={path:?}")
+        }
+        assert_eq!(a, b);
+        a
+    }
+    fn descend_to_byte(&mut self, k: u8) -> bool {
+        let a = self.a.descend_to_byte(k);
+        let b = self.b.descend_to_byte(k);
+        if self.log_moves {
+            println!("DiffZipper: descend_to_byte k={k}")
+        }
+        assert_eq!(a, b);
+        a
+    }
+    fn descend_indexed_byte(&mut self, idx: usize) -> bool {
+        let a = self.a.descend_indexed_byte(idx);
+        let b = self.b.descend_indexed_byte(idx);
+        if self.log_moves {
+            println!("DiffZipper: descend_indexed_byte idx={idx}")
+        }
+        assert_eq!(a, b);
+        a
+    }
+    fn descend_first_byte(&mut self) -> bool {
+        let a = self.a.descend_first_byte();
+        let b = self.b.descend_first_byte();
+        if self.log_moves {
+            println!("DiffZipper: descend_first_byte")
+        }
+        assert_eq!(a, b);
+        a
+    }
+    fn descend_until(&mut self) -> bool {
+        let a = self.a.descend_until();
+        let b = self.b.descend_until();
+        if self.log_moves {
+            println!("DiffZipper: descend_until")
+        }
+        assert_eq!(a, b);
+        a
+    }
+    fn ascend(&mut self, steps: usize) -> bool {
+        let a = self.a.ascend(steps);
+        let b = self.b.ascend(steps);
+        if self.log_moves {
+            println!("DiffZipper: ascend steps={steps}")
+        }
+        assert_eq!(a, b);
+        a
+    }
+    fn ascend_byte(&mut self) -> bool {
+        let a = self.a.ascend_byte();
+        let b = self.b.ascend_byte();
+        if self.log_moves {
+            println!("DiffZipper: ascend_byte")
+        }
+        assert_eq!(a, b);
+        a
+    }
+    fn ascend_until(&mut self) -> bool {
+        let a = self.a.ascend_until();
+        let b = self.b.ascend_until();
+        if self.log_moves {
+            println!("DiffZipper: ascend_until")
+        }
+        assert_eq!(a, b);
+        a
+    }
+    fn ascend_until_branch(&mut self) -> bool {
+        let a = self.a.ascend_until_branch();
+        let b = self.b.ascend_until_branch();
+        if self.log_moves {
+            println!("DiffZipper: ascend_until_branch")
+        }
+        assert_eq!(a, b);
+        a
+    }
+    fn to_next_sibling_byte(&mut self) -> bool {
+        let a = self.a.to_next_sibling_byte();
+        let b = self.b.to_next_sibling_byte();
+        if self.log_moves {
+            println!("DiffZipper: to_next_sibling_byte")
+        }
+        assert_eq!(a, b);
+        a
+    }
+    fn to_prev_sibling_byte(&mut self) -> bool {
+        let a = self.a.to_prev_sibling_byte();
+        let b = self.b.to_prev_sibling_byte();
+        if self.log_moves {
+            println!("DiffZipper: to_prev_sibling_byte")
+        }
+        assert_eq!(a, b);
+        a
+    }
+}
+
+impl<A: Zipper + ZipperAbsolutePath, B: Zipper + ZipperAbsolutePath> ZipperAbsolutePath for DiffZipper<A, B>
+{
+    fn origin_path(&self) -> &[u8] {
+        let a = self.a.origin_path();
+        let b = self.b.origin_path();
+        assert_eq!(a, b);
+        a
+    }
+    fn root_prefix_path(&self) -> &[u8] {
+        let a = self.a.root_prefix_path();
+        let b = self.b.root_prefix_path();
+        assert_eq!(a, b);
+        a
+    }
+}
+
+impl<A: Zipper + ZipperPathBuffer, B: Zipper + ZipperPathBuffer> ZipperPathBuffer for DiffZipper<A, B>
+{
+    unsafe fn origin_path_assert_len(&self, len: usize) -> &[u8] {
+        let a = unsafe{ self.a.origin_path_assert_len(len) };
+        let b = unsafe{ self.b.origin_path_assert_len(len) };
+        assert_eq!(a, b);
+        a
+    }
+    fn reserve_buffers(&mut self, path_len: usize, stack_depth: usize) {
+        self.a.reserve_buffers(path_len, stack_depth);
+        self.b.reserve_buffers(path_len, stack_depth);
+    }
+
+    fn prepare_buffers(&mut self) {
+        self.a.prepare_buffers();
+        self.b.prepare_buffers();
+    }
+}
+
+impl<A: Zipper + ZipperIteration, B: Zipper + ZipperIteration> ZipperIteration for DiffZipper<A, B>
+{
+    fn to_next_val(&mut self) -> bool {
+        let a = self.a.to_next_val();
+        let b = self.b.to_next_val();
+        assert_eq!(a, b);
+        a
+    }
+    fn descend_first_k_path(&mut self, k: usize) -> bool {
+        let a = self.a.descend_first_k_path(k);
+        let b = self.b.descend_first_k_path(k);
+        assert_eq!(a, b);
+        a
+    }
+    fn to_next_k_path(&mut self, k: usize) -> bool {
+        let a = self.a.to_next_k_path(k);
+        let b = self.b.to_next_k_path(k);
+        assert_eq!(a, b);
+        a
+    }
+}
+
+//This is a bit cheezy, but we don't have a trait for ProductZipper inspection methods, and
+// I don't see adding one any time soon.
+impl<V, A, Primary, Secondary> DiffZipper<ProductZipper<'_, '_, V, A>, ProductZipperG<'_, Primary, Secondary, V>>
+where
+A: Allocator,
+V: Clone + Send + Sync + Unpin,
+Primary: ZipperValues<V> + ZipperAbsolutePath + ZipperPathBuffer,
+Secondary: ZipperValues<V> + ZipperAbsolutePath + ZipperPathBuffer,
+{
+    pub fn path_indices(&self) -> &[usize] {
+        let a = self.a.path_indices();
+        let b = self.b.path_indices();
+        assert_eq!(a, b);
+        a
+    }
+}

--- a/src/utils/debug/diff_zipper.rs
+++ b/src/utils/debug/diff_zipper.rs
@@ -234,18 +234,27 @@ impl<A: Zipper + ZipperIteration, B: Zipper + ZipperIteration> ZipperIteration f
     fn to_next_val(&mut self) -> bool {
         let a = self.a.to_next_val();
         let b = self.b.to_next_val();
+        if self.log_moves {
+            println!("DiffZipper: to_next_val")
+        }
         assert_eq!(a, b);
         a
     }
     fn descend_first_k_path(&mut self, k: usize) -> bool {
         let a = self.a.descend_first_k_path(k);
         let b = self.b.descend_first_k_path(k);
+        if self.log_moves {
+            println!("DiffZipper: descend_first_k_path k={k}")
+        }
         assert_eq!(a, b);
         a
     }
     fn to_next_k_path(&mut self, k: usize) -> bool {
         let a = self.a.to_next_k_path(k);
         let b = self.b.to_next_k_path(k);
+        if self.log_moves {
+            println!("DiffZipper: to_next_k_path k={k}")
+        }
         assert_eq!(a, b);
         a
     }

--- a/src/utils/debug/mod.rs
+++ b/src/utils/debug/mod.rs
@@ -1,0 +1,4 @@
+//! Handy utilities to help debug PathMap and software that uses `pathmap`
+
+mod diff_zipper;
+pub use diff_zipper::DiffZipper;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,6 +3,8 @@ use crate::ring::*;
 
 pub mod ints;
 
+pub mod debug;
+
 /// A 256-bit type containing a bit for every possible value in a byte
 #[derive(Clone, Copy, Default, PartialEq, Eq)]
 #[repr(transparent)]

--- a/src/write_zipper.rs
+++ b/src/write_zipper.rs
@@ -49,8 +49,6 @@ pub trait ZipperWriting<V: Clone + Send + Sync, A: Allocator = GlobalAlloc>: Wri
     ///
     /// Returns `Some(replaced_val)` if an existing value was replaced, otherwise returns `None` if
     /// the value was added without replacing anything.
-    ///
-    /// Panics if the zipper's focus is unable to hold a value
     fn set_val(&mut self, val: V) -> Option<V>;
 
     /// Deprecated alias for [ZipperWriting::set_val]
@@ -62,8 +60,7 @@ pub trait ZipperWriting<V: Clone + Send + Sync, A: Allocator = GlobalAlloc>: Wri
     /// Removes the value at the zipper's focus.  Does not affect any onward branches.  Returns `Some(val)`
     /// with the value that was removed, otherwise returns `None`
     ///
-    /// WARNING: This method may cause the trie to be pruned above the zipper's focus, and may result in
-    /// [Zipper::path_exists] returning `false`, where it previously returned `true`
+    /// Pass `true` to the `prune` argument to automatically remove any dangling path created by this operation.
     fn remove_val(&mut self, prune: bool) -> Option<V>;
 
     /// Deprecated alias for [ZipperWriting::remove_val]
@@ -80,10 +77,8 @@ pub trait ZipperWriting<V: Clone + Send + Sync, A: Allocator = GlobalAlloc>: Wri
     /// If there is a value at the zipper's focus, it will not be affected.
     /// GOAT: This method's behavior is affected by the `graft_root_vals` feature
     ///
-    /// WARNING: If the `read_zipper` is not on an existing path (according to [Zipper::path_exists]) then the
-    /// effect will be the same as [Self::remove_branches] causing the trie to be pruned below the graft location.
-    /// Since dangling paths aren't allowed, This method may cause the trie to be pruned above the zipper's focus,
-    /// and may lead to `path_exists` returning `false`, where it previously returned `true`
+    /// NOTE: If the `read_zipper` is not on an existing path (according to [Zipper::path_exists]) then the
+    /// effect will be the same as [remove_branches](ZipperWriting::remove_branches)
     fn graft<Z: ZipperSubtries<V, A>>(&mut self, read_zipper: &Z);
 
     /// Replaces the trie below the zipper's focus with the contents of a [PathMap], consuming the map
@@ -91,10 +86,7 @@ pub trait ZipperWriting<V: Clone + Send + Sync, A: Allocator = GlobalAlloc>: Wri
     /// If there is a value at the zipper's focus, it will not be affected.
     /// GOAT: This method's behavior is affected by the `graft_root_vals` feature
     ///
-    /// WARNING: If the `map` is empty then the effect will be the same as [Self::remove_branches] causing the
-    /// trie to be pruned below the graft location.  Since dangling paths aren't allowed, This method may cause
-    /// the trie to be pruned above the zipper's focus, and may lead to [Zipper::path_exists] returning `false`,
-    /// where it previously returned `true`
+    /// NOTE: If the `map` is empty then the effect will be the same as [remove_branches](ZipperWriting::remove_branches)
     fn graft_map(&mut self, map: PathMap<V, A>);
 
     /// Joins (union of) the subtrie below the zipper's focus with the subtrie downstream from the focus of
@@ -105,7 +97,7 @@ pub trait ZipperWriting<V: Clone + Send + Sync, A: Allocator = GlobalAlloc>: Wri
     /// It actually makes sense that the answer should be yes.  If this is the decision, the `join_map`
     /// method has an implementation that could likely be factord out and shared among all the ops.
     ///
-    /// If the &self zipper is at a path that does not exist, this method behaves like graft.
+    /// If the `self` zipper is at a path that does not exist, this method behaves like [graft](ZipperWriting::graft).
     fn join<Z: ZipperSubtries<V, A>>(&mut self, read_zipper: &Z) -> AlgebraicStatus where V: Lattice;
 
     /// Joins (union of) the trie below the zipper's focus with the contents of a [PathMap],
@@ -122,8 +114,11 @@ pub trait ZipperWriting<V: Clone + Send + Sync, A: Allocator = GlobalAlloc>: Wri
 
     /// Joins the subtrie below the focus of `src_zipper` with the subtrie below the focus of `self`,
     /// consuming `src_zipper`'s subtrie
+    ///
+    /// Pass `true` to the `prune` argument to automatically remove any dangling path created in `src_zipper`.
+    //
     //GOAT, `WriteZipper::join` already is "join_into", so `WriteZipper::join_into` should be renamed to something like `take_and_join`
-    fn join_into<Z: ZipperSubtries<V, A> + ZipperWriting<V, A>>(&mut self, src_zipper: &mut Z) -> AlgebraicStatus where V: Lattice;
+    fn join_into<Z: ZipperSubtries<V, A> + ZipperWriting<V, A>>(&mut self, src_zipper: &mut Z, prune: bool) -> AlgebraicStatus where V: Lattice;
 
     /// Collapses all the paths below the zipper's focus by removing the leading `byte_cnt` bytes from
     /// each path and joining together all of the downstream sub-paths
@@ -183,27 +178,27 @@ pub trait ZipperWriting<V: Clone + Send + Sync, A: Allocator = GlobalAlloc>: Wri
     //GOAT, gotta document this much better and decide if a return of AlgebraicStatus is called for.  Probably.
     fn restricting<Z: ZipperSubtries<V, A>>(&mut self, read_zipper: &Z) -> bool;
 
-    /// Removes all branches below the zipper's focus.  Does not affect the value if there is one.  Returns `true`
-    /// if a branch was removed, otherwise returns `false`
-    ///
-    /// WARNING: This method may cause the trie to be pruned above the zipper's focus, and may result in
-    /// [Zipper::path_exists] returning `false`, where it previously returned `true`
-    fn remove_branches(&mut self) -> bool;
-
     /// Creates a new [PathMap] from the zipper's focus, removing all downstream branches from the zipper
+    ///
+    /// Pass `true` to the `prune` argument to automatically remove any dangling path created by this operation.
     ///
     /// GOAT: This method's behavior is affected by the `graft_root_vals` feature
     /// A value at the zipper's focus will not be affected, and will not be included in the resulting map.
     /// GOAT: See discussion in [ZipperSubtries::make_map] about whether this behavior should be changed
-    fn take_map(&mut self) -> Option<PathMap<V, A>>;
+    fn take_map(&mut self, prune: bool) -> Option<PathMap<V, A>>;
+
+    /// Removes all branches below the zipper's focus.  Does not affect the value if there is one.  Returns `true`
+    /// if a branch was removed, otherwise returns `false`
+    ///
+    /// Pass `true` to the `prune` argument to automatically remove any dangling path created by this operation.
+    fn remove_branches(&mut self, prune: bool) -> bool;
 
     /// Removes multiple branches below the zipper's focus based on the supplied 256-bit `mask`
     ///
     /// Key bytes for which the corresponding `mask` bit is `0` will be removed.
     ///
-    /// WARNING: This method may cause the trie to be pruned above the zipper's focus, and may result in
-    /// [Zipper::path_exists] returning `false`, where it previously returned `true`
-    fn remove_unmasked_branches(&mut self, mask: ByteMask);
+    /// Pass `true` to the `prune` argument to automatically remove any dangling path created by this operation.
+    fn remove_unmasked_branches(&mut self, mask: ByteMask, prune: bool);
 
     /// Prunes a dangling path above the zipper's focus.  Returns the number of path bytes removed
     ///
@@ -217,7 +212,7 @@ pub(crate) mod write_zipper_priv {
     use super::*;
 
     pub trait WriteZipperPriv<V: Clone + Send + Sync, A: Allocator> {
-        fn take_focus(&mut self) -> Option<TrieNodeODRc<V, A>>;
+        fn take_focus(&mut self, prune: bool) -> Option<TrieNodeODRc<V, A>>;
         /// Takes the root_prefix_path from a zipper, and leaves its buffers in an "unprepared" state
         fn take_root_prefix_path(&mut self) -> Vec<u8>;
         /// Returns the allocator belonging to the WZ
@@ -238,7 +233,7 @@ impl<V: Clone + Send + Sync, Z, A: Allocator> ZipperWriting<V, A> for &mut Z whe
     fn graft_map(&mut self, map: PathMap<V, A>) { (**self).graft_map(map) }
     fn join<RZ: ZipperSubtries<V, A>>(&mut self, read_zipper: &RZ) -> AlgebraicStatus where V: Lattice { (**self).join(read_zipper) }
     fn join_map(&mut self, map: PathMap<V, A>) -> AlgebraicStatus where V: Lattice { (**self).join_map(map) }
-    fn join_into<RZ: ZipperSubtries<V, A> + ZipperWriting<V, A>>(&mut self, src_zipper: &mut RZ) -> AlgebraicStatus where V: Lattice { (**self).join_into(src_zipper) }
+    fn join_into<RZ: ZipperSubtries<V, A> + ZipperWriting<V, A>>(&mut self, src_zipper: &mut RZ, prune: bool) -> AlgebraicStatus where V: Lattice { (**self).join_into(src_zipper, prune) }
     fn drop_head(&mut self, byte_cnt: usize) -> bool where V: Lattice { (**self).drop_head(byte_cnt) }
     fn insert_prefix<K: AsRef<[u8]>>(&mut self, prefix: K) -> bool { (**self).insert_prefix(prefix) }
     fn remove_prefix(&mut self, n: usize) -> bool { (**self).remove_prefix(n) }
@@ -247,14 +242,14 @@ impl<V: Clone + Send + Sync, Z, A: Allocator> ZipperWriting<V, A> for &mut Z whe
     fn subtract<RZ: ZipperSubtries<V, A>>(&mut self, read_zipper: &RZ) -> AlgebraicStatus where V: DistributiveLattice { (**self).subtract(read_zipper) }
     fn restrict<RZ: ZipperSubtries<V, A>>(&mut self, read_zipper: &RZ) -> AlgebraicStatus { (**self).restrict(read_zipper) }
     fn restricting<RZ: ZipperSubtries<V, A>>(&mut self, read_zipper: &RZ) -> bool { (**self).restricting(read_zipper) }
-    fn remove_branches(&mut self) -> bool { (**self).remove_branches() }
-    fn take_map(&mut self) -> Option<PathMap<V, A>> { (**self).take_map() }
-    fn remove_unmasked_branches(&mut self, mask: ByteMask) { (**self).remove_unmasked_branches(mask) }
+    fn take_map(&mut self, prune: bool) -> Option<PathMap<V, A>> { (**self).take_map(prune) }
+    fn remove_branches(&mut self, prune: bool) -> bool { (**self).remove_branches(prune) }
+    fn remove_unmasked_branches(&mut self, mask: ByteMask, prune: bool) { (**self).remove_unmasked_branches(mask, prune) }
     fn prune(&mut self) -> usize { (**self).prune() }
 }
 
 impl<V: Clone + Send + Sync, Z, A: Allocator> WriteZipperPriv<V, A> for &mut Z where Z: WriteZipperPriv<V, A> {
-    fn take_focus(&mut self) -> Option<TrieNodeODRc<V, A>> { (**self).take_focus() }
+    fn take_focus(&mut self, prune: bool) -> Option<TrieNodeODRc<V, A>> { (**self).take_focus(prune) }
     fn take_root_prefix_path(&mut self) -> Vec<u8> { (**self).take_root_prefix_path() }
     fn alloc(&self) -> A { (**self).alloc() }
 }
@@ -388,7 +383,7 @@ impl<'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> ZipperWriting
     fn graft_map(&mut self, map: PathMap<V, A>) { self.z.graft_map(map) }
     fn join<Z: ZipperSubtries<V, A>>(&mut self, read_zipper: &Z) -> AlgebraicStatus where V: Lattice { self.z.join(read_zipper) }
     fn join_map(&mut self, map: PathMap<V, A>) -> AlgebraicStatus where V: Lattice { self.z.join_map(map) }
-    fn join_into<Z: ZipperSubtries<V, A> + ZipperWriting<V, A>>(&mut self, src_zipper: &mut Z) -> AlgebraicStatus where V: Lattice { self.z.join_into(src_zipper) }
+    fn join_into<Z: ZipperSubtries<V, A> + ZipperWriting<V, A>>(&mut self, src_zipper: &mut Z, prune: bool) -> AlgebraicStatus where V: Lattice { self.z.join_into(src_zipper, prune) }
     fn drop_head(&mut self, byte_cnt: usize) -> bool where V: Lattice { self.z.drop_head(byte_cnt) }
     fn insert_prefix<K: AsRef<[u8]>>(&mut self, prefix: K) -> bool { self.z.insert_prefix(prefix) }
     fn remove_prefix(&mut self, n: usize) -> bool { self.z.remove_prefix(n) }
@@ -397,14 +392,14 @@ impl<'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> ZipperWriting
     fn subtract<Z: ZipperSubtries<V, A>>(&mut self, read_zipper: &Z) -> AlgebraicStatus where V: DistributiveLattice { self.z.subtract(read_zipper) }
     fn restrict<Z: ZipperSubtries<V, A>>(&mut self, read_zipper: &Z) -> AlgebraicStatus { self.z.restrict(read_zipper) }
     fn restricting<Z: ZipperSubtries<V, A>>(&mut self, read_zipper: &Z) -> bool { self.z.restricting(read_zipper) }
-    fn remove_branches(&mut self) -> bool { self.z.remove_branches() }
-    fn take_map(&mut self) -> Option<PathMap<V, A>> { self.z.take_map() }
-    fn remove_unmasked_branches(&mut self, mask: ByteMask) { self.z.remove_unmasked_branches(mask) }
+    fn take_map(&mut self, prune: bool) -> Option<PathMap<V, A>> { self.z.take_map(prune) }
+    fn remove_branches(&mut self, prune: bool) -> bool { self.z.remove_branches(prune) }
+    fn remove_unmasked_branches(&mut self, mask: ByteMask, prune: bool) { self.z.remove_unmasked_branches(mask, prune) }
     fn prune(&mut self) -> usize { self.z.prune() }
 }
 
 impl<'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperPriv<V, A> for WriteZipperTracked<'a, 'path, V, A> {
-    fn take_focus(&mut self) -> Option<TrieNodeODRc<V, A>> { self.z.take_focus() }
+    fn take_focus(&mut self, prune: bool) -> Option<TrieNodeODRc<V, A>> { self.z.take_focus(prune) }
     fn take_root_prefix_path(&mut self) -> Vec<u8> { self.z.take_root_prefix_path() }
     fn alloc(&self) -> A { self.z.alloc.clone() }
 }
@@ -560,7 +555,7 @@ impl<'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> ZipperWriting
     fn graft_map(&mut self, map: PathMap<V, A>) { self.z.graft_map(map) }
     fn join<Z: ZipperSubtries<V, A>>(&mut self, read_zipper: &Z) -> AlgebraicStatus where V: Lattice { self.z.join(read_zipper) }
     fn join_map(&mut self, map: PathMap<V, A>) -> AlgebraicStatus where V: Lattice { self.z.join_map(map) }
-    fn join_into<Z: ZipperSubtries<V, A> + ZipperWriting<V, A>>(&mut self, src_zipper: &mut Z) -> AlgebraicStatus where V: Lattice { self.z.join_into(src_zipper) }
+    fn join_into<Z: ZipperSubtries<V, A> + ZipperWriting<V, A>>(&mut self, src_zipper: &mut Z, prune: bool) -> AlgebraicStatus where V: Lattice { self.z.join_into(src_zipper, prune) }
     fn drop_head(&mut self, byte_cnt: usize) -> bool where V: Lattice { self.z.drop_head(byte_cnt) }
     fn insert_prefix<K: AsRef<[u8]>>(&mut self, prefix: K) -> bool { self.z.insert_prefix(prefix) }
     fn remove_prefix(&mut self, n: usize) -> bool { self.z.remove_prefix(n) }
@@ -569,14 +564,14 @@ impl<'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> ZipperWriting
     fn subtract<Z: ZipperSubtries<V, A>>(&mut self, read_zipper: &Z) -> AlgebraicStatus where V: DistributiveLattice { self.z.subtract(read_zipper) }
     fn restrict<Z: ZipperSubtries<V, A>>(&mut self, read_zipper: &Z) -> AlgebraicStatus { self.z.restrict(read_zipper) }
     fn restricting<Z: ZipperSubtries<V, A>>(&mut self, read_zipper: &Z) -> bool { self.z.restricting(read_zipper) }
-    fn remove_branches(&mut self) -> bool { self.z.remove_branches() }
-    fn take_map(&mut self) -> Option<PathMap<V, A>> { self.z.take_map() }
-    fn remove_unmasked_branches(&mut self, mask: ByteMask) { self.z.remove_unmasked_branches(mask) }
+    fn take_map(&mut self, prune: bool) -> Option<PathMap<V, A>> { self.z.take_map(prune) }
+    fn remove_branches(&mut self, prune: bool) -> bool { self.z.remove_branches(prune) }
+    fn remove_unmasked_branches(&mut self, mask: ByteMask, prune: bool) { self.z.remove_unmasked_branches(mask, prune) }
     fn prune(&mut self) -> usize { self.z.prune() }
 }
 
 impl<'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperPriv<V, A> for WriteZipperUntracked<'a, 'path, V, A> {
-    fn take_focus(&mut self) -> Option<TrieNodeODRc<V, A>> { self.z.take_focus() }
+    fn take_focus(&mut self, prune: bool) -> Option<TrieNodeODRc<V, A>> { self.z.take_focus(prune) }
     fn take_root_prefix_path(&mut self) -> Vec<u8> { self.z.take_root_prefix_path() }
     fn alloc(&self) -> A { self.z.alloc.clone() }
 }
@@ -724,7 +719,7 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperWriting<V, A> for Write
     fn graft_map(&mut self, map: PathMap<V, A>) { self.z.graft_map(map) }
     fn join<Z: ZipperSubtries<V, A>>(&mut self, read_zipper: &Z) -> AlgebraicStatus where V: Lattice { self.z.join(read_zipper) }
     fn join_map(&mut self, map: PathMap<V, A>) -> AlgebraicStatus where V: Lattice { self.z.join_map(map) }
-    fn join_into<Z: ZipperSubtries<V, A> + ZipperWriting<V, A>>(&mut self, src_zipper: &mut Z) -> AlgebraicStatus where V: Lattice { self.z.join_into(src_zipper) }
+    fn join_into<Z: ZipperSubtries<V, A> + ZipperWriting<V, A>>(&mut self, src_zipper: &mut Z, prune: bool) -> AlgebraicStatus where V: Lattice { self.z.join_into(src_zipper, prune) }
     fn drop_head(&mut self, byte_cnt: usize) -> bool where V: Lattice { self.z.drop_head(byte_cnt) }
     fn insert_prefix<K: AsRef<[u8]>>(&mut self, prefix: K) -> bool { self.z.insert_prefix(prefix) }
     fn remove_prefix(&mut self, n: usize) -> bool { self.z.remove_prefix(n) }
@@ -733,14 +728,14 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperWriting<V, A> for Write
     fn subtract<Z: ZipperSubtries<V, A>>(&mut self, read_zipper: &Z) -> AlgebraicStatus where V: DistributiveLattice { self.z.subtract(read_zipper) }
     fn restrict<Z: ZipperSubtries<V, A>>(&mut self, read_zipper: &Z) -> AlgebraicStatus { self.z.restrict(read_zipper) }
     fn restricting<Z: ZipperSubtries<V, A>>(&mut self, read_zipper: &Z) -> bool { self.z.restricting(read_zipper) }
-    fn remove_branches(&mut self) -> bool { self.z.remove_branches() }
-    fn take_map(&mut self) -> Option<PathMap<V, A>> { self.z.take_map() }
-    fn remove_unmasked_branches(&mut self, mask: ByteMask) { self.z.remove_unmasked_branches(mask) }
+    fn take_map(&mut self, prune: bool) -> Option<PathMap<V, A>> { self.z.take_map(prune) }
+    fn remove_branches(&mut self, prune: bool) -> bool { self.z.remove_branches(prune) }
+    fn remove_unmasked_branches(&mut self, mask: ByteMask, prune: bool) { self.z.remove_unmasked_branches(mask, prune) }
     fn prune(&mut self) -> usize { self.z.prune() }
 }
 
 impl<V: Clone + Send + Sync + Unpin, A: Allocator> WriteZipperPriv<V, A> for WriteZipperOwned<V, A> {
-    fn take_focus(&mut self) -> Option<TrieNodeODRc<V, A>> { self.z.take_focus() }
+    fn take_focus(&mut self, prune: bool) -> Option<TrieNodeODRc<V, A>> { self.z.take_focus(prune) }
     fn take_root_prefix_path(&mut self) -> Vec<u8> { self.z.take_root_prefix_path() }
     fn alloc(&self) -> A { self.z.alloc.clone() }
 }
@@ -1144,7 +1139,7 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
         let alloc = self.alloc.clone();
         let sub_branch_added = self.in_zipper_mut_static_result(
             |node, key| {
-                let new_node = if let Some(remaining) = node.take_node_at_key(key) {
+                let new_node = if let Some(remaining) = node.take_node_at_key(key, false) {
                     remaining
                 } else {
                     #[cfg(not(feature = "all_dense_nodes"))]
@@ -1443,8 +1438,8 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
         return node_status.merge(val_status, true, true)
     }
     /// See [ZipperWriting::join_into]
-    pub fn join_into<Z: ZipperSubtries<V, A> + ZipperWriting<V, A>>(&mut self, src_zipper: &mut Z) -> AlgebraicStatus where V: Lattice {
-        match src_zipper.take_focus() {
+    pub fn join_into<Z: ZipperSubtries<V, A> + ZipperWriting<V, A>>(&mut self, src_zipper: &mut Z, prune: bool) -> AlgebraicStatus where V: Lattice {
+        match src_zipper.take_focus(prune) {
             None => {
                 if self.get_focus().is_none() {
                     return AlgebraicStatus::None
@@ -1453,7 +1448,7 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
                 }
             },
             Some(src) => {
-                match self.take_focus() {
+                match self.take_focus(false) {
                     Some(mut self_node) => {
                         let (status, result) = self_node.make_mut().join_into_dyn(src);
                         match result {
@@ -1469,7 +1464,6 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
                 }
             }
         }
-        //GOAT-prune!!!!!  We should prune the path at the source zipper, since we're effectively leaving behind an empty node
     }
     /// See [ZipperWriting::drop_head]
     pub fn drop_head(&mut self, byte_cnt: usize) -> bool where V: Lattice {
@@ -1485,7 +1479,6 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
             },
             None => { false }
         }
-        //GOAT-prune!!!!!  We should prune the path upstream, if we ended up removing all downstream paths
     }
     /// See [ZipperWriting::insert_prefix]
     pub fn insert_prefix<K: AsRef<[u8]>>(&mut self, prefix: K) -> bool {
@@ -1660,13 +1653,13 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
         }
     }
     /// See [WriteZipper::remove_branches]
-    pub fn remove_branches(&mut self) -> bool {
+    pub fn remove_branches(&mut self, prune: bool) -> bool {
         let node_key = self.key.node_key();
         if node_key.len() > 0 {
             let mut focus_node = self.focus_stack.top_mut().unwrap();
-            if focus_node.node_remove_all_branches(node_key) {
-                if focus_node.reborrow().node_is_empty() {
-                    self.prune_path(false); //goat-prune
+            if focus_node.node_remove_all_branches(node_key, prune) {
+                if prune {
+                    self.prune_path(false);
                 }
                 true
             } else {
@@ -1683,18 +1676,15 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
                 true
             }
         }
-        //GOAT-prune, is this where we want to do the upstream pruning??  I think this is the place to do it, taking a prune flag into this method,
-        // because graft_internal calls here
     }
     /// See [WriteZipper::take_map]
-    pub fn take_map(&mut self) -> Option<PathMap<V, A>> {
+    pub fn take_map(&mut self, prune: bool) -> Option<PathMap<V, A>> {
         #[cfg(not(feature = "graft_root_vals"))]
         let root_val = None;
         #[cfg(feature = "graft_root_vals")]
-        let root_val = self.remove_val(true); //goat-prune
+        let root_val = self.remove_val(prune);
 
-        let root_node = self.take_focus();
-        //GOAT-prune, we should prune upstream here!!
+        let root_node = self.take_focus(prune);
 
         self.get_focus().into_option();
         if root_node.is_some() || root_val.is_some() {
@@ -1704,32 +1694,32 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
         }
     }
     /// See [WriteZipper::remove_unmasked_branches]
-    pub fn remove_unmasked_branches(&mut self, mask: ByteMask) {
+    pub fn remove_unmasked_branches(&mut self, mask: ByteMask, prune: bool) {
         let mut focus_node = self.focus_stack.top_mut().unwrap();
         let node_key = self.key.node_key();
         if node_key.len() > 0 {
             match focus_node.node_get_child_mut(node_key) {
                 Some((consumed_bytes, child_node)) => {
                     if node_key.len() >= consumed_bytes {
-                        child_node.make_mut().node_remove_unmasked_branches(&node_key[consumed_bytes..], mask);
+                        child_node.make_mut().node_remove_unmasked_branches(&node_key[consumed_bytes..], mask, prune);
                         if child_node.as_tagged().node_is_empty() {
-                            focus_node.node_remove_all_branches(&node_key[..consumed_bytes]);
+                            focus_node.node_remove_all_branches(&node_key[..consumed_bytes], prune);
                         }
                     } else {
                         //Zipper is positioned at non-existent node.  Removing anything from nothing is nothing
                     }
                 },
                 None => {
-                    focus_node.node_remove_unmasked_branches(node_key, mask);
+                    focus_node.node_remove_unmasked_branches(node_key, mask, prune);
                 }
             }
         } else {
-            focus_node.node_remove_unmasked_branches(node_key, mask);
+            debug_assert!(self.key.prefix_buf.len() <= self.key.origin_path.len()); //Equivalent to `self.at_root()`, but can't borrow `self` here
+            focus_node.node_remove_unmasked_branches(node_key, mask, prune);
         }
-        if focus_node.reborrow().node_is_empty() {
+        if prune {
             self.prune_path(false);
         }
-        //GOAT-prune, this method should have a switch as to whether to prune the upstream branch or not
     }
 
     /// See [ZipperWriting::prune]
@@ -1748,7 +1738,7 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
 
     /// Internal method, Removes and returns the node at the zipper's focus.  This method may leave behind a dangling path
     #[inline]
-    fn take_focus(&mut self) -> Option<TrieNodeODRc<V, A>> {
+    fn take_focus(&mut self, prune: bool) -> Option<TrieNodeODRc<V, A>> {
         let mut focus_node = self.focus_stack.top_mut().unwrap();
         let node_key = self.key.node_key();
         if node_key.len() == 0 {
@@ -1763,9 +1753,9 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
                 None
             }
         } else {
-            if let Some(new_node) = focus_node.take_node_at_key(node_key) {
-                if focus_node.reborrow().node_is_empty() {
-                    self.prune_path(false); //goat-prune
+            if let Some(new_node) = focus_node.take_node_at_key(node_key, prune) {
+                if prune {
+                    self.prune_path(false);
                 }
                 Some(new_node)
             } else {
@@ -1818,7 +1808,7 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
                     *stack_root = src;
                 }
             },
-            None => { self.remove_branches(); }
+            None => { self.remove_branches(false); }
         }
     }
 
@@ -1862,6 +1852,7 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
         let mut temp_path = path_buf;
         let mut ascended = false;
         let mut just_popped = false;
+        let mut node_key_end = temp_path.len();
 
         //This loop mirrors the behavior of `ascend_until`, popping from the node stack but leaving the path buffer alone
         loop {
@@ -1878,6 +1869,10 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
             ascended = true;
             temp_path = &temp_path[..new_len];
 
+            // When we break, we want to drop everything after the current `node_key`, so
+            // this will yield a 1-byte node key
+            node_key_end = new_len + 1;
+
             //This mirrors the logic of `ascend_across_nodes`
             let node_key = &temp_path[node_key_start..];
             if node_key.len() == 0 {
@@ -1893,7 +1888,7 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
             let mut node_key_start = self.key.node_key_start();
             let node_key = &temp_path[node_key_start..];
             let focus_node = self.focus_stack.top().unwrap();
-            if node_count_branches_recursive(focus_node, node_key) > 1 || focus_node.node_contains_val(node_key) {
+            if node_count_branches_recursive(focus_node, node_key) > 1 {
                 if just_popped {
                     let mut node_path = &path_buf[node_key_start..];
                     Self::descend_step_internal(&mut self.focus_stack, &mut self.key.prefix_idx, &mut node_path, &mut node_key_start);
@@ -1901,15 +1896,22 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
                 break
             }
             just_popped = false;
+
+            //If we encounter a value, then we should also stop ascending
+            if focus_node.node_contains_val(node_key) {
+                //In this case, we want to remove the current subtrie, as opposed to the subtrie
+                // one level deeper that we remove in the other cases, when we stop due to a branch
+                node_key_end = temp_path.len();
+                break;
+            }
         };
 
         //At this point, the zipper's node stack reflects the position it would be after `ascend_until`
         if ascended {
             let mut focus_node = self.focus_stack.top_mut().unwrap();
             let node_key_start = self.key.node_key_start();
-            // We want the byte immediately after the current `node_key`
-            let next_node_key_byte = &path_buf[node_key_start..temp_path.len()+1];
-            let removed = focus_node.node_remove_all_branches(next_node_key_byte);
+            let next_node_key = &path_buf[node_key_start..node_key_end];
+            let removed = focus_node.node_remove_all_branches(next_node_key, true);
 
             //If we got here, we should have either removed something, or we should be at the top of the zipper
             debug_assert!(removed || self.focus_stack.depth()==1);
@@ -2028,7 +2030,7 @@ pub(crate) fn swap_top_node<'cursor, V: Clone + Send + Sync, A: Allocator + 'cur
         focus_stack.backtrack();
         let mut parent_node = unsafe{ focus_stack.top_mut().unwrap_unchecked() };
         let parent_key = key.parent_key();
-        let existing_node = parent_node.take_node_at_key(parent_key).unwrap();
+        let existing_node = parent_node.take_node_at_key(parent_key, false).unwrap();
         let replacement_node = func(existing_node);
         parent_node.node_set_branch(parent_key, replacement_node).unwrap();
         focus_stack.advance(|node| node.node_get_child_mut(parent_key).map(|(_, child_node)| child_node.make_mut()));
@@ -2604,7 +2606,7 @@ mod tests {
         assert_eq!(a.val_count(), 12);
         assert_eq!(b.val_count(), 8);
 
-        a.join_into(&mut b);
+        a.join_into(&mut b, true);
         assert_eq!(a.val_count(), 20);
         assert_eq!(b.val_count(), 0);
 
@@ -2808,7 +2810,7 @@ mod tests {
         let mut map: PathMap<i32> = keys.iter().enumerate().map(|(i, k)| (k, i as i32)).collect();
 
         let mut wz = map.write_zipper_at_path(b"roman");
-        wz.remove_branches();
+        wz.remove_branches(true);
         drop(wz);
 
         //Test that the original keys were left alone, above the graft point
@@ -2827,7 +2829,7 @@ mod tests {
         let mut wz = map.write_zipper();
         wz.descend_to(b"ro");
         assert!(wz.path_exists());
-        wz.remove_branches();
+        wz.remove_branches(true);
         assert!(!wz.path_exists());
         drop(wz);
 
@@ -2835,7 +2837,7 @@ mod tests {
         wz.descend_to(b"abcdefghijklmnopq");
         assert!(wz.path_exists());
         assert_eq!(wz.path(), b"abcdefghijklmnopq");
-        wz.remove_branches();
+        wz.remove_branches(true);
         assert!(!wz.path_exists());
         assert_eq!(wz.path(), b"abcdefghijklmnopq");
         drop(wz);
@@ -3086,7 +3088,7 @@ mod tests {
 
         let mut wr = map.write_zipper();
         wr.descend_to(b"rom");
-        let sub_map = wr.take_map().unwrap();
+        let sub_map = wr.take_map(true).unwrap();
         drop(wr);
 
         let sub_map_keys: Vec<String> = sub_map.iter().map(|(k, _v)| String::from_utf8_lossy(&k).to_string()).collect();
@@ -3113,7 +3115,7 @@ mod tests {
 
         let mut m = [0, 0, 0, 0];
         for b in "abc".bytes() { m[((b & 0b11000000) >> 6) as usize] |= 1u64 << (b & 0b00111111); }
-        wr.remove_unmasked_branches(m.into());
+        wr.remove_unmasked_branches(m.into(), true);
         drop(wr);
 
         let result = map.iter().map(|(k, _v)| String::from_utf8_lossy(&k).to_string()).collect::<Vec<_>>();
@@ -3140,11 +3142,11 @@ mod tests {
 
         let mut m = [0, 0, 0, 0];
         for b in "dco".bytes() { m[((b & 0b11000000) >> 6) as usize] |= 1u64 << (b & 0b00111111); }
-        wr.remove_unmasked_branches(m.into());
+        wr.remove_unmasked_branches(m.into(), true);
         m = [0, 0, 0, 0];
         wr.descend_to("d".as_bytes());
         for b in "o".bytes() { m[((b & 0b11000000) >> 6) as usize] |= 1u64 << (b & 0b00111111); }
-        wr.remove_unmasked_branches(m.into());
+        wr.remove_unmasked_branches(m.into(), true);
         drop(wr);
 
         let result = map.iter().map(|(k, _v)| String::from_utf8_lossy(&k).to_string()).collect::<Vec<_>>();
@@ -3169,7 +3171,7 @@ mod tests {
 
         m = [0, 0, 0, 0];
         for b in "b".bytes() { m[((b & 0b11000000) >> 6) as usize] |= 1u64 << (b & 0b00111111); }
-        wr.remove_unmasked_branches(m.into());
+        wr.remove_unmasked_branches(m.into(), true);
         drop(wr);
 
         let result = map.iter().map(|(k, _v)| String::from_utf8_lossy(&k).to_string()).collect::<Vec<_>>();
@@ -3185,7 +3187,7 @@ mod tests {
         let mut map: PathMap<u64> = keys.iter().enumerate().map(|(i, k)| (k, i as u64)).collect();
 
         let mut wr = map.write_zipper();
-        wr.remove_unmasked_branches([0xFF, !(1<<(b'M'-64)), 0xFF, 0xFF].into());
+        wr.remove_unmasked_branches([0xFF, !(1<<(b'M'-64)), 0xFF, 0xFF].into(), true);
         //McKinley didn't make it
         wr.descend_to("McKinley");
         assert_eq!(wr.val(), None);
@@ -3193,7 +3195,7 @@ mod tests {
         wr.reset();
         wr.descend_to("Roos");
         assert_eq!(wr.path_exists(), true);
-        wr.remove_unmasked_branches([0xFF, !(1<<(b'i'-64)), 0xFF, 0xFF].into());
+        wr.remove_unmasked_branches([0xFF, !(1<<(b'i'-64)), 0xFF, 0xFF].into(), true);
         //Missed Roosevelt
         wr.descend_to("evelt");
         assert_eq!(wr.val(), Some(&2));
@@ -3201,7 +3203,7 @@ mod tests {
         wr.reset();
         wr.descend_to("Garf");
         assert_eq!(wr.path_exists(), true);
-        wr.remove_unmasked_branches([0xFF, !(1<<(b'i'-64)), 0xFF, 0xFF].into());
+        wr.remove_unmasked_branches([0xFF, !(1<<(b'i'-64)), 0xFF, 0xFF].into(), true);
         wr.descend_to("ield");
         //Garfield was removed
         assert_eq!(wr.val(), None);
@@ -3310,7 +3312,7 @@ mod tests {
 
         // [C, D] \/-> [A, B] should be `Element`
         let mut wz = head.write_zipper_at_exclusive_path(b"src:").unwrap();
-        wz.remove_branches();
+        wz.remove_branches(true);
         wz.descend_to_byte(b'C');
         wz.set_val(true);
         wz.ascend_byte();
@@ -3326,7 +3328,7 @@ mod tests {
 
         // [Carousel] \/-> [A, B, C, D] should be `Element`
         let mut wz = head.write_zipper_at_exclusive_path(b"src:").unwrap();
-        wz.remove_branches();
+        wz.remove_branches(true);
         wz.descend_to(b"Carousel");
         wz.set_val(true);
         drop(wz);
@@ -3339,7 +3341,7 @@ mod tests {
 
         // Empty \/-> Something should be `Identity`
         let mut wz = head.write_zipper_at_exclusive_path(b"src:").unwrap();
-        wz.remove_branches();
+        wz.remove_branches(true);
         drop(wz);
         let mut wz = head.write_zipper_at_exclusive_path(b"dst:").unwrap();
         let rz = head.read_zipper_at_path(b"src:").unwrap();
@@ -3681,6 +3683,154 @@ mod tests {
         assert_eq!(wz.prune(), 3);
         assert_eq!(wz.path_exists(), false);
         assert_eq!(wz.ascend(3), true);
+        assert_eq!(wz.child_count(), 2);
+    }
+
+    /// This test exercises removing branches to create dangling paths, with an emphasis on pair nodes
+    #[test]
+    fn write_zipper_prune_path_test4() {
+        let mut map = PathMap::<()>::new();
+        map.set_val_at([0], ());
+        map.set_val_at([0, 0, 0], ());
+        map.set_val_at([0, 0, 1, 0, 0, 0, 0], ());
+        let mut wz = map.write_zipper();
+
+        //Use `remove_branches` to to cut a path within a pair node
+        assert_eq!(wz.descend_to([0, 0, 1, 0, 0]), true);
+        assert_eq!(wz.path_exists(), true);
+        assert_eq!(wz.remove_branches(false), true);
+        assert_eq!(wz.path_exists(), true);
+        assert_eq!(wz.descend_to_byte(0), false);
+        assert_eq!(wz.path_exists(), false);
+        assert_eq!(wz.ascend_byte(), true);
+        assert_eq!(wz.path_exists(), true);
+
+        //Test `prune`
+        assert_eq!(wz.prune(), 3);
+        assert_eq!(wz.path(), &[0, 0, 1, 0, 0]);
+        assert_eq!(wz.path_exists(), false);
+        assert_eq!(wz.ascend(3), true);
+        assert_eq!(wz.path_exists(), true);
+
+        //Recreate some new paths, remove one and try re-extending it
+        assert_eq!(wz.descend_to([0, 0, 0, 0]), false);
+        assert_eq!(wz.set_val(()), None);
+        assert_eq!(wz.ascend(4), true);
+        assert_eq!(wz.descend_to([0, 0, 1, 0]), false);
+        assert_eq!(wz.set_val(()), None);
+        assert_eq!(wz.ascend(2), true);
+        assert_eq!(wz.descend_to_byte(0), true);
+        assert_eq!(wz.remove_branches(false), true);
+        assert_eq!(wz.path_exists(), true);
+        assert_eq!(wz.descend_to_byte(0), false);
+        assert_eq!(wz.path_exists(), false);
+        assert_eq!(wz.set_val(()), None);
+        assert_eq!(wz.ascend_byte(), true);
+        assert_eq!(wz.remove_branches(false), true);
+
+        //A test for `remove_unmasked_branches`
+        wz.reset();
+        assert_eq!(wz.child_count(), 1);
+        assert_eq!(wz.descend_to_byte(0), true);
+        assert_eq!(wz.child_count(), 1);
+        assert_eq!(wz.descend_to_byte(0), true);
+        assert_eq!(wz.path_exists(), true);
+        assert_eq!(wz.child_count(), 1);
+        assert_eq!(wz.prune(), 0);
+        wz.remove_unmasked_branches(ByteMask::from_iter([1u8]), false);
+        assert_eq!(wz.child_count(), 0);
+        assert_eq!(wz.path_exists(), true);
+        assert_eq!(wz.prune(), 1);
+        wz.reset();
+        assert_eq!(wz.child_count(), 1);
+        assert_eq!(wz.descend_to_byte(0), true);
+        assert_eq!(wz.child_count(), 0);
+        assert_eq!(wz.val(), Some(&()));
+        assert_eq!(wz.prune(), 0);
+        assert_eq!(wz.remove_val(false), Some(()));
+        assert_eq!(wz.prune(), 1);
+    }
+
+    /// This test exercises `take_node` (source for join_into, take_map, etc.) to remove branches to create dangling paths, with an emphasis on pair nodes
+    #[test]
+    fn write_zipper_prune_path_test5() {
+        let mut src_map = PathMap::<()>::new();
+        src_map.set_val_at([0], ());
+        src_map.set_val_at([0, 0, 0], ());
+        src_map.set_val_at([0, 0, 1, 0, 0, 0, 0], ());
+        let mut src_z = src_map.write_zipper();
+
+        //Test removing from the middle of a node
+        assert_eq!(src_z.descend_to([0, 0, 1, 0, 0]), true);
+        assert_eq!(src_z.path_exists(), true);
+        let mut dst_map = src_z.take_map(false).unwrap();
+        assert_eq!(src_z.path_exists(), true);
+        assert_eq!(src_z.descend_to_byte(0), false);
+        assert_eq!(src_z.path_exists(), false);
+        assert_eq!(src_z.ascend_byte(), true);
+        assert_eq!(src_z.path_exists(), true);
+
+        //Test prune
+        assert_eq!(src_z.prune(), 3);
+        assert_eq!(src_z.path(), &[0, 0, 1, 0, 0]);
+        assert_eq!(src_z.path_exists(), false);
+        assert_eq!(src_z.ascend(3), true);
+        assert_eq!(src_z.path_exists(), true);
+
+        //Test removing from a node boundary
+        let mut dst_z = dst_map.write_zipper();
+        assert_eq!(dst_z.join_into(&mut src_z, false), AlgebraicStatus::Element);
+        assert_eq!(src_z.path_exists(), true);
+        assert_eq!(src_z.prune(), 1);
+        assert_eq!(src_z.path_exists(), false);
+
+        drop(src_z);
+        drop(dst_z);
+        assert_eq!(src_map.val_count(), 1);
+        assert_eq!(dst_map.val_count(), 2);
+    }
+
+    //Similar test to `write_zipper_prune_path_test4`, but designed to exercise byte nodes
+    #[test]
+    fn write_zipper_prune_path_test6() {
+        let mut map = PathMap::<()>::new();
+        map.set_val_at([0], ());
+        map.set_val_at([1, 9, 0], ());
+        map.set_val_at([1, 9, 0, 9, 0], ());
+        map.set_val_at([1, 9, 0, 9, 1], ());
+        map.set_val_at([1, 9, 0, 9, 2], ());
+        map.set_val_at([1, 9, 0, 9, 3], ());
+        map.set_val_at([1, 9, 1], ());
+        map.set_val_at([1, 9, 2], ());
+        map.set_val_at([1, 9, 3], ());
+        map.set_val_at([2, 9, 0], ());
+        let mut wz = map.write_zipper();
+
+        //Use `remove_unmaksed_branches` to chop off every part of a ByteNode
+        assert_eq!(wz.descend_to([1, 9, 0, 9]), true);
+        assert_eq!(wz.path_exists(), true);
+        assert_eq!(wz.child_count(), 4);
+        wz.remove_unmasked_branches(ByteMask::EMPTY, false);
+        assert_eq!(wz.path_exists(), true);
+        assert_eq!(wz.child_count(), 0);
+        assert_eq!(wz.prune(), 1);
+        assert_eq!(wz.path_exists(), false);
+
+        assert_eq!(wz.ascend_byte(), true);
+        assert_eq!(wz.path_exists(), true);
+        assert_eq!(wz.child_count(), 0);
+        assert_eq!(wz.ascend_byte(), true);
+        assert_eq!(wz.child_count(), 4);
+        wz.remove_branches(false);
+        assert_eq!(wz.child_count(), 0);
+        assert_eq!(wz.path_exists(), true);
+        assert_eq!(wz.path(), &[1, 9]);
+        assert_eq!(wz.prune(), 2);
+        assert_eq!(wz.path_exists(), false);
+        assert_eq!(wz.ascend_byte(), true);
+        assert_eq!(wz.path_exists(), false);
+        assert_eq!(wz.ascend_byte(), true);
+        assert_eq!(wz.path_exists(), true);
         assert_eq!(wz.child_count(), 2);
     }
 

--- a/src/zipper.rs
+++ b/src/zipper.rs
@@ -1428,7 +1428,7 @@ pub(crate) mod read_zipper_core {
         /// The issue is how miri scopes its pointer tags, which make self-referential types fail
         /// when they are dropped, because the reference and the referant get dropped within the same
         /// scope.
-        #[derive(Clone)]
+        #[derive(Clone, Debug)]
         pub struct MiriWrapper<T>(T);
 
         impl<T> Deref for MiriWrapper<T> {

--- a/src/zipper_head.rs
+++ b/src/zipper_head.rs
@@ -299,7 +299,8 @@ impl<'trie, Z, V: 'trie + Clone + Send + Sync + Unpin, A: Allocator + 'trie> Zip
                 inner_z.move_to_path(origin_path);
                 if inner_z.try_borrow_focus().unwrap().as_tagged().node_is_empty() {
                     if !inner_z.is_val() && inner_z.child_count() == 0 {
-                        inner_z.prune_path();
+                        inner_z.remove_branches(); //GOAT, I can just pass the `prune` flag here, instead of calling prune_path below
+                        inner_z.prune_path(false);
                     }
                 }
                 inner_z.reset();
@@ -887,7 +888,7 @@ mod tests {
 
         let mut wz = unsafe{ space.write_zipper_at_exclusive_path_unchecked(&[4, 200, 0, 0, 0, 0, 0, 0, 0, 6, 2, 200, 0, 0, 0, 0, 0, 0, 0, 4]) };
         wz.descend_to(&[200, 0, 0, 0, 0, 0, 0, 0, 7, 2, 200, 0, 0, 0, 0, 0, 0, 0, 3, 2, 200, 0, 0, 0, 0, 0, 0, 0, 4, 2, 200, 0, 0, 0, 0, 0, 0, 0, 8, 192, 2, 200, 0, 0, 0, 0, 0, 0, 0, 3, 2, 200, 0, 0, 0, 0, 0, 0, 0, 4, 2, 200, 0, 0, 0, 0, 0, 0, 0, 9, 128]);
-        wz.remove_val();
+        wz.remove_val(true);
         drop(wz);
 
         let wz = unsafe{ space.write_zipper_at_exclusive_path_unchecked(&[2, 200, 0, 0, 0, 0, 0, 0, 0, 4, 2, 200, 0, 0, 0, 0, 0, 0, 0, 9]) };
@@ -898,7 +899,7 @@ mod tests {
 
         let mut wz = unsafe{ space.write_zipper_at_exclusive_path_unchecked(&[4, 200, 0, 0, 0, 0, 0, 0, 0, 6, 2, 200, 0, 0, 0, 0, 0, 0, 0, 4]) };
         wz.descend_to(&[200, 0, 0, 0, 0, 0, 0, 0, 7, 2, 200, 0, 0, 0, 0, 0, 0, 0, 3, 2, 200, 0, 0, 0, 0, 0, 0, 0, 4, 200, 0, 0, 0, 0, 0, 0, 0, 5, 2, 200, 0, 0, 0, 0, 0, 0, 0, 3, 2, 200, 0, 0, 0, 0, 0, 0, 0, 4, 200, 0, 0, 0, 0, 0, 0, 0, 10]);
-        wz.remove_val();
+        wz.remove_val(true);
         drop(wz);
 
         let wz = unsafe{ space.write_zipper_at_exclusive_path_unchecked(&[2, 200, 0, 0, 0, 0, 0, 0, 0, 4, 200, 0, 0, 0, 0, 0, 0, 0, 10]) };
@@ -990,7 +991,7 @@ mod tests {
 
         //Now that the witness is gone, validate I can create the WZ, and remove the value
         let mut wz = zh.write_zipper_at_exclusive_path(b"path").unwrap();
-        wz.remove_val();
+        wz.remove_val(true);
         drop(wz);
         drop(zh);
         assert_eq!(map.get_val_at(b"path"), None);

--- a/src/zipper_tracking.rs
+++ b/src/zipper_tracking.rs
@@ -377,7 +377,7 @@ impl<M: TrackingMode> ZipperTracker<M> {
                 match write_zipper.get_val_mut() {
                     Some(cnt) => {
                         if *cnt == NonZero::<u32>::MIN {
-                            write_zipper.remove_val();
+                            write_zipper.remove_val(true);
                         } else {
                             *cnt = unsafe { NonZero::new_unchecked(cnt.get() - 1) };
                         };
@@ -389,7 +389,7 @@ impl<M: TrackingMode> ZipperTracker<M> {
                 let removed = paths
                     .written_paths
                     .write_zipper_at_path(this_path)
-                    .remove_val();
+                    .remove_val(true);
                 removed.is_some()
             }
         });


### PR DESCRIPTION
Change in behavior to ensure paths are always stable (won't be removed as a side effect of another operation)

* Adding checks inside ListNode so Null node ptrs aren't considered an illegal node anymore, and in ByteNode so Cf(None, None) isn't considered illegal
* adding explicit WriteZipper methods to prune and create paths
* adding flag arguments to a handful of existing WriteZipper and PathMap methods to prune explicitly.