### PR TITLE
Generic three-way zipper merge

### DIFF
--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -251,21 +251,41 @@ where
 }
 
 trait MergePolicy<V: Clone + Send + Sync> {
+    #[inline]
     fn on_left_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
     where
         A: Allocator,
         Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-        Out: ZipperWriting<V, A>;
+        Out: ZipperWriting<V, A>,
+    {
+        Self::on_single(z, 0b01, range, out);
+    }
 
+    #[inline]
     fn on_right_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
     where
         A: Allocator,
         Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Out: ZipperWriting<V, A>,
+    {
+        Self::on_single(z, 0b10, range, out);
+    }
+
+    fn on_single<Z, Out, A>(z: &mut Z, mask: u64, range: ByteMask, out: &mut Out)
+    where
+        A: Allocator,
+        Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
         Out: ZipperWriting<V, A>;
+
+    fn descend_on_some_equal(mask: u64) -> bool;
 }
 
 trait ValuePolicy<V> {
     fn combine(l: Option<&V>, r: Option<&V>) -> Option<V>;
+    fn combine3(l: Option<&V>, m: Option<&V>, r: Option<&V>) -> Option<V> {
+        // (l op m) op r
+        Self::combine(Self::combine(l, m).as_ref(), r)
+    }
 }
 
 fn zipper_merge<P, V, ZL, ZR, Out, A>(lhs: &mut ZL, rhs: &mut ZR, out: &mut Out)
@@ -367,12 +387,198 @@ where
     }
 }
 
+fn zipper_merge3<P, V, ZL, ZM, ZR, Out, A>(lhs: &mut ZL, mid: &mut ZM, rhs: &mut ZR, out: &mut Out)
+where
+    V: Clone + Send + Sync,
+    P: MergePolicy<V> + ValuePolicy<V>,
+    A: Allocator,
+    ZL: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    ZM: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    ZR: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    Out: ZipperWriting<V, A>,
+{
+    const L: u8 = 0b001;
+    const M: u8 = 0b010;
+    const R: u8 = 0b100;
+    const LM: u8 = L | M;
+    const LR: u8 = L | R;
+    const MR: u8 = M | R;
+    const LMR: u8 = L | M | R;
+
+    fn descend2<P, V, ZL, ZR, Out, A>(b: u8, lhs: &mut ZL, rhs: &mut ZR, mask: u8, out: &mut Out)
+    where
+        V: Clone + Send + Sync,
+        P: MergePolicy<V> + ValuePolicy<V>,
+        A: Allocator,
+        ZL: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        ZR: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Out: ZipperWriting<V, A>,
+    {
+        if !P::descend_on_some_equal(mask as u64) {
+            return;
+        }
+        out.descend_to_byte(b);
+        lhs.descend_to_byte(b);
+        rhs.descend_to_byte(b);
+
+        zipper_merge::<P, V, ZL, ZR, Out, A>(lhs, rhs, out);
+
+        rhs.ascend_byte();
+        lhs.ascend_byte();
+        out.ascend_byte();
+    }
+
+    // merge root values before descending
+    if let Some(v) = P::combine3(lhs.val(), mid.val(), rhs.val()) {
+        out.set_val(v);
+    }
+
+    let mut k = 0;
+    let mut lhs_mask = lhs.child_mask();
+    let mut mid_mask = mid.child_mask();
+    let mut rhs_mask = rhs.child_mask();
+    let mut lhs_idx = 0;
+    let mut mid_idx = 0;
+    let mut rhs_idx = 0;
+
+    'ascend: loop {
+        'merge_level: loop {
+            let l = lhs_mask.indexed_bit::<true>(lhs_idx as usize);
+            let m = mid_mask.indexed_bit::<true>(mid_idx as usize);
+            let r = rhs_mask.indexed_bit::<true>(rhs_idx as usize);
+
+            let mut a = l;
+            let mut b = m;
+            let mut c = r;
+
+            fn cmp_swap(a: &mut Option<u8>, b: &mut Option<u8>) {
+                if let Some(x) = *a {
+                    if let Some(y) = *b {
+                        if y < x {
+                            std::mem::swap(a, b);
+                        }
+                    }
+                } else {
+                    std::mem::swap(a, b);
+                }
+            }
+            cmp_swap(&mut a, &mut b);
+            cmp_swap(&mut a, &mut c);
+
+            if let Some(min) = a {
+                let mut frontier = 0;
+                if a == l {
+                    frontier = L;
+                }
+                if a == m {
+                    frontier |= M;
+                }
+                if a == r {
+                    frontier |= R;
+                }
+
+                cmp_swap(&mut b, &mut c);
+                let range = if let Some(next) = b {
+                    ByteMask::from_range(min..next)
+                } else {
+                    ByteMask::from_range(min..)
+                };
+
+                match frontier {
+                    // single → graft
+                    L => {
+                        P::on_single(lhs, L as u64, range, out);
+                    }
+                    M => {
+                        P::on_single(mid, M as u64, range, out);
+                    }
+                    R => {
+                        P::on_single(rhs, R as u64, range, out);
+                    }
+                    // two-way → descend 2
+                    LM => {
+                        descend2::<P, V, ZL, ZM, Out, A>(min, lhs, mid, LM, out);
+                    }
+                    MR => {
+                        descend2::<P, V, ZM, ZR, Out, A>(min, mid, rhs, MR, out);
+                    }
+                    LR => {
+                        descend2::<P, V, ZL, ZR, Out, A>(min, lhs, rhs, LR, out);
+                    }
+                    // full 3-way
+                    LMR => {
+                        out.descend_to_byte(min);
+
+                        lhs.descend_to_byte(min);
+                        mid.descend_to_byte(min);
+                        rhs.descend_to_byte(min);
+
+                        if let Some(val) = P::combine3(lhs.val(), mid.val(), rhs.val()) {
+                            out.set_val(val);
+                        }
+
+                        lhs_mask = lhs.child_mask();
+                        mid_mask = mid.child_mask();
+                        rhs_mask = rhs.child_mask();
+
+                        lhs_idx = 0;
+                        mid_idx = 0;
+                        rhs_idx = 0;
+
+                        k += 1;
+                        continue 'merge_level;
+                    }
+                    _ => unreachable!(),
+                }
+
+                if let Some(next) = b {
+                    if (frontier & L != 0) {
+                        lhs_idx = lhs_mask.index_of(next);
+                    }
+                    if (frontier & M != 0) {
+                        mid_idx = mid_mask.index_of(next);
+                    }
+                    if (frontier & R != 0) {
+                        rhs_idx = rhs_mask.index_of(next);
+                    }
+                } else {
+                    break 'merge_level;
+                }
+            } else {
+                break 'merge_level;
+            }
+        }
+
+        // If we are at root and no deeper recursion pending, we're done
+        if k == 0 {
+            break 'ascend;
+        }
+
+        let byte_from = *lhs.path().last().expect("non-empty path when k > 0");
+
+        rhs.ascend_byte();
+        rhs_mask = rhs.child_mask();
+        rhs_idx = rhs_mask.index_of(byte_from) + 1;
+
+        mid.ascend_byte();
+        mid_mask = mid.child_mask();
+        mid_idx = mid_mask.index_of(byte_from) + 1;
+
+        lhs.ascend_byte();
+        lhs_mask = lhs.child_mask();
+        lhs_idx = lhs_mask.index_of(byte_from) + 1;
+
+        out.ascend_byte();
+        k -= 1;
+    }
+}
+
 // ==================== JOIN ====================
 
 struct Join;
 impl<V: Clone + Send + Sync> MergePolicy<V> for Join {
     #[inline]
-    fn on_left_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
+    fn on_single<Z, Out, A>(z: &mut Z, _mask: u64, range: ByteMask, out: &mut Out)
     where
         A: Allocator,
         Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
@@ -382,13 +588,8 @@ impl<V: Clone + Send + Sync> MergePolicy<V> for Join {
     }
 
     #[inline]
-    fn on_right_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
-    where
-        A: Allocator,
-        Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-        Out: ZipperWriting<V, A>,
-    {
-        out.graft_children(z, range);
+    fn descend_on_some_equal(_mask: u64) -> bool {
+        true
     }
 }
 
@@ -421,7 +622,7 @@ impl<V: Lattice + Clone> ValuePolicy<V> for Join {
 struct Meet;
 impl<V: Clone + Send + Sync> MergePolicy<V> for Meet {
     #[inline(always)]
-    fn on_left_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
+    fn on_single<Z, Out, A>(_z: &mut Z, _mask: u64, _range: ByteMask, _out: &mut Out)
     where
         A: Allocator,
         Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
@@ -430,12 +631,8 @@ impl<V: Clone + Send + Sync> MergePolicy<V> for Meet {
     }
 
     #[inline(always)]
-    fn on_right_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
-    where
-        A: Allocator,
-        Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-        Out: ZipperWriting<V, A>,
-    {
+    fn descend_on_some_equal(_mask: u64) -> bool {
+        false
     }
 }
 
@@ -452,6 +649,38 @@ impl<V: Lattice + Clone> ValuePolicy<V> for Meet {
                     }
                 }
                 AlgebraicResult::Element(v) => Some(v),
+            })
+        })
+    }
+
+    fn combine3(l: Option<&V>, m: Option<&V>, r: Option<&V>) -> Option<V> {
+        l.and_then(|x| {
+            m.and_then(|y| {
+                r.and_then(|z| {
+                    let xy = match x.pmeet(y) {
+                        AlgebraicResult::None => return None,
+                        AlgebraicResult::Identity(mask) => {
+                            if mask & SELF_IDENT != 0 {
+                                x.clone()
+                            } else {
+                                y.clone()
+                            }
+                        }
+                        AlgebraicResult::Element(v) => v,
+                    };
+
+                    match xy.pmeet(z) {
+                        AlgebraicResult::None => None,
+                        AlgebraicResult::Identity(mask) => {
+                            if mask & SELF_IDENT != 0 {
+                                Some(xy)
+                            } else {
+                                Some(z.clone())
+                            }
+                        }
+                        AlgebraicResult::Element(v) => Some(v),
+                    }
+                })
             })
         })
     }
@@ -472,12 +701,29 @@ impl<V: Clone + Send + Sync> MergePolicy<V> for Subtract {
     }
 
     #[inline]
-    fn on_right_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
+    fn on_right_only<Z, Out, A>(_z: &mut Z, _range: ByteMask, _out: &mut Out)
     where
         A: Allocator,
         Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
         Out: ZipperWriting<V, A>,
     {
+    }
+
+    #[inline]
+    fn on_single<Z, Out, A>(z: &mut Z, mask: u64, range: ByteMask, out: &mut Out)
+    where
+        A: Allocator,
+        Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Out: ZipperWriting<V, A>,
+    {
+        if mask == 1 {
+            out.graft_children(z, range);
+        }
+    }
+
+    #[inline]
+    fn descend_on_some_equal(mask: u64) -> bool {
+        mask & 1 != 0
     }
 }
 
@@ -503,6 +749,7 @@ impl<V: DistributiveLattice + Clone> ValuePolicy<V> for Subtract {
         })
     }
 }
+
 #[cfg(test)]
 mod tests {
     use crate::{

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -448,6 +448,19 @@ where
     }
 }
 
+#[inline(always)]
+fn cmp_swap(a: &mut Option<u8>, b: &mut Option<u8>) {
+    if let Some(x) = *a {
+        if let Some(y) = *b {
+            if y < x {
+                std::mem::swap(a, b);
+            }
+        }
+    } else {
+        std::mem::swap(a, b);
+    }
+}
+
 fn zipper_merge3<P, V, ZL, ZM, ZR, Out, A>(lhs: &mut ZL, mid: &mut ZM, rhs: &mut ZR, out: &mut Out)
 where
     V: Clone + Send + Sync,
@@ -509,17 +522,6 @@ where
             let mut b = m;
             let mut c = r;
 
-            fn cmp_swap(a: &mut Option<u8>, b: &mut Option<u8>) {
-                if let Some(x) = *a {
-                    if let Some(y) = *b {
-                        if y < x {
-                            std::mem::swap(a, b);
-                        }
-                    }
-                } else {
-                    std::mem::swap(a, b);
-                }
-            }
             cmp_swap(&mut a, &mut b);
             cmp_swap(&mut a, &mut c);
 
@@ -535,36 +537,37 @@ where
                     frontier |= R;
                 }
 
-                cmp_swap(&mut b, &mut c);
-
                 match frontier {
                     // single → graft
-                    L if b.is_some() => {
-                        let next = b.unwrap();
-                        P::on_single(lhs, L as u64, ByteMask::from_range(min..next), out);
-                        lhs_idx = lhs_mask.index_of(next);
-                    }
                     L => {
-                        P::on_single(lhs, L as u64, ByteMask::from_range(min..), out);
-                        break 'merge_level;
-                    }
-                    M if b.is_some() => {
-                        let next = b.unwrap();
-                        P::on_single(mid, M as u64, ByteMask::from_range(min..next), out);
-                        mid_idx = mid_mask.index_of(next);
+                        cmp_swap(&mut b, &mut c);
+                        if let Some(next) = b {
+                            P::on_single(lhs, L as u64, ByteMask::from_range(min..next), out);
+                            lhs_idx = lhs_mask.index_of(next)
+                        } else {
+                            P::on_single(lhs, L as u64, ByteMask::from_range(min..), out);
+                            break 'merge_level;
+                        }
                     }
                     M => {
-                        P::on_single(mid, M as u64, ByteMask::from_range(min..), out);
-                        break 'merge_level;
-                    }
-                    R if b.is_some() => {
-                        let next = b.unwrap();
-                        P::on_single(rhs, R as u64, ByteMask::from_range(min..next), out);
-                        rhs_idx = rhs_mask.index_of(next);
+                        cmp_swap(&mut b, &mut c);
+                        if let Some(next) = b {
+                            P::on_single(mid, M as u64, ByteMask::from_range(min..next), out);
+                            mid_idx = mid_mask.index_of(next);
+                        } else {
+                            P::on_single(mid, M as u64, ByteMask::from_range(min..), out);
+                            break 'merge_level;
+                        }
                     }
                     R => {
-                        P::on_single(rhs, R as u64, ByteMask::from_range(min..), out);
-                        break 'merge_level;
+                        cmp_swap(&mut b, &mut c);
+                        if let Some(next) = b {
+                            P::on_single(rhs, R as u64, ByteMask::from_range(min..next), out);
+                            rhs_idx = rhs_mask.index_of(next);
+                        } else {
+                            P::on_single(rhs, R as u64, ByteMask::from_range(min..), out);
+                            break 'merge_level;
+                        }
                     }
                     // two-way → descend 2
                     LM => {

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -139,121 +139,7 @@ where
     ZR: ZipperInfallibleSubtries<V, A> + ZipperMoving,
     Out: ZipperWriting<V, A>,
 {
-    fn join_values<V, ZL, ZR, Out, A>(lhs: &ZL, rhs: &ZR, out: &mut Out)
-    where
-        V: Lattice + Clone + Send + Sync,
-        A: Allocator,
-        ZL: ZipperValues<V>,
-        ZR: ZipperValues<V>,
-        Out: ZipperWriting<V, A>,
-    {
-        if let Some(lv) = lhs.val() {
-            if let Some(rv) = rhs.val() {
-                match lv.pjoin(rv) {
-                    AlgebraicResult::None => {}
-                    AlgebraicResult::Identity(mask) => {
-                        if mask & SELF_IDENT != 0 {
-                            out.set_val(lv.clone());
-                        } else if mask & COUNTER_IDENT != 0 {
-                            out.set_val(rv.clone());
-                        }
-                    }
-                    AlgebraicResult::Element(v) => {
-                        out.set_val(v);
-                    }
-                }
-            } else {
-                out.set_val(lv.clone());
-            }
-        } else if let Some(rv) = rhs.val() {
-            out.set_val(rv.clone());
-        }
-    }
-
-    // join root values before descending
-    join_values(lhs, rhs, out);
-
-    let mut k = 0;
-    let mut lhs_mask = lhs.child_mask();
-    let mut rhs_mask = rhs.child_mask();
-    let mut lhs_idx = 0;
-    let mut rhs_idx = 0;
-
-    // At each node, the algorithm treats the sets of child edges of `lhs` and `rhs` as two
-    // sorted sequences and performs a merge-like traversal:
-    //
-    // - If a range of edges exists only in one side, the corresponding subtries are *grafted*
-    //   into the output without further traversal.
-    // - If both sides contain the same edge, the algorithm descends into that child,
-    //   recursively merging the corresponding subtries.
-    // - Descent is simulated iteratively using zipper movement (`descend_to_byte` /
-    //   `ascend_byte`) and an explicit depth counter (`k`).
-    'ascend: loop {
-        'merge_level: loop {
-            let lhs_next = lhs_mask.indexed_bit::<true>(lhs_idx as usize);
-            let rhs_next = rhs_mask.indexed_bit::<true>(rhs_idx as usize);
-
-            match lhs_next {
-                Some(lhs_byte) => match rhs_next {
-                    Some(rhs_byte) if lhs_byte < rhs_byte => {
-                        out.graft_children(lhs, ByteMask::from_range(lhs_byte..rhs_byte));
-                        lhs_idx = lhs_mask.index_of(rhs_byte);
-                    }
-                    Some(rhs_byte) if lhs_byte > rhs_byte => {
-                        out.graft_children(rhs, ByteMask::from_range(rhs_byte..lhs_byte));
-                        rhs_idx = rhs_mask.index_of(lhs_byte);
-                    }
-                    Some(rhs_byte) => {
-                        // equal → descend
-                        out.descend_to_byte(lhs_byte);
-
-                        lhs.descend_to_byte(lhs_byte);
-                        rhs.descend_to_byte(lhs_byte);
-
-                        join_values(lhs, rhs, out);
-
-                        lhs_mask = lhs.child_mask();
-                        rhs_mask = rhs.child_mask();
-
-                        lhs_idx = 0;
-                        rhs_idx = 0;
-
-                        k += 1;
-                        continue 'merge_level;
-                    }
-                    None => {
-                        out.graft_children(lhs, ByteMask::from_range(lhs_byte..));
-                        break 'merge_level;
-                    }
-                },
-                None => match rhs_next {
-                    Some(rhs_byte) => {
-                        out.graft_children(rhs, ByteMask::from_range(rhs_byte..));
-                        break 'merge_level;
-                    }
-                    None => break 'merge_level,
-                },
-            }
-        }
-
-        // If we are at root and no deeper recursion pending, we're done
-        if k == 0 {
-            break 'ascend;
-        }
-
-        let byte_from = *lhs.path().last().expect("non-empty path when k > 0");
-
-        rhs.ascend_byte();
-        rhs_mask = rhs.child_mask();
-        rhs_idx = rhs_mask.index_of(byte_from) + 1;
-
-        lhs.ascend_byte();
-        lhs_mask = lhs.child_mask();
-        lhs_idx = lhs_mask.index_of(byte_from) + 1;
-
-        out.ascend_byte();
-        k -= 1;
-    }
+    zipper_merge::<Join, V, ZL, ZR, Out, A>(lhs, rhs, out);
 }
 
 /// Performs an ordered meet (greatest lower bound) of two radix-256 tries using zipper traversal.
@@ -304,107 +190,7 @@ where
     ZR: ZipperInfallibleSubtries<V, A> + ZipperMoving,
     Out: ZipperWriting<V, A>,
 {
-    fn meet_values<V, ZL, ZR, Out, A>(lhs: &ZL, rhs: &ZR, out: &mut Out)
-    where
-        V: Lattice + Clone + Send + Sync,
-        A: Allocator,
-        ZL: ZipperValues<V>,
-        ZR: ZipperValues<V>,
-        Out: ZipperWriting<V, A>,
-    {
-        if let Some(lv) = lhs.val() {
-            if let Some(rv) = rhs.val() {
-                match lv.pmeet(rv) {
-                    AlgebraicResult::None => {}
-                    AlgebraicResult::Identity(mask) => {
-                        if mask & SELF_IDENT != 0 {
-                            out.set_val(lv.clone());
-                        } else if mask & COUNTER_IDENT != 0 {
-                            out.set_val(rv.clone());
-                        }
-                    }
-                    AlgebraicResult::Element(v) => {
-                        out.set_val(v);
-                    }
-                }
-            }
-        }
-    }
-
-    // meet root values before descending
-    meet_values(lhs, rhs, out);
-
-    let mut k = 0;
-    let mut lhs_mask = lhs.child_mask();
-    let mut rhs_mask = rhs.child_mask();
-    let mut lhs_idx = 0;
-    let mut rhs_idx = 0;
-
-    // At each node, the algorithm treats the sets of child edges of `lhs` and `rhs` as two
-    // sorted sequences and performs a merge-like traversal:
-    //
-    // - If a range of edges exists only in one side, the corresponding subtries are skipped
-    //   without further traversal.
-    // - If both sides contain the same edge, the algorithm descends into that child,
-    //   recursively merging the corresponding subtries.
-    // - Descent is simulated iteratively using zipper movement (`descend_to_byte` /
-    //   `ascend_byte`) and an explicit depth counter (`k`).
-    'ascend: loop {
-        'merge_level: loop {
-            let lhs_next = lhs_mask.indexed_bit::<true>(lhs_idx as usize);
-            let rhs_next = rhs_mask.indexed_bit::<true>(rhs_idx as usize);
-
-            match lhs_next {
-                Some(lhs_byte) => match rhs_next {
-                    Some(rhs_byte) if lhs_byte < rhs_byte => {
-                        // skip lhs-only range
-                        lhs_idx = lhs_mask.index_of(rhs_byte);
-                    }
-                    Some(rhs_byte) if lhs_byte > rhs_byte => {
-                        // skip rhs-only range
-                        rhs_idx = rhs_mask.index_of(lhs_byte);
-                    }
-                    Some(rhs_byte) => {
-                        // equal → descend
-                        out.descend_to_byte(lhs_byte);
-
-                        lhs.descend_to_byte(lhs_byte);
-                        rhs.descend_to_byte(lhs_byte);
-
-                        meet_values(lhs, rhs, out);
-
-                        lhs_mask = lhs.child_mask();
-                        rhs_mask = rhs.child_mask();
-
-                        lhs_idx = 0;
-                        rhs_idx = 0;
-
-                        k += 1;
-                        continue 'merge_level;
-                    }
-                    None => break 'merge_level,
-                },
-                None => break 'merge_level,
-            }
-        }
-
-        if k == 0 {
-            break 'ascend;
-        }
-
-        let byte_from = *lhs.path().last().expect("non-empty path when k > 0");
-
-        rhs.ascend_byte();
-        rhs_mask = rhs.child_mask();
-        rhs_idx = rhs_mask.index_of(byte_from) + 1;
-
-        lhs.ascend_byte();
-        lhs_mask = lhs.child_mask();
-        lhs_idx = lhs_mask.index_of(byte_from) + 1;
-
-        out.ascend_byte();
-        k -= 1;
-    }
+    zipper_merge::<Meet, V, ZL, ZR, Out, A>(lhs, rhs, out);
 }
 
 /// Performs an ordered subtraction (set difference, `lhs \ rhs`) of two radix-256 tries
@@ -461,36 +247,163 @@ where
     ZR: ZipperInfallibleSubtries<V, A> + ZipperMoving,
     Out: ZipperWriting<V, A>,
 {
-    fn combine_values<V, ZL, ZR, Out, A>(lhs: &ZL, rhs: &ZR, out: &mut Out)
+    zipper_merge::<Subtract, V, ZL, ZR, Out, A>(lhs, rhs, out);
+}
+
+trait MergePolicy<V: Clone + Send + Sync> {
+    fn combine(l: Option<&V>, r: Option<&V>) -> Option<V>;
+
+    fn on_left_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
     where
-        V: DistributiveLattice + Clone + Send + Sync,
         A: Allocator,
-        ZL: ZipperValues<V>,
-        ZR: ZipperValues<V>,
-        Out: ZipperWriting<V, A>,
-    {
-        if let Some(lv) = lhs.val() {
-            if let Some(rv) = rhs.val() {
-                match lv.psubtract(rv) {
-                    AlgebraicResult::None => {}
+        Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Out: ZipperWriting<V, A>;
+
+    fn on_right_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
+    where
+        A: Allocator,
+        Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Out: ZipperWriting<V, A>;
+}
+
+struct Join;
+impl<V: Lattice + Clone + Send + Sync> MergePolicy<V> for Join {
+    fn combine(l: Option<&V>, r: Option<&V>) -> Option<V> {
+        if let Some(lv) = l {
+            if let Some(rv) = r {
+                match lv.pjoin(rv) {
+                    AlgebraicResult::None => None,
                     AlgebraicResult::Identity(mask) => {
                         if mask & SELF_IDENT != 0 {
-                            out.set_val(lv.clone());
+                            l.cloned()
+                        } else {
+                            r.cloned()
                         }
                     }
-                    AlgebraicResult::Element(v) => {
-                        out.set_val(v);
-                    }
+                    AlgebraicResult::Element(v) => Some(v),
                 }
             } else {
-                // lhs-only → keep
-                out.set_val(lv.clone());
+                l.cloned()
             }
+        } else {
+            r.cloned()
         }
     }
 
-    // combine root values before descending
-    combine_values(lhs, rhs, out);
+    #[inline]
+    fn on_left_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
+    where
+        A: Allocator,
+        Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Out: ZipperWriting<V, A>,
+    {
+        out.graft_children(z, range);
+    }
+
+    #[inline]
+    fn on_right_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
+    where
+        A: Allocator,
+        Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Out: ZipperWriting<V, A>,
+    {
+        out.graft_children(z, range);
+    }
+}
+
+struct Meet;
+impl<V: Lattice + Clone + Send + Sync> MergePolicy<V> for Meet {
+    fn combine(l: Option<&V>, r: Option<&V>) -> Option<V> {
+        l.and_then(|lv| {
+            r.and_then(|rv| match lv.pmeet(rv) {
+                AlgebraicResult::None => None,
+                AlgebraicResult::Identity(mask) => {
+                    if mask & SELF_IDENT != 0 {
+                        Some(lv.clone())
+                    } else {
+                        Some(rv.clone())
+                    }
+                }
+                AlgebraicResult::Element(v) => Some(v),
+            })
+        })
+    }
+
+    #[inline(always)]
+    fn on_left_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
+    where
+        A: Allocator,
+        Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Out: ZipperWriting<V, A>,
+    {
+    }
+
+    #[inline(always)]
+    fn on_right_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
+    where
+        A: Allocator,
+        Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Out: ZipperWriting<V, A>,
+    {
+    }
+}
+
+struct Subtract;
+impl<V: DistributiveLattice + Clone + Send + Sync> MergePolicy<V> for Subtract {
+    fn combine(l: Option<&V>, r: Option<&V>) -> Option<V> {
+        l.and_then(|lv| {
+            if let Some(rv) = r {
+                match lv.psubtract(rv) {
+                    AlgebraicResult::None => None,
+                    AlgebraicResult::Identity(mask) => {
+                        if mask & SELF_IDENT != 0 {
+                            Some(lv.clone())
+                        } else {
+                            None
+                        }
+                    }
+                    AlgebraicResult::Element(v) => Some(v),
+                }
+            } else {
+                // lhs-only → keep
+                Some(lv.clone())
+            }
+        })
+    }
+
+    #[inline]
+    fn on_left_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
+    where
+        A: Allocator,
+        Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Out: ZipperWriting<V, A>,
+    {
+        out.graft_children(z, range);
+    }
+
+    #[inline]
+    fn on_right_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
+    where
+        A: Allocator,
+        Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Out: ZipperWriting<V, A>,
+    {
+    }
+}
+
+fn zipper_merge<P, V, ZL, ZR, Out, A>(lhs: &mut ZL, rhs: &mut ZR, out: &mut Out)
+where
+    V: Clone + Send + Sync,
+    P: MergePolicy<V>,
+    A: Allocator,
+    ZL: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    ZR: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    Out: ZipperWriting<V, A>,
+{
+    // merge root values before descending
+    if let Some(v) = P::combine(lhs.val(), rhs.val()) {
+        out.set_val(v);
+    }
 
     let mut k = 0;
     let mut lhs_mask = lhs.child_mask();
@@ -498,12 +411,15 @@ where
     let mut lhs_idx = 0;
     let mut rhs_idx = 0;
 
-    // The traversal follows a merge-like strategy over ordered child edges:
+    // At each node, the algorithm treats the sets of child edges of `lhs` and `rhs` as two sorted
+    // sequences and performs a merge-like traversal:
     //
-    // - Subtries that exist only in `lhs` are *grafted* directly into the output.
-    // - Subtries that exist only in `rhs` are skipped.
-    // - When both sides contain the same edge, the algorithm descends into that child
-    //   and continues subtracting recursively.
+    // - If a range of edges exists only in one side, the corresponding merge policy method is
+    //   called.
+    // - If both sides contain the same edge, the algorithm descends into that child, recursively
+    //   merging the corresponding subtries.
+    // - Descent is simulated iteratively using zipper movement (`descend_to_byte` / `ascend_byte`)
+    //   and an explicit depth counter (`k`).
     'ascend: loop {
         'merge_level: loop {
             let lhs_next = lhs_mask.indexed_bit::<true>(lhs_idx as usize);
@@ -512,11 +428,11 @@ where
             match lhs_next {
                 Some(lhs_byte) => match rhs_next {
                     Some(rhs_byte) if lhs_byte < rhs_byte => {
-                        out.graft_children(lhs, ByteMask::from_range(lhs_byte..rhs_byte));
+                        P::on_left_only(lhs, ByteMask::from_range(lhs_byte..rhs_byte), out);
                         lhs_idx = lhs_mask.index_of(rhs_byte);
                     }
                     Some(rhs_byte) if lhs_byte > rhs_byte => {
-                        // skip rhs-only range
+                        P::on_right_only(rhs, ByteMask::from_range(rhs_byte..lhs_byte), out);
                         rhs_idx = rhs_mask.index_of(lhs_byte);
                     }
                     Some(rhs_byte) => {
@@ -526,7 +442,9 @@ where
                         lhs.descend_to_byte(lhs_byte);
                         rhs.descend_to_byte(lhs_byte);
 
-                        combine_values(lhs, rhs, out);
+                        if let Some(v) = P::combine(lhs.val(), rhs.val()) {
+                            out.set_val(v);
+                        }
 
                         lhs_mask = lhs.child_mask();
                         rhs_mask = rhs.child_mask();
@@ -538,14 +456,21 @@ where
                         continue 'merge_level;
                     }
                     None => {
-                        out.graft_children(lhs, ByteMask::from_range(lhs_byte..));
+                        P::on_left_only(lhs, ByteMask::from_range(lhs_byte..), out);
                         break 'merge_level;
                     }
                 },
-                None => break 'merge_level,
+                None => match rhs_next {
+                    Some(rhs_byte) => {
+                        P::on_right_only(rhs, ByteMask::from_range(rhs_byte..), out);
+                        break 'merge_level;
+                    }
+                    None => break 'merge_level,
+                },
             }
         }
 
+        // If we are at root and no deeper recursion pending, we're done
         if k == 0 {
             break 'ascend;
         }

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -251,150 +251,27 @@ where
 }
 
 trait MergePolicy<V: Clone + Send + Sync> {
+    fn on_left_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
+    where
+        A: Allocator,
+        Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Out: ZipperWriting<V, A>;
+
+    fn on_right_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
+    where
+        A: Allocator,
+        Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Out: ZipperWriting<V, A>;
+}
+
+trait ValuePolicy<V> {
     fn combine(l: Option<&V>, r: Option<&V>) -> Option<V>;
-
-    fn on_left_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
-    where
-        A: Allocator,
-        Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-        Out: ZipperWriting<V, A>;
-
-    fn on_right_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
-    where
-        A: Allocator,
-        Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-        Out: ZipperWriting<V, A>;
-}
-
-struct Join;
-impl<V: Lattice + Clone + Send + Sync> MergePolicy<V> for Join {
-    fn combine(l: Option<&V>, r: Option<&V>) -> Option<V> {
-        if let Some(lv) = l {
-            if let Some(rv) = r {
-                match lv.pjoin(rv) {
-                    AlgebraicResult::None => None,
-                    AlgebraicResult::Identity(mask) => {
-                        if mask & SELF_IDENT != 0 {
-                            l.cloned()
-                        } else {
-                            r.cloned()
-                        }
-                    }
-                    AlgebraicResult::Element(v) => Some(v),
-                }
-            } else {
-                l.cloned()
-            }
-        } else {
-            r.cloned()
-        }
-    }
-
-    #[inline]
-    fn on_left_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
-    where
-        A: Allocator,
-        Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-        Out: ZipperWriting<V, A>,
-    {
-        out.graft_children(z, range);
-    }
-
-    #[inline]
-    fn on_right_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
-    where
-        A: Allocator,
-        Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-        Out: ZipperWriting<V, A>,
-    {
-        out.graft_children(z, range);
-    }
-}
-
-struct Meet;
-impl<V: Lattice + Clone + Send + Sync> MergePolicy<V> for Meet {
-    fn combine(l: Option<&V>, r: Option<&V>) -> Option<V> {
-        l.and_then(|lv| {
-            r.and_then(|rv| match lv.pmeet(rv) {
-                AlgebraicResult::None => None,
-                AlgebraicResult::Identity(mask) => {
-                    if mask & SELF_IDENT != 0 {
-                        Some(lv.clone())
-                    } else {
-                        Some(rv.clone())
-                    }
-                }
-                AlgebraicResult::Element(v) => Some(v),
-            })
-        })
-    }
-
-    #[inline(always)]
-    fn on_left_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
-    where
-        A: Allocator,
-        Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-        Out: ZipperWriting<V, A>,
-    {
-    }
-
-    #[inline(always)]
-    fn on_right_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
-    where
-        A: Allocator,
-        Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-        Out: ZipperWriting<V, A>,
-    {
-    }
-}
-
-struct Subtract;
-impl<V: DistributiveLattice + Clone + Send + Sync> MergePolicy<V> for Subtract {
-    fn combine(l: Option<&V>, r: Option<&V>) -> Option<V> {
-        l.and_then(|lv| {
-            if let Some(rv) = r {
-                match lv.psubtract(rv) {
-                    AlgebraicResult::None => None,
-                    AlgebraicResult::Identity(mask) => {
-                        if mask & SELF_IDENT != 0 {
-                            Some(lv.clone())
-                        } else {
-                            None
-                        }
-                    }
-                    AlgebraicResult::Element(v) => Some(v),
-                }
-            } else {
-                // lhs-only → keep
-                Some(lv.clone())
-            }
-        })
-    }
-
-    #[inline]
-    fn on_left_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
-    where
-        A: Allocator,
-        Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-        Out: ZipperWriting<V, A>,
-    {
-        out.graft_children(z, range);
-    }
-
-    #[inline]
-    fn on_right_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
-    where
-        A: Allocator,
-        Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-        Out: ZipperWriting<V, A>,
-    {
-    }
 }
 
 fn zipper_merge<P, V, ZL, ZR, Out, A>(lhs: &mut ZL, rhs: &mut ZR, out: &mut Out)
 where
     V: Clone + Send + Sync,
-    P: MergePolicy<V>,
+    P: MergePolicy<V> + ValuePolicy<V>,
     A: Allocator,
     ZL: ZipperInfallibleSubtries<V, A> + ZipperMoving,
     ZR: ZipperInfallibleSubtries<V, A> + ZipperMoving,
@@ -490,6 +367,142 @@ where
     }
 }
 
+// ==================== JOIN ====================
+
+struct Join;
+impl<V: Clone + Send + Sync> MergePolicy<V> for Join {
+    #[inline]
+    fn on_left_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
+    where
+        A: Allocator,
+        Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Out: ZipperWriting<V, A>,
+    {
+        out.graft_children(z, range);
+    }
+
+    #[inline]
+    fn on_right_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
+    where
+        A: Allocator,
+        Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Out: ZipperWriting<V, A>,
+    {
+        out.graft_children(z, range);
+    }
+}
+
+impl<V: Lattice + Clone> ValuePolicy<V> for Join {
+    fn combine(l: Option<&V>, r: Option<&V>) -> Option<V> {
+        if let Some(lv) = l {
+            if let Some(rv) = r {
+                match lv.pjoin(rv) {
+                    AlgebraicResult::None => None,
+                    AlgebraicResult::Identity(mask) => {
+                        if mask & SELF_IDENT != 0 {
+                            l.cloned()
+                        } else {
+                            r.cloned()
+                        }
+                    }
+                    AlgebraicResult::Element(v) => Some(v),
+                }
+            } else {
+                l.cloned()
+            }
+        } else {
+            r.cloned()
+        }
+    }
+}
+
+// ==================== MEET ====================
+
+struct Meet;
+impl<V: Clone + Send + Sync> MergePolicy<V> for Meet {
+    #[inline(always)]
+    fn on_left_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
+    where
+        A: Allocator,
+        Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Out: ZipperWriting<V, A>,
+    {
+    }
+
+    #[inline(always)]
+    fn on_right_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
+    where
+        A: Allocator,
+        Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Out: ZipperWriting<V, A>,
+    {
+    }
+}
+
+impl<V: Lattice + Clone> ValuePolicy<V> for Meet {
+    fn combine(l: Option<&V>, r: Option<&V>) -> Option<V> {
+        l.and_then(|lv| {
+            r.and_then(|rv| match lv.pmeet(rv) {
+                AlgebraicResult::None => None,
+                AlgebraicResult::Identity(mask) => {
+                    if mask & SELF_IDENT != 0 {
+                        Some(lv.clone())
+                    } else {
+                        Some(rv.clone())
+                    }
+                }
+                AlgebraicResult::Element(v) => Some(v),
+            })
+        })
+    }
+}
+
+// ==================== SUBTRACT ====================
+
+struct Subtract;
+impl<V: Clone + Send + Sync> MergePolicy<V> for Subtract {
+    #[inline]
+    fn on_left_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
+    where
+        A: Allocator,
+        Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Out: ZipperWriting<V, A>,
+    {
+        out.graft_children(z, range);
+    }
+
+    #[inline]
+    fn on_right_only<Z, Out, A>(z: &mut Z, range: ByteMask, out: &mut Out)
+    where
+        A: Allocator,
+        Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Out: ZipperWriting<V, A>,
+    {
+    }
+}
+
+impl<V: DistributiveLattice + Clone> ValuePolicy<V> for Subtract {
+    fn combine(l: Option<&V>, r: Option<&V>) -> Option<V> {
+        l.and_then(|lv| {
+            if let Some(rv) = r {
+                match lv.psubtract(rv) {
+                    AlgebraicResult::None => None,
+                    AlgebraicResult::Identity(mask) => {
+                        if mask & SELF_IDENT != 0 {
+                            Some(lv.clone())
+                        } else {
+                            None
+                        }
+                    }
+                    AlgebraicResult::Element(v) => Some(v),
+                }
+            } else {
+                // lhs-only → keep
+                Some(lv.clone())
+            }
+        })
+    }
+}
 #[cfg(test)]
 mod tests {
     use crate::{

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -142,6 +142,25 @@ where
     zipper_merge::<Join, V, ZL, ZR, Out, A>(lhs, rhs, out);
 }
 
+/// Performs an ordered join (least upper bound) of three radix-256 tries using zipper traversal.
+/// That is, it performs: (`lhs` ⊔ `mid`) ⊔ `rhs`, where `⊔` = [`zipper_join`]
+///
+/// # See also
+///
+/// [`zipper_join`]
+///
+pub fn zipper_join3<V, ZL, ZM, ZR, Out, A>(lhs: &mut ZL, mid: &mut ZM, rhs: &mut ZR, out: &mut Out)
+where
+    V: Lattice + Clone + Send + Sync,
+    A: Allocator,
+    ZL: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    ZM: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    ZR: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    Out: ZipperWriting<V, A>,
+{
+    zipper_merge3::<Join, V, ZL, ZM, ZR, Out, A>(lhs, mid, rhs, out);
+}
+
 /// Performs an ordered meet (greatest lower bound) of two radix-256 tries using zipper traversal.
 ///
 /// This function intersects two tries by simultaneously traversing them in lexicographic order,
@@ -191,6 +210,25 @@ where
     Out: ZipperWriting<V, A>,
 {
     zipper_merge::<Meet, V, ZL, ZR, Out, A>(lhs, rhs, out);
+}
+
+/// Performs an ordered meet (greater lower bound) of three radix-256 tries using zipper traversal.
+/// That is, it performs: (`lhs` ⊓ `mid`) ⊓ `rhs`, where `⊓` = [`zipper_meet`]
+///
+/// # See also
+///
+/// [`zipper_meet`]
+///
+pub fn zipper_meet3<V, ZL, ZM, ZR, Out, A>(lhs: &mut ZL, mid: &mut ZM, rhs: &mut ZR, out: &mut Out)
+where
+    V: Lattice + Clone + Send + Sync,
+    A: Allocator,
+    ZL: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    ZM: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    ZR: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    Out: ZipperWriting<V, A>,
+{
+    zipper_merge3::<Meet, V, ZL, ZM, ZR, Out, A>(lhs, mid, rhs, out);
 }
 
 /// Performs an ordered subtraction (set difference, `lhs \ rhs`) of two radix-256 tries
@@ -248,6 +286,29 @@ where
     Out: ZipperWriting<V, A>,
 {
     zipper_merge::<Subtract, V, ZL, ZR, Out, A>(lhs, rhs, out);
+}
+
+/// Performs an ordered subtraction (set difference of three radix-256 tries using zipper traversal.
+/// That is, it performs: (`lhs` \ `mid`) \ `rhs`, where `\` = [`zipper_subtract`]
+///
+/// # See also
+///
+/// [`zipper_subtract`]
+///
+pub fn zipper_subtract3<V, ZL, ZM, ZR, Out, A>(
+    lhs: &mut ZL,
+    mid: &mut ZM,
+    rhs: &mut ZR,
+    out: &mut Out,
+) where
+    V: DistributiveLattice + Clone + Send + Sync,
+    A: Allocator,
+    ZL: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    ZM: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    ZR: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    Out: ZipperWriting<V, A>,
+{
+    zipper_merge3::<Subtract, V, ZL, ZM, ZR, Out, A>(lhs, mid, rhs, out);
 }
 
 trait MergePolicy<V: Clone + Send + Sync> {
@@ -405,7 +466,7 @@ where
     const MR: u8 = M | R;
     const LMR: u8 = L | M | R;
 
-    fn descend2<P, V, ZL, ZR, Out, A>(b: u8, lhs: &mut ZL, rhs: &mut ZR, mask: u8, out: &mut Out)
+    fn descend2<P, V, ZL, ZR, Out, A>(b: u8, lhs: &mut ZL, rhs: &mut ZR, out: &mut Out)
     where
         V: Clone + Send + Sync,
         P: MergePolicy<V> + ValuePolicy<V>,
@@ -414,9 +475,6 @@ where
         ZR: ZipperInfallibleSubtries<V, A> + ZipperMoving,
         Out: ZipperWriting<V, A>,
     {
-        if !P::descend_on_some_equal(mask as u64) {
-            return;
-        }
         out.descend_to_byte(b);
         lhs.descend_to_byte(b);
         rhs.descend_to_byte(b);
@@ -478,32 +536,57 @@ where
                 }
 
                 cmp_swap(&mut b, &mut c);
-                let range = if let Some(next) = b {
-                    ByteMask::from_range(min..next)
-                } else {
-                    ByteMask::from_range(min..)
-                };
 
                 match frontier {
                     // single → graft
+                    L if b.is_some() => {
+                        let next = b.unwrap();
+                        P::on_single(lhs, L as u64, ByteMask::from_range(min..next), out);
+                        lhs_idx = lhs_mask.index_of(next);
+                    }
                     L => {
-                        P::on_single(lhs, L as u64, range, out);
+                        P::on_single(lhs, L as u64, ByteMask::from_range(min..), out);
+                        break 'merge_level;
+                    }
+                    M if b.is_some() => {
+                        let next = b.unwrap();
+                        P::on_single(mid, M as u64, ByteMask::from_range(min..next), out);
+                        mid_idx = mid_mask.index_of(next);
                     }
                     M => {
-                        P::on_single(mid, M as u64, range, out);
+                        P::on_single(mid, M as u64, ByteMask::from_range(min..), out);
+                        break 'merge_level;
+                    }
+                    R if b.is_some() => {
+                        let next = b.unwrap();
+                        P::on_single(rhs, R as u64, ByteMask::from_range(min..next), out);
+                        rhs_idx = rhs_mask.index_of(next);
                     }
                     R => {
-                        P::on_single(rhs, R as u64, range, out);
+                        P::on_single(rhs, R as u64, ByteMask::from_range(min..), out);
+                        break 'merge_level;
                     }
                     // two-way → descend 2
                     LM => {
-                        descend2::<P, V, ZL, ZM, Out, A>(min, lhs, mid, LM, out);
+                        if P::descend_on_some_equal(LM as u64) {
+                            descend2::<P, V, ZL, ZM, Out, A>(min, lhs, mid, out);
+                        }
+                        lhs_idx += 1;
+                        mid_idx += 1;
                     }
                     MR => {
-                        descend2::<P, V, ZM, ZR, Out, A>(min, mid, rhs, MR, out);
+                        if P::descend_on_some_equal(MR as u64) {
+                            descend2::<P, V, ZM, ZR, Out, A>(min, mid, rhs, out);
+                        }
+                        mid_idx += 1;
+                        rhs_idx += 1;
                     }
                     LR => {
-                        descend2::<P, V, ZL, ZR, Out, A>(min, lhs, rhs, LR, out);
+                        if P::descend_on_some_equal(LR as u64) {
+                            descend2::<P, V, ZL, ZR, Out, A>(min, lhs, rhs, out);
+                        }
+                        lhs_idx += 1;
+                        rhs_idx += 1;
                     }
                     // full 3-way
                     LMR => {
@@ -529,20 +612,6 @@ where
                         continue 'merge_level;
                     }
                     _ => unreachable!(),
-                }
-
-                if let Some(next) = b {
-                    if (frontier & L != 0) {
-                        lhs_idx = lhs_mask.index_of(next);
-                    }
-                    if (frontier & M != 0) {
-                        mid_idx = mid_mask.index_of(next);
-                    }
-                    if (frontier & R != 0) {
-                        rhs_idx = rhs_mask.index_of(next);
-                    }
-                } else {
-                    break 'merge_level;
                 }
             } else {
                 break 'merge_level;
@@ -758,13 +827,22 @@ mod tests {
     };
 
     type Paths = &'static [(&'static [u8], u64)];
-    type Test = (Paths, Paths);
+    type BinaryTest = (Paths, Paths);
+    type TernaryTest = (Paths, Paths, Paths);
 
-    fn mk_test(test: &Test) -> (PathMap<u64>, PathMap<u64>) {
+    fn mk_binary_test(test: &BinaryTest) -> (PathMap<u64>, PathMap<u64>) {
         (PathMap::from_iter(test.0), PathMap::from_iter(test.1))
     }
 
-    fn check<
+    fn mk_ternary_test(test: &TernaryTest) -> (PathMap<u64>, PathMap<u64>, PathMap<u64>) {
+        (
+            PathMap::from_iter(test.0),
+            PathMap::from_iter(test.1),
+            PathMap::from_iter(test.2),
+        )
+    }
+
+    fn check2<
         'x,
         T: IntoIterator<Item = &'x (&'x [u8], u64)>,
         F: for<'a> FnOnce(
@@ -773,11 +851,11 @@ mod tests {
             &mut WriteZipperUntracked<'a, 'x, u64>,
         ),
     >(
-        test: &Test,
+        test: &BinaryTest,
         expected: T,
         op: F,
     ) {
-        let (left, right) = mk_test(test);
+        let (left, right) = mk_binary_test(test);
 
         let mut result = PathMap::new();
 
@@ -787,6 +865,41 @@ mod tests {
 
         op(&mut lhs, &mut rhs, &mut out);
 
+        assert_trie(expected, result);
+    }
+
+    fn check3<
+        'x,
+        T: IntoIterator<Item = &'x (&'x [u8], u64)>,
+        F: for<'a> FnOnce(
+            &mut ReadZipperUntracked<'a, 'x, u64>,
+            &mut ReadZipperUntracked<'a, 'x, u64>,
+            &mut ReadZipperUntracked<'a, 'x, u64>,
+            &mut WriteZipperUntracked<'a, 'x, u64>,
+        ),
+    >(
+        test: &TernaryTest,
+        expected: T,
+        op: F,
+    ) {
+        let (left, middle, right) = mk_ternary_test(test);
+
+        let mut result = PathMap::new();
+
+        let mut lhs = left.read_zipper();
+        let mut mid = middle.read_zipper();
+        let mut rhs = right.read_zipper();
+        let mut out = result.write_zipper();
+
+        op(&mut lhs, &mut mid, &mut rhs, &mut out);
+
+        assert_trie(expected, result);
+    }
+
+    fn assert_trie<'a, T: IntoIterator<Item = &'a (&'a [u8], u64)>>(
+        expected: T,
+        result: PathMap<u64>,
+    ) {
         let mut result_copy = result.clone();
 
         for (expected_path, expected_val) in expected {
@@ -810,7 +923,7 @@ mod tests {
         );
     }
 
-    const DISJOINT_PATHS: Test = (
+    const DISJOINT_PATHS: BinaryTest = (
         &[
             (&[0x00], 0),
             (&[0x00, 0x00], 1),
@@ -825,17 +938,50 @@ mod tests {
         ],
     );
 
-    const PATHS_WITH_SHARED_PREFIX: Test = (
+    const DISJOINT_PATHS_3: TernaryTest = (
+        &[
+            (&[0x00], 0),
+            (&[0x00, 0x00], 1),
+            (&[0x00, 0x00, 0x00], 2),
+            (&[0x00, 0x00, 0x00, 0x00], 3),
+        ],
+        &[
+            (&[0xF0], 0),
+            (&[0xF0, 0x00], 1),
+            (&[0xF0, 0x00, 0x00], 2),
+            (&[0xF0, 0x00, 0x00, 0x00], 3),
+        ],
+        &[
+            (&[0xFF], 0),
+            (&[0xFF, 0x00], 1),
+            (&[0xFF, 0x00, 0x00], 2),
+            (&[0xFF, 0x00, 0x00, 0x00], 3),
+        ],
+    );
+
+    const PATHS_WITH_SHARED_PREFIX: BinaryTest = (
         &[(b"aaaaa0", 0), (b"bbbbbbbb0", 1)],
         &[(b"aaaaa1", 0), (b"bbbbb1", 1), (b"bbbbbbbb1", 2)],
     );
 
-    const INTERLEAVING_PATHS: Test = (
+    const PATHS_WITH_SHARED_PREFIX_3: TernaryTest = (
+        &[(b"aaaaa0", 0), (b"bbbbbbbb0", 1)],
+        &[(b"aaaaa1", 0), (b"bbbbb1", 1), (b"bbbbbbbb1", 2)],
+        &[(b"aaaaa2", 0), (b"bbbbb2", 1), (b"bbbbbbbb2", 2)],
+    );
+
+    const INTERLEAVING_PATHS: BinaryTest = (
         &[(&[0], 0), (&[2], 1), (&[4], 2), (&[6], 3)],
         &[(&[1], 0), (&[3], 1), (&[5], 2), (&[7], 3)],
     );
 
-    const ONE_SIDED_PATHS: Test = (
+    const INTERLEAVING_PATHS_3: TernaryTest = (
+        &[(&[0], 0), (&[3], 1), (&[6], 2), (&[9], 3)],
+        &[(&[1], 0), (&[4], 1), (&[7], 2), (&[10], 3)],
+        &[(&[2], 0), (&[5], 1), (&[8], 2), (&[11], 3)],
+    );
+
+    const ONE_SIDED_PATHS: BinaryTest = (
         &[
             (&[0x00], 0),
             (&[0x00, 0x01], 1),
@@ -855,7 +1001,28 @@ mod tests {
         ],
     );
 
-    const ALMOST_IDENTICAL_PATHS: Test = (
+    const ONE_SIDED_PATHS_3: TernaryTest = (
+        &[
+            (&[0x00], 0),
+            (&[0x00, 0x01], 1),
+            (&[0x00, 0x01, 0x02], 2),
+            (&[0x00, 0x01, 0x02, 0x03], 3),
+            (&[0x01], 4),
+            (&[0x01, 0x02], 5),
+            (&[0x01, 0x02, 0x03], 6),
+            (&[0x01, 0x02, 0x03, 0x04], 7),
+            (&[0x01, 0x02, 0x03, 0x04, 0x05], 8),
+            (&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06], 9),
+        ],
+        &[
+            (&[0x00], 0),
+            (&[0x00, 0x01, 0x02, 0x03], 1),
+            (&[0x01, 0x02, 0x03, 0x04, 0x05], 2),
+        ],
+        &[(&[0x00], 0), (&[0x00, 0x01, 0x02], 1)],
+    );
+
+    const ALMOST_IDENTICAL_PATHS: BinaryTest = (
         &[
             (b"abcdefg", 0),
             (b"hijklmnop", 1),
@@ -879,11 +1046,48 @@ mod tests {
         ],
     );
 
-    const LHS_EMPTY: Test = (&[], &[(&[1], 0), (&[2], 1)]);
+    const ALMOST_IDENTICAL_PATHS_3: TernaryTest = (
+        &[
+            (b"abcdefg", 0),
+            (b"hijklmnop", 1),
+            (b"qrstuwvxyz", 2),
+            (b"0", 3),
+            (b"1", 4),
+            (b"2", 5),
+            (b"3", 6),
+            (b"4", 7),
+            (b"5", 8),
+            (b"6789", 9),
+        ],
+        &[
+            (b"abcdefg", 0),
+            (b"qrstuwvxyz", 2),
+            (b"0", 3),
+            (b"1", 4),
+            (b"4", 7),
+            (b"5", 8),
+            (b"6789", 9),
+        ],
+        &[
+            (b"abcdefg", 0),
+            (b"hijklmnop", 1),
+            (b"1", 4),
+            (b"2", 5),
+            (b"3", 6),
+            (b"4", 7),
+            (b"5", 8),
+        ],
+    );
 
-    const RHS_EMPTY: Test = (&[(&[1], 0), (&[2], 1)], &[]);
+    const LHS_EMPTY: BinaryTest = (&[], &[(&[1], 0), (&[2], 1)]);
+    const LHS_EMPTY_3: TernaryTest = (&[], &[(&[1], 0), (&[2], 1)], &[(&[3], 0), (&[4], 1)]);
 
-    const PATHS_WITH_SAME_PREFIX_DIFFERENT_CHILDREN: Test = (
+    const RHS_EMPTY: BinaryTest = (&[(&[1], 0), (&[2], 1)], &[]);
+    const RHS_EMPTY_3: TernaryTest = (&[(&[1], 0), (&[2], 1)], &[(&[3], 0), (&[4], 1)], &[]);
+
+    const MID_EMPTY: TernaryTest = (&[(&[1], 0), (&[2], 1)], &[], &[(&[3], 0), (&[4], 1)]);
+
+    const PATHS_WITH_SAME_PREFIX_DIFFERENT_CHILDREN: BinaryTest = (
         &[
             (&[1, 2, 3], 0),
             (&[1, 2, 3, 4], 1),
@@ -896,7 +1100,25 @@ mod tests {
         ],
     );
 
-    const ZIGZAG_PATHS: Test = (
+    const PATHS_WITH_SAME_PREFIX_DIFFERENT_CHILDREN_3: TernaryTest = (
+        &[
+            (&[1, 2, 3], 0),
+            (&[1, 2, 3, 4], 1),
+            (&[1, 2, 3, 10, 11, 12], 2),
+        ],
+        &[
+            (&[1, 2, 3], 10),
+            (&[1, 2, 3, 5], 11),
+            (&[1, 2, 3, 10, 11, 0], 12),
+        ],
+        &[
+            (&[1, 2, 3], 20),
+            (&[1, 2, 3, 6], 21),
+            (&[1, 2, 3, 10, 11, 1], 22),
+        ],
+    );
+
+    const ZIGZAG_PATHS: BinaryTest = (
         &[
             (&[1, 1], 0),
             (&[2], 1),
@@ -916,16 +1138,50 @@ mod tests {
         ],
     );
 
-    const PATHS_WITH_ROOT_VALS_AND_CHILDREN: Test =
+    const ZIGZAG_PATHS_3: TernaryTest = (
+        &[
+            (&[1, 1], 0),
+            (&[2], 1),
+            (&[2, 1], 2),
+            (&[3], 3),
+            (&[3, 2, 1], 4),
+            (&[4], 4),
+            (&[4, 3, 2, 1], 5),
+        ],
+        &[
+            (&[1], 0),
+            (&[1, 2], 1),
+            (&[2, 1], 2),
+            (&[3], 3),
+            (&[3, 4], 4),
+            (&[4, 3], 5),
+        ],
+        &[
+            (&[1], 0),
+            (&[2], 1),
+            (&[2, 1], 2),
+            (&[3, 2, 1, 0], 3),
+            (&[4, 3, 2, 1, 0], 4),
+            (&[4, 3, 2, 1], 5),
+        ],
+    );
+
+    const PATHS_WITH_ROOT_VALS_AND_CHILDREN: BinaryTest =
         (&[(&[], 1), (&[1], 10)], &[(&[], 2), (&[1], 20)]);
+
+    const PATHS_WITH_ROOT_VALS_AND_CHILDREN_3: TernaryTest = (
+        &[(&[], 1), (&[1], 10)],
+        &[(&[], 2), (&[1], 20)],
+        &[(&[], 3), (&[1], 30)],
+    );
 
     mod join {
         use super::*;
-        use crate::experimental::zipper_algebra::{ZipperAlgebraExt, zipper_join};
+        use crate::experimental::zipper_algebra::{ZipperAlgebraExt, zipper_join, zipper_join3};
 
         #[test]
         fn test_disjoint() {
-            check(
+            check2(
                 &DISJOINT_PATHS,
                 &[DISJOINT_PATHS.0, DISJOINT_PATHS.1].concat(),
                 |lhs, rhs, out| lhs.join(rhs, out),
@@ -933,8 +1189,17 @@ mod tests {
         }
 
         #[test]
+        fn test_disjoint3() {
+            check3(
+                &DISJOINT_PATHS_3,
+                &[DISJOINT_PATHS_3.0, DISJOINT_PATHS_3.1, DISJOINT_PATHS_3.2].concat(),
+                |lhs, mid, rhs, out| zipper_join3(lhs, mid, rhs, out),
+            );
+        }
+
+        #[test]
         fn test_deep_shared_prefix_then_split() {
-            check(
+            check2(
                 &PATHS_WITH_SHARED_PREFIX,
                 &[PATHS_WITH_SHARED_PREFIX.0, PATHS_WITH_SHARED_PREFIX.1].concat(),
                 |lhs, rhs, out| lhs.join(rhs, out),
@@ -942,8 +1207,22 @@ mod tests {
         }
 
         #[test]
+        fn test_deep_shared_prefix_then_split3() {
+            check3(
+                &PATHS_WITH_SHARED_PREFIX_3,
+                &[
+                    PATHS_WITH_SHARED_PREFIX_3.0,
+                    PATHS_WITH_SHARED_PREFIX_3.1,
+                    PATHS_WITH_SHARED_PREFIX_3.2,
+                ]
+                .concat(),
+                |lhs, mid, rhs, out| zipper_join3(lhs, mid, rhs, out),
+            );
+        }
+
+        #[test]
         fn test_interleaving_paths() {
-            check(
+            check2(
                 &INTERLEAVING_PATHS,
                 &[INTERLEAVING_PATHS.0, INTERLEAVING_PATHS.1].concat(),
                 |lhs, rhs, out| lhs.join(rhs, out),
@@ -951,15 +1230,38 @@ mod tests {
         }
 
         #[test]
+        fn test_interleaving_paths3() {
+            check3(
+                &INTERLEAVING_PATHS_3,
+                &[
+                    INTERLEAVING_PATHS_3.0,
+                    INTERLEAVING_PATHS_3.1,
+                    INTERLEAVING_PATHS_3.2,
+                ]
+                .concat(),
+                |lhs, mid, rhs, out| zipper_join3(lhs, mid, rhs, out),
+            );
+        }
+
+        #[test]
         fn test_one_side_empty_at_many_levels() {
-            check(&ONE_SIDED_PATHS, ONE_SIDED_PATHS.0, |lhs, rhs, out| {
+            check2(&ONE_SIDED_PATHS, ONE_SIDED_PATHS.0, |lhs, rhs, out| {
                 lhs.join(rhs, out)
             });
         }
 
         #[test]
+        fn test_one_side_empty_at_many_levels3() {
+            check3(
+                &ONE_SIDED_PATHS_3,
+                ONE_SIDED_PATHS_3.0,
+                |lhs, mid, rhs, out| zipper_join3(lhs, mid, rhs, out),
+            );
+        }
+
+        #[test]
         fn test_almost_identical_paths() {
-            check(
+            check2(
                 &ALMOST_IDENTICAL_PATHS,
                 ALMOST_IDENTICAL_PATHS.0,
                 |lhs, rhs, out| lhs.join(rhs, out),
@@ -967,9 +1269,37 @@ mod tests {
         }
 
         #[test]
+        fn test_almost_identical_paths3() {
+            check3(
+                &ALMOST_IDENTICAL_PATHS_3,
+                ALMOST_IDENTICAL_PATHS_3.0,
+                |lhs, mid, rhs, out| zipper_join3(lhs, mid, rhs, out),
+            );
+        }
+
+        #[test]
         fn test_one_side_empty() {
-            check(&LHS_EMPTY, LHS_EMPTY.1, |lhs, rhs, out| lhs.join(rhs, out));
-            check(&RHS_EMPTY, RHS_EMPTY.0, |lhs, rhs, out| lhs.join(rhs, out));
+            check2(&LHS_EMPTY, LHS_EMPTY.1, |lhs, rhs, out| lhs.join(rhs, out));
+            check2(&RHS_EMPTY, RHS_EMPTY.0, |lhs, rhs, out| lhs.join(rhs, out));
+        }
+
+        #[test]
+        fn test_one_side_empty3() {
+            check3(
+                &LHS_EMPTY_3,
+                &[LHS_EMPTY_3.1, LHS_EMPTY_3.2].concat(),
+                |lhs, mid, rhs, out| zipper_join3(lhs, mid, rhs, out),
+            );
+            check3(
+                &MID_EMPTY,
+                &[MID_EMPTY.0, MID_EMPTY.2].concat(),
+                |lhs, mid, rhs, out| zipper_join3(lhs, mid, rhs, out),
+            );
+            check3(
+                &RHS_EMPTY_3,
+                &[RHS_EMPTY_3.0, RHS_EMPTY_3.1].concat(),
+                |lhs, mid, rhs, out| zipper_join3(lhs, mid, rhs, out),
+            );
         }
 
         #[test]
@@ -981,7 +1311,7 @@ mod tests {
                 (&[1, 2, 3, 10, 11, 0], 12),
                 (&[1, 2, 3, 10, 11, 12], 2),
             ];
-            check(
+            check2(
                 &PATHS_WITH_SAME_PREFIX_DIFFERENT_CHILDREN,
                 expected,
                 |lhs, rhs, out| lhs.join(rhs, out),
@@ -989,8 +1319,26 @@ mod tests {
         }
 
         #[test]
+        fn test_exact_overlap_divergent_subtries3() {
+            let expected: Paths = &[
+                (&[1, 2, 3], 0),
+                (&[1, 2, 3, 4], 1),
+                (&[1, 2, 3, 5], 11),
+                (&[1, 2, 3, 6], 21),
+                (&[1, 2, 3, 10, 11, 0], 12),
+                (&[1, 2, 3, 10, 11, 1], 22),
+                (&[1, 2, 3, 10, 11, 12], 2),
+            ];
+            check3(
+                &PATHS_WITH_SAME_PREFIX_DIFFERENT_CHILDREN_3,
+                expected,
+                |lhs, mid, rhs, out| zipper_join3(lhs, mid, rhs, out),
+            );
+        }
+
+        #[test]
         fn test_zigzag() {
-            check(
+            check2(
                 &ZIGZAG_PATHS,
                 &[ZIGZAG_PATHS.0, ZIGZAG_PATHS.1].concat(),
                 |lhs, rhs, out| lhs.join(rhs, out),
@@ -998,37 +1346,76 @@ mod tests {
         }
 
         #[test]
+        fn test_zigzag3() {
+            check3(
+                &ZIGZAG_PATHS_3,
+                &[ZIGZAG_PATHS.0, ZIGZAG_PATHS.1, ZIGZAG_PATHS_3.2].concat(),
+                |lhs, mid, rhs, out| zipper_join3(lhs, mid, rhs, out),
+            );
+        }
+
+        #[test]
         fn test_root_values() {
-            check(
+            check2(
                 &PATHS_WITH_ROOT_VALS_AND_CHILDREN,
                 PATHS_WITH_ROOT_VALS_AND_CHILDREN.0,
                 |lhs, rhs, out| lhs.join(rhs, out),
+            );
+        }
+
+        #[test]
+        fn test_root_values3() {
+            check3(
+                &PATHS_WITH_ROOT_VALS_AND_CHILDREN_3,
+                PATHS_WITH_ROOT_VALS_AND_CHILDREN_3.0,
+                |lhs, mid, rhs, out| zipper_join3(lhs, mid, rhs, out),
             );
         }
     }
 
     mod meet {
         use super::*;
-        use crate::experimental::zipper_algebra::{ZipperAlgebraExt, zipper_meet};
+        use crate::experimental::zipper_algebra::{ZipperAlgebraExt, zipper_meet, zipper_meet3};
 
         #[test]
         fn test_disjoint() {
-            check(&DISJOINT_PATHS, [], |lhs, rhs, out| {
+            check2(&DISJOINT_PATHS, [], |lhs, rhs, out| {
                 lhs.meet(rhs, out);
+            });
+        }
+
+        #[test]
+        fn test_disjoint3() {
+            check3(&DISJOINT_PATHS_3, [], |lhs, mid, rhs, out| {
+                zipper_meet3(lhs, mid, rhs, out);
             });
         }
 
         #[test]
         fn test_deep_shared_prefix_then_split() {
-            check(&PATHS_WITH_SHARED_PREFIX, [], |lhs, rhs, out| {
+            check2(&PATHS_WITH_SHARED_PREFIX, [], |lhs, rhs, out| {
                 lhs.meet(rhs, out);
             });
         }
 
         #[test]
+        fn test_deep_shared_prefix_then_split3() {
+            check3(&PATHS_WITH_SHARED_PREFIX_3, [], |lhs, mid, rhs, out| {
+                zipper_meet3(lhs, mid, rhs, out);
+            });
+        }
+
+        #[test]
         fn test_interleaving_paths() {
-            check(&INTERLEAVING_PATHS, [], |lhs, rhs, out| {
+            check2(&INTERLEAVING_PATHS, [], |lhs, rhs, out| {
                 lhs.meet(rhs, out);
+            });
+        }
+
+        #[test]
+        fn test_interleaving_paths3() {
+            check3(&INTERLEAVING_PATHS_3, [], |lhs, mid, rhs, out| {
+                zipper_meet3(lhs, mid, rhs, out);
             });
         }
 
@@ -1039,14 +1426,22 @@ mod tests {
                 (&[0x00, 0x01, 0x02, 0x03], 3),
                 (&[0x01, 0x02, 0x03, 0x04, 0x05], 8),
             ];
-            check(&ONE_SIDED_PATHS, expected, |lhs, rhs, out| {
+            check2(&ONE_SIDED_PATHS, expected, |lhs, rhs, out| {
                 lhs.meet(rhs, out);
             });
         }
 
         #[test]
+        fn test_one_side_empty_at_many_levels3() {
+            let expected: Paths = &[(&[0x00], 0)];
+            check3(&ONE_SIDED_PATHS_3, expected, |lhs, mid, rhs, out| {
+                zipper_meet3(lhs, mid, rhs, out);
+            });
+        }
+
+        #[test]
         fn test_almost_identical_paths() {
-            check(
+            check2(
                 &ALMOST_IDENTICAL_PATHS,
                 ALMOST_IDENTICAL_PATHS.1,
                 |lhs, rhs, out| lhs.meet(rhs, out),
@@ -1054,15 +1449,36 @@ mod tests {
         }
 
         #[test]
+        fn test_almost_identical_paths3() {
+            let expected: Paths = &[(b"abcdefg", 0), (b"1", 4), (b"4", 7), (b"5", 8)];
+            check3(&ALMOST_IDENTICAL_PATHS_3, expected, |lhs, mid, rhs, out| {
+                zipper_meet3(lhs, mid, rhs, out);
+            });
+        }
+
+        #[test]
         fn test_one_side_empty() {
-            check(&LHS_EMPTY, [], |lhs, rhs, out| lhs.meet(rhs, out));
-            check(&RHS_EMPTY, [], |lhs, rhs, out| lhs.meet(rhs, out));
+            check2(&LHS_EMPTY, [], |lhs, rhs, out| lhs.meet(rhs, out));
+            check2(&RHS_EMPTY, [], |lhs, rhs, out| lhs.meet(rhs, out));
+        }
+
+        #[test]
+        fn test_one_side_empty3() {
+            check3(&LHS_EMPTY_3, [], |lhs, mid, rhs, out| {
+                zipper_meet3(lhs, mid, rhs, out)
+            });
+            check3(&MID_EMPTY, [], |lhs, mid, rhs, out| {
+                zipper_meet3(lhs, mid, rhs, out)
+            });
+            check3(&RHS_EMPTY_3, [], |lhs, mid, rhs, out| {
+                zipper_meet3(lhs, mid, rhs, out)
+            });
         }
 
         #[test]
         fn test_exact_overlap_divergent_subtries() {
             let expected: Paths = &[(&[1, 2, 3], 0)];
-            check(
+            check2(
                 &PATHS_WITH_SAME_PREFIX_DIFFERENT_CHILDREN,
                 expected,
                 |lhs, rhs, out| lhs.meet(rhs, out),
@@ -1070,37 +1486,77 @@ mod tests {
         }
 
         #[test]
+        fn test_exact_overlap_divergent_subtries3() {
+            let expected: Paths = &[(&[1, 2, 3], 0)];
+            check3(
+                &PATHS_WITH_SAME_PREFIX_DIFFERENT_CHILDREN_3,
+                expected,
+                |lhs, mid, rhs, out| zipper_meet3(lhs, mid, rhs, out),
+            );
+        }
+
+        #[test]
         fn test_zigzag() {
             let expected: Paths = &[(&[2, 1], 2), (&[3], 3)];
-            check(&ZIGZAG_PATHS, expected, |lhs, rhs, out| {
+            check2(&ZIGZAG_PATHS, expected, |lhs, rhs, out| {
                 lhs.meet(rhs, out);
             });
         }
 
         #[test]
+        fn test_zigzag3() {
+            let expected: Paths = &[(&[2, 1], 2)];
+            check3(&ZIGZAG_PATHS_3, expected, |lhs, mid, rhs, out| {
+                zipper_meet3(lhs, mid, rhs, out)
+            });
+        }
+
+        #[test]
         fn test_root_values() {
-            check(
+            check2(
                 &PATHS_WITH_ROOT_VALS_AND_CHILDREN,
                 PATHS_WITH_ROOT_VALS_AND_CHILDREN.0,
                 |lhs, rhs, out| lhs.meet(rhs, out),
+            );
+        }
+
+        #[test]
+        fn test_root_values3() {
+            check3(
+                &PATHS_WITH_ROOT_VALS_AND_CHILDREN_3,
+                PATHS_WITH_ROOT_VALS_AND_CHILDREN.0,
+                |lhs, mid, rhs, out| zipper_meet3(lhs, mid, rhs, out),
             );
         }
     }
 
     mod subtract {
         use super::*;
-        use crate::experimental::zipper_algebra::{ZipperAlgebraExt, zipper_subtract};
+        use crate::experimental::zipper_algebra::{
+            ZipperAlgebraExt, zipper_subtract, zipper_subtract3,
+        };
 
         #[test]
         fn test_disjoint() {
-            check(&DISJOINT_PATHS, DISJOINT_PATHS.0, |lhs, rhs, out| {
+            check2(&DISJOINT_PATHS, DISJOINT_PATHS.0, |lhs, rhs, out| {
                 lhs.subtract(rhs, out);
             });
         }
 
         #[test]
+        fn test_disjoint3() {
+            check3(
+                &DISJOINT_PATHS_3,
+                DISJOINT_PATHS_3.0,
+                |lhs, mid, rhs, out| {
+                    zipper_subtract3(lhs, mid, rhs, out);
+                },
+            );
+        }
+
+        #[test]
         fn test_deep_shared_prefix_then_split() {
-            check(
+            check2(
                 &PATHS_WITH_SHARED_PREFIX,
                 PATHS_WITH_SHARED_PREFIX.0,
                 |lhs, rhs, out| lhs.subtract(rhs, out),
@@ -1108,11 +1564,33 @@ mod tests {
         }
 
         #[test]
+        fn test_deep_shared_prefix_then_split3() {
+            check3(
+                &PATHS_WITH_SHARED_PREFIX_3,
+                PATHS_WITH_SHARED_PREFIX_3.0,
+                |lhs, mid, rhs, out| {
+                    zipper_subtract3(lhs, mid, rhs, out);
+                },
+            );
+        }
+
+        #[test]
         fn test_interleaving_paths() {
-            check(
+            check2(
                 &INTERLEAVING_PATHS,
                 INTERLEAVING_PATHS.0,
                 |lhs, rhs, out| lhs.subtract(rhs, out),
+            );
+        }
+
+        #[test]
+        fn test_interleaving_paths3() {
+            check3(
+                &INTERLEAVING_PATHS_3,
+                INTERLEAVING_PATHS_3.0,
+                |lhs, mid, rhs, out| {
+                    zipper_subtract3(lhs, mid, rhs, out);
+                },
             );
         }
 
@@ -1129,33 +1607,82 @@ mod tests {
                 (&[0x01, 0x02, 0x03, 0x04, 0x05], 8),
                 (&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06], 9),
             ];
-            check(&ONE_SIDED_PATHS, expected, |lhs, rhs, out| {
+            check2(&ONE_SIDED_PATHS, expected, |lhs, rhs, out| {
                 lhs.subtract(rhs, out)
+            });
+        }
+
+        #[test]
+        fn test_one_side_empty_at_many_levels3() {
+            let expected: Paths = &[
+                (&[0x00, 0x01], 1),
+                (&[0x00, 0x01, 0x02], 2),
+                (&[0x00, 0x01, 0x02, 0x03], 3),
+                (&[0x01], 4),
+                (&[0x01, 0x02], 5),
+                (&[0x01, 0x02, 0x03], 6),
+                (&[0x01, 0x02, 0x03, 0x04], 7),
+                (&[0x01, 0x02, 0x03, 0x04, 0x05], 8),
+                (&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06], 9),
+            ];
+            check3(&ONE_SIDED_PATHS_3, expected, |lhs, mid, rhs, out| {
+                zipper_subtract3(lhs, mid, rhs, out);
             });
         }
 
         #[test]
         fn test_almost_identical_paths() {
             let expected: Paths = &[(b"hijklmnop", 1), (b"2", 5), (b"3", 6)];
-            check(&ALMOST_IDENTICAL_PATHS, expected, |lhs, rhs, out| {
+            check2(&ALMOST_IDENTICAL_PATHS, expected, |lhs, rhs, out| {
                 lhs.subtract(rhs, out)
+            });
+        }
+
+        #[test]
+        fn test_almost_identical_paths3() {
+            check3(&ALMOST_IDENTICAL_PATHS_3, [], |lhs, mid, rhs, out| {
+                zipper_subtract3(lhs, mid, rhs, out);
             });
         }
 
         #[test]
         fn test_one_side_empty() {
-            check(&LHS_EMPTY, [], |lhs, rhs, out| lhs.subtract(rhs, out));
-            check(&RHS_EMPTY, RHS_EMPTY.0, |lhs, rhs, out| {
+            check2(&LHS_EMPTY, [], |lhs, rhs, out| lhs.subtract(rhs, out));
+            check2(&RHS_EMPTY, RHS_EMPTY.0, |lhs, rhs, out| {
                 lhs.subtract(rhs, out)
             });
         }
 
         #[test]
+        fn test_one_side_empty3() {
+            check3(&LHS_EMPTY_3, [], |lhs, mid, rhs, out| {
+                zipper_subtract3(lhs, mid, rhs, out);
+            });
+            check3(&MID_EMPTY, MID_EMPTY.0, |lhs, mid, rhs, out| {
+                zipper_subtract3(lhs, mid, rhs, out);
+            });
+            check3(&RHS_EMPTY_3, RHS_EMPTY_3.0, |lhs, mid, rhs, out| {
+                zipper_subtract3(lhs, mid, rhs, out);
+            });
+        }
+
+        #[test]
         fn test_exact_overlap_divergent_subtries() {
-            check(
+            check2(
                 &PATHS_WITH_SAME_PREFIX_DIFFERENT_CHILDREN,
                 PATHS_WITH_SAME_PREFIX_DIFFERENT_CHILDREN.0,
                 |lhs, rhs, out| lhs.subtract(rhs, out),
+            );
+        }
+
+        #[test]
+        fn test_exact_overlap_divergent_subtries3() {
+            check3(
+                &PATHS_WITH_SAME_PREFIX_DIFFERENT_CHILDREN_3,
+                PATHS_WITH_SAME_PREFIX_DIFFERENT_CHILDREN_3.0,
+                |lhs, mid, rhs, out| {
+                    zipper_subtract3(lhs, mid, rhs, out);
+                },
             );
         }
 
@@ -1168,17 +1695,36 @@ mod tests {
                 (&[4], 4),
                 (&[4, 3, 2, 1], 5),
             ];
-            check(&ZIGZAG_PATHS, expected, |lhs, rhs, out| {
+            check2(&ZIGZAG_PATHS, expected, |lhs, rhs, out| {
                 lhs.subtract(rhs, out)
             });
         }
 
         #[test]
+        fn test_zigzag3() {
+            let expected: Paths = &[(&[1, 1], 0), (&[3, 2, 1], 4), (&[4], 4)];
+            check3(&ZIGZAG_PATHS_3, expected, |lhs, mid, rhs, out| {
+                zipper_subtract3(lhs, mid, rhs, out);
+            });
+        }
+
+        #[test]
         fn test_root_values() {
-            check(
+            check2(
                 &PATHS_WITH_ROOT_VALS_AND_CHILDREN,
                 PATHS_WITH_ROOT_VALS_AND_CHILDREN.0,
                 |lhs, rhs, out| lhs.subtract(rhs, out),
+            );
+        }
+
+        #[test]
+        fn test_root_values3() {
+            check3(
+                &PATHS_WITH_ROOT_VALS_AND_CHILDREN_3,
+                PATHS_WITH_ROOT_VALS_AND_CHILDREN_3.0,
+                |lhs, mid, rhs, out| {
+                    zipper_subtract3(lhs, mid, rhs, out);
+                },
             );
         }
     }

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -710,51 +710,40 @@ impl<V: Clone + Send + Sync> MergePolicy<V> for Meet {
 
 impl<V: Lattice + Clone> ValuePolicy<V> for Meet {
     fn combine(l: Option<&V>, r: Option<&V>) -> Option<V> {
-        l.and_then(|lv| {
-            r.and_then(|rv| match lv.pmeet(rv) {
-                AlgebraicResult::None => None,
-                AlgebraicResult::Identity(mask) => {
-                    if mask & SELF_IDENT != 0 {
-                        Some(lv.clone())
-                    } else {
-                        Some(rv.clone())
-                    }
-                }
-                AlgebraicResult::Element(v) => Some(v),
-            })
-        })
+        l.and_then(|lv| r.and_then(|rv| meet_refs(lv, rv)))
     }
 
     fn combine3(l: Option<&V>, m: Option<&V>, r: Option<&V>) -> Option<V> {
-        l.and_then(|x| {
-            m.and_then(|y| {
-                r.and_then(|z| {
-                    let xy = match x.pmeet(y) {
-                        AlgebraicResult::None => return None,
-                        AlgebraicResult::Identity(mask) => {
-                            if mask & SELF_IDENT != 0 {
-                                x.clone()
-                            } else {
-                                y.clone()
-                            }
-                        }
-                        AlgebraicResult::Element(v) => v,
-                    };
+        l.and_then(|x| m.and_then(|y| r.and_then(|z| meet_acc(meet_refs(x, y)?, z))))
+    }
+}
 
-                    match xy.pmeet(z) {
-                        AlgebraicResult::None => None,
-                        AlgebraicResult::Identity(mask) => {
-                            if mask & SELF_IDENT != 0 {
-                                Some(xy)
-                            } else {
-                                Some(z.clone())
-                            }
-                        }
-                        AlgebraicResult::Element(v) => Some(v),
-                    }
-                })
-            })
-        })
+#[inline]
+fn meet_refs<V: Lattice + Clone>(a: &V, b: &V) -> Option<V> {
+    match a.pmeet(b) {
+        AlgebraicResult::None => None,
+        AlgebraicResult::Identity(mask) => {
+            if mask & SELF_IDENT != 0 {
+                Some(a.clone())
+            } else {
+                Some(b.clone())
+            }
+        }
+        AlgebraicResult::Element(v) => Some(v),
+    }
+}
+#[inline]
+fn meet_acc<V: Lattice + Clone>(a: V, b: &V) -> Option<V> {
+    match a.pmeet(b) {
+        AlgebraicResult::None => None,
+        AlgebraicResult::Identity(mask) => {
+            if mask & SELF_IDENT != 0 {
+                Some(a)
+            } else {
+                Some(b.clone())
+            }
+        }
+        AlgebraicResult::Element(v) => Some(v),
     }
 }
 


### PR DESCRIPTION
This PR introduces a generic three-way zipper merge:

```rust
zipper_merge3::<P>(lhs, mid, rhs, out)
```

It also introduces policy-driven semantics: fully generic over `MergePolicy` (structure) and `ValuePolicy` (values); supports `Join`, `Meet`, and `Subtract` with no special-casing in the engine.

In short: this lifts the zipper merge from binary to ternary without sacrificing performance, while keeping algebraic semantics cleanly encapsulated in policies.

## Note to the reviewers
Please review #33 first, in case you haven't done it yet