### PR TITLE
Add monomorphized N-way zipper merge with frontier-based dispatch and specialization

### DIFF
--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -956,6 +956,9 @@ fn zipper_merge_n_mono<P, V, Out, A, const N: usize>(
     Out: ZipperWriting<V, A>,
 {
     debug_assert!(N > 0 && N <= 64);
+    // LLVM needs to prove: `0 ≤ i < N` But i comes from: `i = bits.trailing_zeros() as usize;`` So the
+    // compiler must connect: “this bitmask only contains bits < N”
+    assert!(active >> N == 0);
 
     #[inline]
     fn active_bits<const N: usize>(active: u64) -> impl Iterator<Item = usize> {
@@ -1080,13 +1083,15 @@ fn zipper_merge_n_mono<P, V, Out, A, const N: usize>(
                         }
                         Some(m) => {
                             next = match next {
-                                Some(n) if n <= b => Some(n),
+                                old @ Some(n) if n <= b => old,
                                 _ => Some(b),
                             };
                         }
                     }
                 }
             }
+
+            debug_assert!(frontier <= active);
 
             match min {
                 None => {
@@ -1572,7 +1577,7 @@ mod zipper_algebra_poly {
             V: Clone + Send + Sync + Unpin + 'trie,
             A: Allocator + 'trie,
             $(
-                for<'x> &'x mut $Z: Into<SomeZ<'x, 'trie, 'path, V, A>>,
+                for<'x> &'x mut $Z: Into<SomeMutRefZ<'x, 'trie, 'path, V, A>>,
             )+
             Out: ZipperWriting<V, A>,
         {

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -1,10 +1,12 @@
+use pathmap_derive::PolyZipperExplicit;
+
 use crate::{
     alloc::{Allocator, GlobalAlloc},
     ring::{AlgebraicResult, COUNTER_IDENT, DistributiveLattice, Lattice, SELF_IDENT},
     utils::ByteMask,
     zipper::{
-        ReadZipperUntracked, Zipper, ZipperInfallibleSubtries, ZipperMoving, ZipperValues,
-        ZipperWriting,
+        ReadZipperTracked, ReadZipperUntracked, Zipper, ZipperInfallibleSubtries, ZipperMoving,
+        ZipperValues, ZipperWriting,
     },
 };
 
@@ -91,6 +93,11 @@ pub trait ZipperAlgebraExt<V: Clone + Send + Sync, A: Allocator = GlobalAlloc>:
 
 impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperAlgebraExt<V, A>
     for ReadZipperUntracked<'_, '_, V, A>
+{
+}
+
+impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperAlgebraExt<V, A>
+    for ReadZipperTracked<'_, '_, V, A>
 {
 }
 
@@ -929,6 +936,213 @@ fn zipper_merge4<P, V, Z0, Z1, Z2, Z3, Out, A>(
     }
 }
 
+use zipper_algebra_poly::SomeZ as Z;
+
+fn zipper_merge_n_mono<P, V, Out, A, const N: usize>(
+    zs: &mut [Z<'_, '_, V, A>; N],
+    active: u64,
+    out: &mut Out,
+) where
+    V: Clone + Send + Sync + Unpin,
+    P: MergePolicy<V> + ValuePolicy<V>,
+    A: Allocator,
+    Out: ZipperWriting<V, A>,
+{
+    debug_assert!(N <= 64);
+
+    #[inline]
+    fn active_bits<const N: usize>(active: u64) -> impl Iterator<Item = usize> {
+        (0..N).filter(move |i| (active >> i) & 1 != 0)
+    }
+
+    fn zippers<'a, 'trie, 'path, V, A, const N: usize>(
+        zs: &'a [Z<'trie, 'path, V, A>; N],
+        active: u64,
+    ) -> impl Iterator<Item = (usize, &'a Z<'trie, 'path, V, A>)>
+    where
+        V: Clone + Send + Sync + Unpin,
+        A: Allocator,
+    {
+        active_bits::<N>(active).map(|i| (i, &zs[i]))
+    }
+
+    fn values<'a, 'trie, 'path, V, A, const N: usize>(
+        zs: &'a [Z<'trie, 'path, V, A>; N],
+        active: u64,
+    ) -> impl Iterator<Item = Option<&'a V>>
+    where
+        V: Clone + Send + Sync + Unpin,
+        A: Allocator,
+    {
+        zippers(zs, active).map(|(_, z)| z.val())
+    }
+
+    // small micro-helpers
+    #[inline(always)]
+    fn for_each_bit(mut bits: u64, mut f: impl FnMut(usize)) {
+        while bits != 0 {
+            let i = bits.trailing_zeros() as usize;
+            bits &= bits - 1;
+            f(i);
+        }
+    }
+
+    #[inline(always)]
+    fn with_k<const K: usize, T, R>(
+        xs: &mut [T],
+        mut bits: u64,
+        f: impl FnOnce([&mut T; K]) -> R,
+    ) -> R {
+        debug_assert!(bits.count_ones() as usize >= K);
+
+        // collect raw pointers first (safe)
+        let mut ptrs: [*mut T; K] = [std::ptr::null_mut(); K];
+
+        let mut i = 0;
+        while i < K {
+            let idx = bits.trailing_zeros() as usize;
+            bits &= bits - 1;
+            ptrs[i] = unsafe { xs.as_mut_ptr().add(idx) };
+            i += 1;
+        }
+
+        // SAFETY:
+        // - indices are distinct (bitmask)
+        // - derived from same slice
+
+        // should be zero-cost after inlining
+        let refs = unsafe { ptrs.map(|p| &mut *p) };
+
+        f(refs)
+    }
+
+    // combine root values
+    if let Some(v) = P::combine_n(values(zs, active)) {
+        out.set_val(v);
+    }
+
+    let mut idxs = [0; N];
+    let mut masks = [ByteMask::EMPTY; N];
+    for (i, z) in zippers(zs, active) {
+        masks[i] = z.child_mask();
+    }
+
+    'merge_level: loop {
+        let mut min = None;
+        let mut frontier = 0u64;
+        let mut next = None;
+
+        for i in active_bits::<N>(active) {
+            if let Some(b) = masks[i].indexed_bit::<true>(idxs[i] as usize) {
+                match min {
+                    None => {
+                        min = Some(b);
+                        frontier = 1 << i;
+                    }
+                    Some(m) if b < m => {
+                        next = Some(m);
+                        min = Some(b);
+                        frontier = 1 << i;
+                    }
+                    Some(m) if b == m => {
+                        frontier |= 1 << i;
+                    }
+                    Some(m) => {
+                        next = match next {
+                            Some(n) if n <= b => Some(n),
+                            _ => Some(b),
+                        };
+                    }
+                }
+            }
+        }
+
+        match min {
+            None => {
+                break 'merge_level;
+            }
+            Some(a) => {
+                let cnt = frontier.count_ones();
+
+                // Dispatch
+                if (cnt == 1) {
+                    let i = frontier.trailing_zeros() as usize;
+                    // singleton (|frontier| = 1)
+                    match next {
+                        None => {
+                            P::on_single(&mut zs[i], frontier, ByteMask::from_range(a..), out);
+                            break 'merge_level;
+                        }
+                        Some(b) => {
+                            P::on_single(&mut zs[i], frontier, ByteMask::from_range(a..b), out);
+                            // advance
+                            idxs[i] = masks[i].index_of(b);
+                        }
+                    }
+                } else {
+                    if P::descend_on_some_equal(frontier) {
+                        out.descend_to_byte(a);
+                        match cnt {
+                            2 => with_k::<2, _, _>(zs, frontier, |[lhs, rhs]| {
+                                lhs.descend_to_byte(a);
+                                rhs.descend_to_byte(a);
+
+                                zipper_merge::<P, _, _, _, _, _>(lhs, rhs, out);
+
+                                rhs.ascend_byte();
+                                lhs.ascend_byte();
+                            }),
+                            3 => with_k::<3, _, _>(zs, frontier, |[lhs, mid, rhs]| {
+                                lhs.descend_to_byte(a);
+                                mid.descend_to_byte(a);
+                                rhs.descend_to_byte(a);
+
+                                zipper_merge3::<P, _, _, _, _, _, _>(lhs, mid, rhs, out);
+
+                                rhs.ascend_byte();
+                                mid.ascend_byte();
+                                lhs.ascend_byte();
+                            }),
+                            4 => with_k::<4, _, _>(zs, frontier, |[z0, z1, z2, z3]| {
+                                z0.descend_to_byte(a);
+                                z1.descend_to_byte(a);
+                                z2.descend_to_byte(a);
+                                z3.descend_to_byte(a);
+
+                                zipper_merge4::<P, _, _, _, _, _, _, _>(z0, z1, z2, z3, out);
+
+                                z3.ascend_byte();
+                                z2.ascend_byte();
+                                z1.ascend_byte();
+                                z0.ascend_byte();
+                            }),
+                            _ => {
+                                // descend all active in the frontier
+                                for_each_bit(frontier, |i| zs[i].descend_to_byte(a));
+
+                                // recursive call with SAME array, smaller mask
+                                zipper_merge_n_mono::<P, V, Out, A, N>(zs, frontier, out);
+
+                                //ascend
+                                for_each_bit(frontier, |i| {
+                                    zs[i].ascend_byte();
+                                });
+                            }
+                        }
+
+                        out.ascend_byte();
+                    }
+
+                    // advance indices
+                    for_each_bit(frontier, |i| {
+                        idxs[i] += 1;
+                    });
+                }
+            }
+        }
+    }
+}
+
 // ==================== JOIN ====================
 
 struct Join;
@@ -1136,6 +1350,62 @@ impl<V: DistributiveLattice + Clone> ValuePolicy<V> for Subtract {
             },
             None => Some(acc),
         })
+    }
+}
+
+mod zipper_algebra_poly {
+    // ==================== Machinery for zipper_merge_n ====================
+    use crate as pathmap;
+    use crate::PathMap;
+    use crate::alloc::Allocator;
+    use crate::trie_node::*;
+    use crate::zipper::*;
+
+    #[derive(PolyZipperExplicit)]
+    #[poly_zipper_explicit(traits(ZipperMoving, ZipperValues))]
+    pub(super) enum SomeZ<'trie, 'path, V: Clone + Send + Sync + Unpin, A: Allocator> {
+        RZ(ReadZipperUntracked<'trie, 'path, V, A>),
+        RZT(ReadZipperTracked<'trie, 'path, V, A>),
+    }
+
+    impl<V: Clone + Send + Sync + Unpin, A: Allocator> zipper_priv::ZipperPriv for SomeZ<'_, '_, V, A> {
+        type V = V;
+
+        type A = A;
+
+        #[inline]
+        fn get_focus(&self) -> AbstractNodeRef<'_, Self::V, Self::A> {
+            match self {
+                SomeZ::RZ(inner) => inner.get_focus(),
+                SomeZ::RZT(inner) => inner.get_focus(),
+            }
+        }
+
+        #[inline]
+        fn try_borrow_focus(&self) -> Option<&TrieNodeODRc<Self::V, Self::A>> {
+            match self {
+                SomeZ::RZ(inner) => inner.try_borrow_focus(),
+                SomeZ::RZT(inner) => inner.try_borrow_focus(),
+            }
+        }
+    }
+
+    impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperInfallibleSubtries<V, A>
+        for SomeZ<'_, '_, V, A>
+    {
+        fn make_map(&self) -> PathMap<V, A> {
+            match self {
+                SomeZ::RZ(inner) => inner.make_map(),
+                SomeZ::RZT(inner) => inner.make_map(),
+            }
+        }
+
+        fn get_trie_ref(&self) -> TrieRef<'_, V, A> {
+            match self {
+                SomeZ::RZ(inner) => inner.get_trie_ref(),
+                SomeZ::RZT(inner) => inner.get_trie_ref(),
+            }
+        }
     }
 }
 

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -10,6 +10,8 @@ use crate::{
     },
 };
 
+pub use zipper_algebra_poly::ZipperMergeF;
+
 /// Extension trait providing algebraic merge operations on radix-256 trie zippers.
 ///
 /// This trait exposes high-level operations such as [`join`](Self::join),
@@ -944,7 +946,7 @@ use zipper_algebra_poly::SomeZ as Z;
 //   for improved performance.
 // - Requires `N ≤ 64`.
 fn zipper_merge_n_mono<P, V, Out, A, const N: usize>(
-    zs: &mut [Z<'_, '_, V, A>; N],
+    zs: &mut [Z<'_, '_, '_, V, A>; N],
     active: u64,
     out: &mut Out,
 ) where
@@ -961,9 +963,9 @@ fn zipper_merge_n_mono<P, V, Out, A, const N: usize>(
     }
 
     fn zippers<'a, 'trie, 'path, V, A, const N: usize>(
-        zs: &'a [Z<'trie, 'path, V, A>; N],
+        zs: &'a [Z<'a, 'trie, 'path, V, A>; N],
         active: u64,
-    ) -> impl Iterator<Item = (usize, &'a Z<'trie, 'path, V, A>)>
+    ) -> impl Iterator<Item = (usize, &'a Z<'a, 'trie, 'path, V, A>)>
     where
         V: Clone + Send + Sync + Unpin,
         A: Allocator,
@@ -971,8 +973,8 @@ fn zipper_merge_n_mono<P, V, Out, A, const N: usize>(
         active_bits::<N>(active).map(|i| (i, &zs[i]))
     }
 
-    fn values<'a, 'trie, 'path, V, A, const N: usize>(
-        zs: &'a [Z<'trie, 'path, V, A>; N],
+    fn values<'a, V, A, const N: usize>(
+        zs: &'a [Z<'a, '_, '_, V, A>; N],
         active: u64,
     ) -> impl Iterator<Item = Option<&'a V>>
     where
@@ -1427,18 +1429,19 @@ mod zipper_algebra_poly {
     use crate as pathmap;
     use crate::PathMap;
     use crate::alloc::Allocator;
+    use crate::ring::{DistributiveLattice, Lattice};
     use crate::trie_node::*;
     use crate::zipper::*;
 
     #[derive(PolyZipperExplicit)]
     #[poly_zipper_explicit(traits(ZipperMoving, ZipperValues))]
-    pub(super) enum SomeZ<'trie, 'path, V: Clone + Send + Sync + Unpin, A: Allocator> {
-        RZ(ReadZipperUntracked<'trie, 'path, V, A>),
-        RZT(ReadZipperTracked<'trie, 'path, V, A>),
+    pub(super) enum SomeZ<'a, 'trie, 'path, V: Clone + Send + Sync + Unpin, A: Allocator> {
+        RZ(&'a mut ReadZipperUntracked<'trie, 'path, V, A>),
+        RZT(&'a mut ReadZipperTracked<'trie, 'path, V, A>),
     }
 
     impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperInfallibleSubtries<V, A>
-        for SomeZ<'_, '_, V, A>
+        for SomeZ<'_, '_, '_, V, A>
     {
         fn make_map(&self) -> PathMap<V, A> {
             match self {
@@ -1468,6 +1471,211 @@ mod zipper_algebra_poly {
             }
         }
     }
+
+    pub trait ZipperMergeF<V, Out, A>
+    where
+        V: Clone + Send + Sync,
+        A: Allocator,
+        Self: Sized,
+    {
+        /// Performs an N-way ordered join (least upper bound) of radix-256 trie zippers using a stackless traversal.
+        ///
+        /// This function generalizes pairwise [`super::zipper_join`] to an arbitrary number of input tries,
+        fn join_n(self, out: &mut Out)
+        where
+            V: Lattice,
+        {
+            self.merge_n::<super::Join>(out);
+        }
+
+        /// Performs an N-way ordered meet(greeatest lower bound) of radix-256 trie zippers using a stackless traversal.
+        ///
+        /// This function generalizes pairwise [`super::zipper_meet`] to an arbitrary number of input tries,
+        fn meet_n(self, out: &mut Out)
+        where
+            V: Lattice,
+        {
+            self.merge_n::<super::Meet>(out);
+        }
+
+        /// Performs an N-way ordered subtraction (left-associative) of radix-256 trie zippers using a stackless traversal.
+        ///
+        /// This function generalizes pairwise [`super::zipper_subtract`] to an arbitrary number of input tries,
+        fn subtract_n(self, out: &mut Out)
+        where
+            V: DistributiveLattice,
+        {
+            self.merge_n::<super::Subtract>(out);
+        }
+
+        fn merge_n<P>(self, out: &mut Out)
+        where
+            P: super::MergePolicy<V> + super::ValuePolicy<V>;
+    }
+
+    impl<V, Z1, Z2, Out, A> ZipperMergeF<V, Out, A> for (&mut Z1, &mut Z2)
+    where
+        V: Clone + Send + Sync,
+        A: Allocator,
+        Z1: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Z2: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Out: ZipperWriting<V, A>,
+    {
+        fn merge_n<P>(mut self, out: &mut Out)
+        where
+            P: super::MergePolicy<V> + super::ValuePolicy<V>,
+        {
+            super::zipper_merge::<P, _, _, _, _, _>(self.0, self.1, out);
+        }
+    }
+
+    impl<V, Z1, Z2, Z3, Out, A> ZipperMergeF<V, Out, A> for (&mut Z1, &mut Z2, &mut Z3)
+    where
+        V: Clone + Send + Sync,
+        A: Allocator,
+        Z1: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Z2: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Z3: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Out: ZipperWriting<V, A>,
+    {
+        fn merge_n<P>(mut self, out: &mut Out)
+        where
+            P: super::MergePolicy<V> + super::ValuePolicy<V>,
+        {
+            super::zipper_merge3::<P, _, _, _, _, _, _>(self.0, self.1, self.2, out);
+        }
+    }
+
+    impl<V, Z1, Z2, Z3, Z4, Out, A> ZipperMergeF<V, Out, A> for (&mut Z1, &mut Z2, &mut Z3, &mut Z4)
+    where
+        V: Clone + Send + Sync,
+        A: Allocator,
+        Z1: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Z2: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Z3: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Z4: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Out: ZipperWriting<V, A>,
+    {
+        fn merge_n<P>(mut self, out: &mut Out)
+        where
+            P: super::MergePolicy<V> + super::ValuePolicy<V>,
+        {
+            super::zipper_merge4::<P, _, _, _, _, _, _, _>(self.0, self.1, self.2, self.3, out);
+        }
+    }
+
+    macro_rules! impl_zipper_merge_f {
+    ($($Z:ident),+) => {
+        impl<'trie, 'path, V, $($Z),+, Out, A> ZipperMergeF<V, Out, A>
+            for ($( &mut $Z ),+)
+        where
+            V: Clone + Send + Sync + Unpin + 'trie,
+            A: Allocator + 'trie,
+            $(
+                for<'x> &'x mut $Z: Into<SomeZ<'x, 'trie, 'path, V, A>>,
+            )+
+            Out: ZipperWriting<V, A>,
+        {
+            fn merge_n<P>(mut self, out: &mut Out)
+            where
+                P: super::MergePolicy<V> + super::ValuePolicy<V>,
+            {
+                // destructure the tuple
+                let ($( $Z ),+) = self;
+
+                let mut zs = [
+                    $( $Z.into() ),+
+                ];
+
+                let active: u64 = (1 << zs.len()) - 1;
+
+                super::zipper_merge_n_mono::<P, _, _, _, _>(
+                    &mut zs,
+                    active,
+                    out,
+                );
+            }
+        }
+    };
+}
+
+    impl_zipper_merge_f!(Z1, Z2, Z3, Z4, Z5);
+    impl_zipper_merge_f!(Z1, Z2, Z3, Z4, Z5, Z6);
+    impl_zipper_merge_f!(Z1, Z2, Z3, Z4, Z5, Z6, Z7);
+    impl_zipper_merge_f!(Z1, Z2, Z3, Z4, Z5, Z6, Z7, Z8);
+    impl_zipper_merge_f!(Z1, Z2, Z3, Z4, Z5, Z6, Z7, Z8, Z9);
+    impl_zipper_merge_f!(Z1, Z2, Z3, Z4, Z5, Z6, Z7, Z8, Z9, Z10);
+    impl_zipper_merge_f!(Z1, Z2, Z3, Z4, Z5, Z6, Z7, Z8, Z9, Z10, Z11);
+    impl_zipper_merge_f!(Z1, Z2, Z3, Z4, Z5, Z6, Z7, Z8, Z9, Z10, Z11, Z12);
+    impl_zipper_merge_f!(Z1, Z2, Z3, Z4, Z5, Z6, Z7, Z8, Z9, Z10, Z11, Z12, Z13);
+    impl_zipper_merge_f!(Z1, Z2, Z3, Z4, Z5, Z6, Z7, Z8, Z9, Z10, Z11, Z12, Z13, Z14);
+    impl_zipper_merge_f!(
+        Z1, Z2, Z3, Z4, Z5, Z6, Z7, Z8, Z9, Z10, Z11, Z12, Z13, Z14, Z15
+    );
+    impl_zipper_merge_f!(
+        Z1, Z2, Z3, Z4, Z5, Z6, Z7, Z8, Z9, Z10, Z11, Z12, Z13, Z14, Z15, Z16
+    );
+    impl_zipper_merge_f!(
+        Z1, Z2, Z3, Z4, Z5, Z6, Z7, Z8, Z9, Z10, Z11, Z12, Z13, Z14, Z15, Z16, Z17
+    );
+    impl_zipper_merge_f!(
+        Z1, Z2, Z3, Z4, Z5, Z6, Z7, Z8, Z9, Z10, Z11, Z12, Z13, Z14, Z15, Z16, Z17, Z18
+    );
+    impl_zipper_merge_f!(
+        Z1, Z2, Z3, Z4, Z5, Z6, Z7, Z8, Z9, Z10, Z11, Z12, Z13, Z14, Z15, Z16, Z17, Z18, Z19
+    );
+    impl_zipper_merge_f!(
+        Z1, Z2, Z3, Z4, Z5, Z6, Z7, Z8, Z9, Z10, Z11, Z12, Z13, Z14, Z15, Z16, Z17, Z18, Z19, Z20
+    );
+    impl_zipper_merge_f!(
+        Z1, Z2, Z3, Z4, Z5, Z6, Z7, Z8, Z9, Z10, Z11, Z12, Z13, Z14, Z15, Z16, Z17, Z18, Z19, Z20,
+        Z21
+    );
+    impl_zipper_merge_f!(
+        Z1, Z2, Z3, Z4, Z5, Z6, Z7, Z8, Z9, Z10, Z11, Z12, Z13, Z14, Z15, Z16, Z17, Z18, Z19, Z20,
+        Z21, Z22
+    );
+    impl_zipper_merge_f!(
+        Z1, Z2, Z3, Z4, Z5, Z6, Z7, Z8, Z9, Z10, Z11, Z12, Z13, Z14, Z15, Z16, Z17, Z18, Z19, Z20,
+        Z21, Z22, Z23
+    );
+    impl_zipper_merge_f!(
+        Z1, Z2, Z3, Z4, Z5, Z6, Z7, Z8, Z9, Z10, Z11, Z12, Z13, Z14, Z15, Z16, Z17, Z18, Z19, Z20,
+        Z21, Z22, Z23, Z24
+    );
+    impl_zipper_merge_f!(
+        Z1, Z2, Z3, Z4, Z5, Z6, Z7, Z8, Z9, Z10, Z11, Z12, Z13, Z14, Z15, Z16, Z17, Z18, Z19, Z20,
+        Z21, Z22, Z23, Z24, Z25
+    );
+    impl_zipper_merge_f!(
+        Z1, Z2, Z3, Z4, Z5, Z6, Z7, Z8, Z9, Z10, Z11, Z12, Z13, Z14, Z15, Z16, Z17, Z18, Z19, Z20,
+        Z21, Z22, Z23, Z24, Z25, Z26
+    );
+    impl_zipper_merge_f!(
+        Z1, Z2, Z3, Z4, Z5, Z6, Z7, Z8, Z9, Z10, Z11, Z12, Z13, Z14, Z15, Z16, Z17, Z18, Z19, Z20,
+        Z21, Z22, Z23, Z24, Z25, Z26, Z27
+    );
+    impl_zipper_merge_f!(
+        Z1, Z2, Z3, Z4, Z5, Z6, Z7, Z8, Z9, Z10, Z11, Z12, Z13, Z14, Z15, Z16, Z17, Z18, Z19, Z20,
+        Z21, Z22, Z23, Z24, Z25, Z26, Z27, Z28
+    );
+    impl_zipper_merge_f!(
+        Z1, Z2, Z3, Z4, Z5, Z6, Z7, Z8, Z9, Z10, Z11, Z12, Z13, Z14, Z15, Z16, Z17, Z18, Z19, Z20,
+        Z21, Z22, Z23, Z24, Z25, Z26, Z27, Z28, Z29
+    );
+    impl_zipper_merge_f!(
+        Z1, Z2, Z3, Z4, Z5, Z6, Z7, Z8, Z9, Z10, Z11, Z12, Z13, Z14, Z15, Z16, Z17, Z18, Z19, Z20,
+        Z21, Z22, Z23, Z24, Z25, Z26, Z27, Z28, Z29, Z30
+    );
+    impl_zipper_merge_f!(
+        Z1, Z2, Z3, Z4, Z5, Z6, Z7, Z8, Z9, Z10, Z11, Z12, Z13, Z14, Z15, Z16, Z17, Z18, Z19, Z20,
+        Z21, Z22, Z23, Z24, Z25, Z26, Z27, Z28, Z29, Z30, Z31
+    );
+    impl_zipper_merge_f!(
+        Z1, Z2, Z3, Z4, Z5, Z6, Z7, Z8, Z9, Z10, Z11, Z12, Z13, Z14, Z15, Z16, Z17, Z18, Z19, Z20,
+        Z21, Z22, Z23, Z24, Z25, Z26, Z27, Z28, Z29, Z30, Z31, Z32
+    );
+
 }
 
 #[cfg(test)]

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -55,13 +55,13 @@ pub use zipper_algebra_poly::ZipperMergeF;
 /// - [`zipper_meet`]
 /// - [`zipper_subtract`]
 pub trait ZipperAlgebraExt<V: Clone + Send + Sync, A: Allocator = GlobalAlloc>:
-    ZipperInfallibleSubtries<V, A> + ZipperMoving + Sized
+    ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving + Sized
 {
     #[inline]
     fn join<ZR, Out>(&mut self, rhs: &mut ZR, out: &mut Out)
     where
         V: Lattice,
-        ZR: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        ZR: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
         Out: ZipperWriting<V, A>,
     {
         zipper_join(self, rhs, out);
@@ -71,7 +71,7 @@ pub trait ZipperAlgebraExt<V: Clone + Send + Sync, A: Allocator = GlobalAlloc>:
     fn meet<ZR, Out>(&mut self, rhs: &mut ZR, out: &mut Out)
     where
         V: Lattice,
-        ZR: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        ZR: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
         Out: ZipperWriting<V, A>,
     {
         zipper_meet(self, rhs, out);
@@ -81,7 +81,7 @@ pub trait ZipperAlgebraExt<V: Clone + Send + Sync, A: Allocator = GlobalAlloc>:
     fn subtract<ZR, Out>(&mut self, rhs: &mut ZR, out: &mut Out)
     where
         V: DistributiveLattice,
-        ZR: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        ZR: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
         Out: ZipperWriting<V, A>,
     {
         zipper_subtract(self, rhs, out);
@@ -139,8 +139,8 @@ pub fn zipper_join<V, ZL, ZR, Out, A>(lhs: &mut ZL, rhs: &mut ZR, out: &mut Out)
 where
     V: Lattice + Clone + Send + Sync,
     A: Allocator,
-    ZL: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-    ZR: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    ZL: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
+    ZR: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
     Out: ZipperWriting<V, A>,
 {
     zipper_merge::<Join, V, ZL, ZR, Out, A>(lhs, rhs, out);
@@ -157,9 +157,9 @@ pub fn zipper_join3<V, ZL, ZM, ZR, Out, A>(lhs: &mut ZL, mid: &mut ZM, rhs: &mut
 where
     V: Lattice + Clone + Send + Sync,
     A: Allocator,
-    ZL: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-    ZM: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-    ZR: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    ZL: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
+    ZM: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
+    ZR: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
     Out: ZipperWriting<V, A>,
 {
     zipper_merge3::<Join, V, ZL, ZM, ZR, Out, A>(lhs, mid, rhs, out);
@@ -209,8 +209,8 @@ pub fn zipper_meet<V, ZL, ZR, Out, A>(lhs: &mut ZL, rhs: &mut ZR, out: &mut Out)
 where
     V: Lattice + Clone + Send + Sync,
     A: Allocator,
-    ZL: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-    ZR: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    ZL: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
+    ZR: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
     Out: ZipperWriting<V, A>,
 {
     zipper_merge::<Meet, V, ZL, ZR, Out, A>(lhs, rhs, out);
@@ -227,9 +227,9 @@ pub fn zipper_meet3<V, ZL, ZM, ZR, Out, A>(lhs: &mut ZL, mid: &mut ZM, rhs: &mut
 where
     V: Lattice + Clone + Send + Sync,
     A: Allocator,
-    ZL: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-    ZM: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-    ZR: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    ZL: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
+    ZM: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
+    ZR: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
     Out: ZipperWriting<V, A>,
 {
     zipper_merge3::<Meet, V, ZL, ZM, ZR, Out, A>(lhs, mid, rhs, out);
@@ -285,8 +285,8 @@ pub fn zipper_subtract<V, ZL, ZR, Out, A>(lhs: &mut ZL, rhs: &mut ZR, out: &mut 
 where
     V: DistributiveLattice + Clone + Send + Sync,
     A: Allocator,
-    ZL: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-    ZR: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    ZL: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
+    ZR: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
     Out: ZipperWriting<V, A>,
 {
     zipper_merge::<Subtract, V, ZL, ZR, Out, A>(lhs, rhs, out);
@@ -307,9 +307,9 @@ pub fn zipper_subtract3<V, ZL, ZM, ZR, Out, A>(
 ) where
     V: DistributiveLattice + Clone + Send + Sync,
     A: Allocator,
-    ZL: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-    ZM: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-    ZR: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    ZL: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
+    ZM: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
+    ZR: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
     Out: ZipperWriting<V, A>,
 {
     zipper_merge3::<Subtract, V, ZL, ZM, ZR, Out, A>(lhs, mid, rhs, out);
@@ -343,6 +343,11 @@ trait MergePolicy<V: Clone + Send + Sync> {
         Out: ZipperWriting<V, A>;
 
     fn descend_on_some_equal(mask: u64) -> bool;
+    fn on_id<Z, Out, A>(z: &mut Z, out: &mut Out)
+    where
+        A: Allocator,
+        Z: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
+        Out: ZipperWriting<V, A>;
 }
 
 trait ValuePolicy<V> {
@@ -373,10 +378,24 @@ where
     V: Clone + Send + Sync,
     P: MergePolicy<V> + ValuePolicy<V>,
     A: Allocator,
-    ZL: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-    ZR: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    ZL: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
+    ZR: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
     Out: ZipperWriting<V, A>,
 {
+    fn check_sharing<ZL, ZR>(lhs: &ZL, rhs: &ZR) -> bool
+    where
+        ZL: ZipperConcrete,
+        ZR: ZipperConcrete,
+    {
+        lhs.shared_node_id()
+            .is_some_and(|lsnid| rhs.shared_node_id().is_some_and(|rsnid| lsnid == rsnid))
+    }
+    // check for node-sharing first
+    if check_sharing(lhs, rhs) {
+        P::on_id(lhs, out);
+        return;
+    }
+
     // merge root values before descending
     if let Some(v) = P::combine(lhs.val(), rhs.val()) {
         out.set_val(v);
@@ -415,6 +434,20 @@ where
 
                         lhs.descend_to_byte(lhs_byte);
                         rhs.descend_to_byte(lhs_byte);
+
+                        // optimization - if both zippers share the node after descend, we can skip
+                        // further descend and continue merging
+                        if check_sharing(lhs, rhs) {
+                            P::on_id(lhs, out);
+
+                            rhs.ascend_byte();
+                            rhs_next = rhs_mask.next_bit(lhs_byte);
+                            lhs.ascend_byte();
+                            lhs_next = lhs_mask.next_bit(lhs_byte);
+                            out.ascend_byte();
+
+                            continue 'merge_level;
+                        }
 
                         if let Some(v) = P::combine(lhs.val(), rhs.val()) {
                             out.set_val(v);
@@ -482,9 +515,9 @@ where
     V: Clone + Send + Sync,
     P: MergePolicy<V> + ValuePolicy<V>,
     A: Allocator,
-    ZL: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-    ZM: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-    ZR: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    ZL: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
+    ZM: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
+    ZR: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
     Out: ZipperWriting<V, A>,
 {
     const L: u8 = 0b001;
@@ -500,8 +533,8 @@ where
         V: Clone + Send + Sync,
         P: MergePolicy<V> + ValuePolicy<V>,
         A: Allocator,
-        ZL: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-        ZR: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        ZL: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
+        ZR: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
         Out: ZipperWriting<V, A>,
     {
         out.descend_to_byte(b);
@@ -513,6 +546,25 @@ where
         rhs.ascend_byte();
         lhs.ascend_byte();
         out.ascend_byte();
+    }
+
+    fn all_share<ZL, ZM, ZR>(lhs: &ZL, mid: &ZM, rhs: &ZR) -> bool
+    where
+        ZL: ZipperConcrete,
+        ZM: ZipperConcrete,
+        ZR: ZipperConcrete,
+    {
+        lhs.shared_node_id().is_some_and(|lsnid| {
+            mid.shared_node_id().is_some_and(|msnid| {
+                lsnid == msnid && rhs.shared_node_id().is_some_and(|rsnid| msnid == rsnid)
+            })
+        })
+    }
+
+    // check for node-sharing first
+    if all_share(lhs, mid, rhs) {
+        P::on_id(lhs, out);
+        return;
     }
 
     // merge root values before descending
@@ -611,6 +663,21 @@ where
                         mid.descend_to_byte(min);
                         rhs.descend_to_byte(min);
 
+                        //structural sharing check
+                        if all_share(lhs, mid, rhs) {
+                            P::on_id(lhs, out);
+
+                            rhs.ascend_byte();
+                            r = rhs_mask.next_bit(min);
+                            mid.ascend_byte();
+                            m = mid_mask.next_bit(min);
+                            lhs.ascend_byte();
+                            l = lhs_mask.next_bit(min);
+                            out.ascend_byte();
+
+                            continue 'merge_level;
+                        }
+
                         if let Some(val) = P::combine3(lhs.val(), mid.val(), rhs.val()) {
                             out.set_val(val);
                         }
@@ -672,12 +739,35 @@ fn zipper_merge4<P, V, Z0, Z1, Z2, Z3, Out, A>(
     V: Clone + Send + Sync,
     P: MergePolicy<V> + ValuePolicy<V>,
     A: Allocator,
-    Z0: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-    Z1: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-    Z2: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-    Z3: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    Z0: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
+    Z1: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
+    Z2: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
+    Z3: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
     Out: ZipperWriting<V, A>,
 {
+    fn all_share<Z0, Z1, Z2, Z3>(z0: &Z0, z1: &Z1, z2: &Z2, z3: &Z3) -> bool
+    where
+        Z0: ZipperConcrete,
+        Z1: ZipperConcrete,
+        Z2: ZipperConcrete,
+        Z3: ZipperConcrete,
+    {
+        z0.shared_node_id().is_some_and(|snid0| {
+            z1.shared_node_id().is_some_and(|snid1| {
+                snid0 == snid1
+                    && z2.shared_node_id().is_some_and(|snid2| {
+                        snid1 == snid2 && z3.shared_node_id().is_some_and(|snid3| snid2 == snid3)
+                    })
+            })
+        })
+    }
+
+    // check for node-sharing first
+    if all_share(z0, z1, z2, z3) {
+        P::on_id(z0, out);
+        return;
+    }
+
     // merge root values before descending
     if let Some(v) = P::combine4(z0.val(), z1.val(), z2.val(), z3.val()) {
         out.set_val(v);
@@ -730,6 +820,23 @@ fn zipper_merge4<P, V, Z0, Z1, Z2, Z3, Out, A>(
                     z1.descend_to_byte(min);
                     z2.descend_to_byte(min);
                     z3.descend_to_byte(min);
+
+                    // check structural sharing
+                    if all_share(z0, z1, z2, z3) {
+                        P::on_id(z0, out);
+
+                        z3.ascend_byte();
+                        b3 = m3.next_bit(min);
+                        z2.ascend_byte();
+                        b2 = m2.next_bit(min);
+                        z1.ascend_byte();
+                        b1 = m1.next_bit(min);
+                        z0.ascend_byte();
+                        b0 = m0.next_bit(min);
+                        out.ascend_byte();
+
+                        continue 'merge_level;
+                    }
 
                     if let Some(v) = P::combine4(z0.val(), z1.val(), z2.val(), z3.val()) {
                         out.set_val(v);
@@ -958,7 +1065,7 @@ fn zipper_merge4<P, V, Z0, Z1, Z2, Z3, Out, A>(
 pub fn zipper_n_join<V, Z, Out, A, const N: usize>(zs: &mut [Z; N], out: &mut Out)
 where
     V: Lattice + Clone + Send + Sync + Unpin,
-    Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    Z: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
     Out: ZipperWriting<V, A>,
     A: Allocator,
 {
@@ -994,7 +1101,7 @@ where
 pub fn zipper_n_meet<V, Z, Out, A, const N: usize>(zs: &mut [Z; N], out: &mut Out)
 where
     V: Lattice + Clone + Send + Sync + Unpin,
-    Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    Z: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
     Out: ZipperWriting<V, A>,
     A: Allocator,
 {
@@ -1037,7 +1144,7 @@ where
 pub fn zipper_n_subtract<V, Z, Out, A, const N: usize>(zs: &mut [Z; N], out: &mut Out)
 where
     V: DistributiveLattice + Clone + Send + Sync + Unpin,
-    Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    Z: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
     Out: ZipperWriting<V, A>,
     A: Allocator,
 {
@@ -1054,7 +1161,7 @@ where
     V: Clone + Send + Sync + Unpin,
     P: MergePolicy<V> + ValuePolicy<V>,
     A: Allocator,
-    Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    Z: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
     Out: ZipperWriting<V, A>,
 {
     debug_assert!(N > 0 && N <= 64);
@@ -1068,10 +1175,10 @@ where
     }
 
     fn only_active<'a, T, const N: usize>(
-        zs: &'a [T; N],
+        ts: &'a [T; N],
         active: u64,
     ) -> impl Iterator<Item = (usize, &'a T)> {
-        active_bits::<N>(active).map(|i| (i, &zs[i]))
+        active_bits::<N>(active).map(|i| (i, &ts[i]))
     }
 
     fn values<'a, V, Z, const N: usize>(
@@ -1085,7 +1192,25 @@ where
         only_active(zs, active).map(|(_, z)| z.val())
     }
 
+    fn all_active_share<Z, const N: usize>(zs: &[Z; N], active: u64) -> bool
+    where
+        Z: ZipperConcrete,
+    {
+        let mut iter = only_active(zs, active).map(|(_, z)| z.shared_node_id());
+        match iter.next() {
+            Some(Some(first)) => iter.all(|next| next.is_some_and(|snid| snid == first)),
+            _ => false,
+        }
+    }
+
     // small micro-helpers
+    #[inline(always)]
+    fn first_active<T, const N: usize>(ts: &mut [T; N], active: u64) -> &mut T {
+        debug_assert_ne!(active, 0);
+        let i0 = active.trailing_zeros() as usize;
+        &mut ts[i0]
+    }
+
     #[inline(always)]
     fn for_each_bit(mut bits: u64, mut f: impl FnMut(usize)) {
         while bits != 0 {
@@ -1124,6 +1249,12 @@ where
         f(refs)
     }
 
+    // check for node-sharing first
+    if all_active_share(zs, active) {
+        P::on_id(first_active(zs, active), out);
+        return;
+    }
+
     // combine root values
     if let Some(v) = P::combine_n(values(zs, active)) {
         out.set_val(v);
@@ -1158,7 +1289,7 @@ where
     // (`descend_to_byte` / `ascend_byte`) and an explicit depth counter,
     // avoiding recursion in the common case.
     let mut k = 0;
-    debug_assert!(active.count_ones() > 0);
+    debug_assert_ne!(active.count_ones(), 0);
     'ascend: loop {
         'merge_level: loop {
             let mut min = None;
@@ -1210,6 +1341,18 @@ where
                             masks[i] = z.child_mask();
                             bytes[i] = masks[i].indexed_bit::<true>(0);
                         });
+
+                        // check structural sharing first
+                        if all_active_share(zs, active) {
+                            P::on_id(first_active(zs, active), out);
+
+                            for_each_bit(active, |i| {
+                                zs[i].ascend_byte();
+                                bytes[i] = masks[i].next_bit(a);
+                            });
+                            out.ascend_byte();
+                            continue 'merge_level;
+                        }
 
                         if let Some(v) = P::combine_n(values(zs, active)) {
                             out.set_val(v);
@@ -1301,9 +1444,10 @@ where
         if (k == 0) {
             break 'ascend;
         }
-
-        let i0 = active.trailing_zeros() as usize;
-        let byte_from = *zs[i0].path().last().expect("non-empty path when k > 0");
+        let byte_from = *first_active(zs, active)
+            .path()
+            .last()
+            .expect("non-empty path when k > 0");
 
         // ascend
         for_each_bit(active, |i| {
@@ -1335,6 +1479,16 @@ impl<V: Clone + Send + Sync> MergePolicy<V> for Join {
     #[inline]
     fn descend_on_some_equal(_mask: u64) -> bool {
         true
+    }
+
+    #[inline]
+    fn on_id<Z, Out, A>(z: &mut Z, out: &mut Out)
+    where
+        A: Allocator,
+        Z: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
+        Out: ZipperWriting<V, A>,
+    {
+        out.graft_children(z, ByteMask::FULL);
     }
 }
 
@@ -1400,6 +1554,16 @@ impl<V: Clone + Send + Sync> MergePolicy<V> for Meet {
     #[inline(always)]
     fn descend_on_some_equal(_mask: u64) -> bool {
         false
+    }
+
+    #[inline(always)]
+    fn on_id<Z, Out, A>(z: &mut Z, out: &mut Out)
+    where
+        A: Allocator,
+        Z: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
+        Out: ZipperWriting<V, A>,
+    {
+        out.graft_children(z, ByteMask::FULL);
     }
 }
 
@@ -1502,6 +1666,15 @@ impl<V: Clone + Send + Sync> MergePolicy<V> for Subtract {
     fn descend_on_some_equal(mask: u64) -> bool {
         mask & 1 != 0
     }
+
+    #[inline]
+    fn on_id<Z, Out, A>(_z: &mut Z, _out: &mut Out)
+    where
+        A: Allocator,
+        Z: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
+        Out: ZipperWriting<V, A>,
+    {
+    }
 }
 
 impl<V: DistributiveLattice + Clone> ValuePolicy<V> for Subtract {
@@ -1581,7 +1754,7 @@ mod zipper_algebra_poly {
     use pathmap_derive::PolyZipperExplicit;
 
     #[derive(PolyZipperExplicit)]
-    #[poly_zipper_explicit(traits(ZipperMoving, ZipperValues))]
+    #[poly_zipper_explicit(traits(ZipperMoving, ZipperValues, ZipperConcrete))]
     pub(super) enum SomeMutRefZ<'a, 'trie, 'path, V: Clone + Send + Sync + Unpin, A: Allocator> {
         RZ(&'a mut ReadZipperUntracked<'trie, 'path, V, A>),
         RZT(&'a mut ReadZipperTracked<'trie, 'path, V, A>),
@@ -1664,8 +1837,8 @@ mod zipper_algebra_poly {
     where
         V: Clone + Send + Sync,
         A: Allocator,
-        Z1: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-        Z2: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Z1: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
+        Z2: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
         Out: ZipperWriting<V, A>,
     {
         fn merge_n<P>(mut self, out: &mut Out)
@@ -1680,9 +1853,9 @@ mod zipper_algebra_poly {
     where
         V: Clone + Send + Sync,
         A: Allocator,
-        Z1: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-        Z2: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-        Z3: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Z1: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
+        Z2: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
+        Z3: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
         Out: ZipperWriting<V, A>,
     {
         fn merge_n<P>(mut self, out: &mut Out)
@@ -1697,10 +1870,10 @@ mod zipper_algebra_poly {
     where
         V: Clone + Send + Sync,
         A: Allocator,
-        Z1: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-        Z2: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-        Z3: ZipperInfallibleSubtries<V, A> + ZipperMoving,
-        Z4: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+        Z1: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
+        Z2: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
+        Z3: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
+        Z4: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
         Out: ZipperWriting<V, A>,
     {
         fn merge_n<P>(mut self, out: &mut Out)

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -938,6 +938,11 @@ fn zipper_merge4<P, V, Z0, Z1, Z2, Z3, Out, A>(
 
 use zipper_algebra_poly::SomeZ as Z;
 
+// - The function is fully monomorphized over `N` and uses a bitmask (`active`)
+//   to track participating zippers.
+// - Small frontiers (`k ≤ 4`) are dispatched to specialized implementations
+//   for improved performance.
+// - Requires `N ≤ 64`.
 fn zipper_merge_n_mono<P, V, Out, A, const N: usize>(
     zs: &mut [Z<'_, '_, V, A>; N],
     active: u64,
@@ -948,7 +953,7 @@ fn zipper_merge_n_mono<P, V, Out, A, const N: usize>(
     A: Allocator,
     Out: ZipperWriting<V, A>,
 {
-    debug_assert!(N <= 64);
+    debug_assert!(N > 0 && N <= 64);
 
     #[inline]
     fn active_bits<const N: usize>(active: u64) -> impl Iterator<Item = usize> {
@@ -1027,119 +1032,183 @@ fn zipper_merge_n_mono<P, V, Out, A, const N: usize>(
         masks[i] = z.child_mask();
     }
 
-    'merge_level: loop {
-        let mut min = None;
-        let mut frontier = 0u64;
-        let mut next = None;
+    // At each node, the algorithm:
+    //
+    // - Treats the child edges of all active zippers as sorted byte sequences,
+    // - Computes the minimal byte `a` across all inputs,
+    // - Forms the *frontier* — the subset of zippers containing `a`,
+    // - Dispatches based on frontier size:
+    //
+    //   - **Full match (`frontier == active`)**
+    //     Descends into all zippers without recursion (fast path).
+    //
+    //   - **Singleton (`|frontier| = 1`)**
+    //     Grafts the corresponding subtrie directly into the output.
+    //
+    //   - **Partial overlap (`1 < |frontier| < N`)**
+    //     Optionally descends into the subset, dispatching to specialized
+    //     implementations for small arities (`k ≤ 4`) or recursively invoking
+    //     this function on the subset.
+    //
+    // The traversal is performed iteratively using zipper movements
+    // (`descend_to_byte` / `ascend_byte`) and an explicit depth counter,
+    // avoiding recursion in the common case.
+    let mut k = 0;
+    debug_assert!(active.count_ones() > 0);
+    'ascend: loop {
+        'merge_level: loop {
+            let mut min = None;
+            let mut frontier = 0u64;
+            let mut next = None;
 
-        for i in active_bits::<N>(active) {
-            if let Some(b) = masks[i].indexed_bit::<true>(idxs[i] as usize) {
-                match min {
-                    None => {
-                        min = Some(b);
-                        frontier = 1 << i;
-                    }
-                    Some(m) if b < m => {
-                        next = Some(m);
-                        min = Some(b);
-                        frontier = 1 << i;
-                    }
-                    Some(m) if b == m => {
-                        frontier |= 1 << i;
-                    }
-                    Some(m) => {
-                        next = match next {
-                            Some(n) if n <= b => Some(n),
-                            _ => Some(b),
-                        };
+            for i in active_bits::<N>(active) {
+                if let Some(b) = masks[i].indexed_bit::<true>(idxs[i] as usize) {
+                    match min {
+                        None => {
+                            min = Some(b);
+                            frontier = 1 << i;
+                        }
+                        Some(m) if b < m => {
+                            next = Some(m);
+                            min = Some(b);
+                            frontier = 1 << i;
+                        }
+                        Some(m) if b == m => {
+                            frontier |= 1 << i;
+                        }
+                        Some(m) => {
+                            next = match next {
+                                Some(n) if n <= b => Some(n),
+                                _ => Some(b),
+                            };
+                        }
                     }
                 }
             }
-        }
 
-        match min {
-            None => {
-                break 'merge_level;
-            }
-            Some(a) => {
-                let cnt = frontier.count_ones();
+            match min {
+                None => {
+                    break 'merge_level;
+                }
+                Some(a) => {
+                    // Dispatch
 
-                // Dispatch
-                if (cnt == 1) {
-                    let i = frontier.trailing_zeros() as usize;
-                    // singleton (|frontier| = 1)
-                    match next {
-                        None => {
-                            P::on_single(&mut zs[i], frontier, ByteMask::from_range(a..), out);
-                            break 'merge_level;
-                        }
-                        Some(b) => {
-                            P::on_single(&mut zs[i], frontier, ByteMask::from_range(a..b), out);
-                            // advance
-                            idxs[i] = masks[i].index_of(b);
-                        }
-                    }
-                } else {
-                    if P::descend_on_some_equal(frontier) {
+                    // - Case A: full match (frontier == all bits)
+                    if frontier == active {
                         out.descend_to_byte(a);
-                        match cnt {
-                            2 => with_k::<2, _, _>(zs, frontier, |[lhs, rhs]| {
-                                lhs.descend_to_byte(a);
-                                rhs.descend_to_byte(a);
 
-                                zipper_merge::<P, _, _, _, _, _>(lhs, rhs, out);
+                        // descend and refresh masks and indices
+                        for_each_bit(active, |i| {
+                            let mut z = &mut zs[i];
+                            z.descend_to_byte(a);
+                            masks[i] = z.child_mask();
+                            idxs[i] = 0;
+                        });
 
-                                rhs.ascend_byte();
-                                lhs.ascend_byte();
-                            }),
-                            3 => with_k::<3, _, _>(zs, frontier, |[lhs, mid, rhs]| {
-                                lhs.descend_to_byte(a);
-                                mid.descend_to_byte(a);
-                                rhs.descend_to_byte(a);
+                        if let Some(v) = P::combine_n(values(zs, active)) {
+                            out.set_val(v);
+                        }
 
-                                zipper_merge3::<P, _, _, _, _, _, _>(lhs, mid, rhs, out);
+                        k += 1;
+                        continue 'merge_level;
+                    }
 
-                                rhs.ascend_byte();
-                                mid.ascend_byte();
-                                lhs.ascend_byte();
-                            }),
-                            4 => with_k::<4, _, _>(zs, frontier, |[z0, z1, z2, z3]| {
-                                z0.descend_to_byte(a);
-                                z1.descend_to_byte(a);
-                                z2.descend_to_byte(a);
-                                z3.descend_to_byte(a);
-
-                                zipper_merge4::<P, _, _, _, _, _, _, _>(z0, z1, z2, z3, out);
-
-                                z3.ascend_byte();
-                                z2.ascend_byte();
-                                z1.ascend_byte();
-                                z0.ascend_byte();
-                            }),
-                            _ => {
-                                // descend all active in the frontier
-                                for_each_bit(frontier, |i| zs[i].descend_to_byte(a));
-
-                                // recursive call with SAME array, smaller mask
-                                zipper_merge_n_mono::<P, V, Out, A, N>(zs, frontier, out);
-
-                                //ascend
-                                for_each_bit(frontier, |i| {
-                                    zs[i].ascend_byte();
-                                });
+                    let cnt = frontier.count_ones();
+                    // - Case B: singleton (|frontier| = 1)
+                    if (cnt == 1) {
+                        let i = frontier.trailing_zeros() as usize;
+                        match next {
+                            None => {
+                                P::on_single(&mut zs[i], frontier, ByteMask::from_range(a..), out);
+                                break 'merge_level;
+                            }
+                            Some(b) => {
+                                P::on_single(&mut zs[i], frontier, ByteMask::from_range(a..b), out);
+                                // advance
+                                idxs[i] = masks[i].index_of(b);
                             }
                         }
+                    } else {
+                        // - Case C: subset (1 < k < N)
+                        if P::descend_on_some_equal(frontier) {
+                            out.descend_to_byte(a);
+                            match cnt {
+                                2 => with_k::<2, _, _>(zs, frontier, |[lhs, rhs]| {
+                                    lhs.descend_to_byte(a);
+                                    rhs.descend_to_byte(a);
 
-                        out.ascend_byte();
+                                    zipper_merge::<P, _, _, _, _, _>(lhs, rhs, out);
+
+                                    rhs.ascend_byte();
+                                    lhs.ascend_byte();
+                                }),
+                                3 => with_k::<3, _, _>(zs, frontier, |[lhs, mid, rhs]| {
+                                    lhs.descend_to_byte(a);
+                                    mid.descend_to_byte(a);
+                                    rhs.descend_to_byte(a);
+
+                                    zipper_merge3::<P, _, _, _, _, _, _>(lhs, mid, rhs, out);
+
+                                    rhs.ascend_byte();
+                                    mid.ascend_byte();
+                                    lhs.ascend_byte();
+                                }),
+                                4 => with_k::<4, _, _>(zs, frontier, |[z0, z1, z2, z3]| {
+                                    z0.descend_to_byte(a);
+                                    z1.descend_to_byte(a);
+                                    z2.descend_to_byte(a);
+                                    z3.descend_to_byte(a);
+
+                                    zipper_merge4::<P, _, _, _, _, _, _, _>(z0, z1, z2, z3, out);
+
+                                    z3.ascend_byte();
+                                    z2.ascend_byte();
+                                    z1.ascend_byte();
+                                    z0.ascend_byte();
+                                }),
+                                _ => {
+                                    // descend all active in the frontier
+                                    for_each_bit(frontier, |i| zs[i].descend_to_byte(a));
+
+                                    // recursive call with SAME array, smaller mask
+                                    zipper_merge_n_mono::<P, V, Out, A, N>(zs, frontier, out);
+
+                                    //ascend
+                                    for_each_bit(frontier, |i| {
+                                        zs[i].ascend_byte();
+                                    });
+                                }
+                            }
+
+                            out.ascend_byte();
+                        }
+
+                        // advance indices
+                        for_each_bit(frontier, |i| {
+                            idxs[i] += 1;
+                        });
                     }
-
-                    // advance indices
-                    for_each_bit(frontier, |i| {
-                        idxs[i] += 1;
-                    });
                 }
             }
         }
+
+        if (k == 0) {
+            break 'ascend;
+        }
+
+        let i0 = active.trailing_zeros() as usize;
+        let byte_from = *zs[i0].path().last().expect("non-empty path when k > 0");
+
+        // ascend
+        for_each_bit(active, |i| {
+            let mut z = &mut zs[i];
+            z.ascend_byte();
+            masks[i] = z.child_mask();
+            idxs[i] = masks[i].index_of(byte_from) + 1;
+        });
+
+        out.ascend_byte();
+        k -= 1;
     }
 }
 

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -2069,7 +2069,10 @@ mod zipper_algebra_poly {
 mod tests {
     use crate::{
         PathMap,
-        zipper::{ReadZipperUntracked, WriteZipperUntracked},
+        zipper::{
+            ReadZipperUntracked, WriteZipperUntracked, ZipperInfallibleSubtries, ZipperMoving,
+            ZipperWriting,
+        },
     };
 
     type Paths = &'static [(&'static [u8], u64)];
@@ -3528,5 +3531,128 @@ mod tests {
                 |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_subtract_n!(z0, z1, z2, z3, z4, z5 => out),
             );
         }
+    }
+
+    const FOR_MERKLEIZATION: Paths = &[
+        // X
+        (&[0b100000, 0b00, 0b0001], 1),
+        (&[0b100000, 0b00, 0b0011], 2),
+        (&[0b100000, 0b00, 0b0111], 3),
+        (&[0b100000, 0b00, 0b1111], 4),
+        (&[0b010000, 0b00, 0b0001], 1),
+        (&[0b010000, 0b00, 0b0011], 2),
+        (&[0b010000, 0b00, 0b0111], 3),
+        (&[0b010000, 0b00, 0b1111], 4),
+        // Y
+        (&[0b001000, 0b01, 0b0001], 5),
+        (&[0b001000, 0b01, 0b0011], 6),
+        (&[0b001000, 0b01, 0b0111], 7),
+        (&[0b001000, 0b01, 0b1111], 8),
+        (&[0b000100, 0b01, 0b0001], 5),
+        (&[0b000100, 0b01, 0b0011], 6),
+        (&[0b000100, 0b01, 0b0111], 7),
+        (&[0b000100, 0b01, 0b1111], 8),
+        // Z
+        (&[0b000010, 0b11, 0b0001], 9),
+        (&[0b000010, 0b11, 0b0011], 10),
+        (&[0b000010, 0b11, 0b0111], 11),
+        (&[0b000010, 0b11, 0b1111], 12),
+        (&[0b000001, 0b11, 0b0001], 9),
+        (&[0b000001, 0b11, 0b0011], 10),
+        (&[0b000001, 0b11, 0b0111], 11),
+        (&[0b000001, 0b11, 0b1111], 12),
+    ];
+
+    #[test]
+    fn test_merkleization() {
+        use crate::experimental::zipper_algebra::*;
+        use crate::{zipper_join_n, zipper_meet_n};
+
+        let mut map = PathMap::from_iter(FOR_MERKLEIZATION);
+        let merkelize_result = map.merkleize();
+        assert!(merkelize_result.reused > 0);
+
+        let mut r1 = map.read_zipper();
+        let mut r2 = map.read_zipper();
+        let mut r3 = map.read_zipper();
+        let mut r4 = map.read_zipper();
+        let mut r5 = map.read_zipper();
+        let mut r6 = map.read_zipper();
+
+        r1.descend_to_byte(0b000001);
+        r2.descend_to_byte(0b000010);
+        r3.descend_to_byte(0b000100);
+        r4.descend_to_byte(0b001000);
+        r5.descend_to_byte(0b010000);
+        r6.descend_to_byte(0b100000);
+
+        // this one simulates X \/ X, where X is shared
+        let mut result0 = PathMap::new();
+        let mut w0 = result0.write_zipper();
+        zipper_join(&mut r1, &mut r2, &mut w0);
+        let expected0: Paths = &[
+            (&[0b11, 0b0001], 9),
+            (&[0b11, 0b0011], 10),
+            (&[0b11, 0b0111], 11),
+            (&[0b11, 0b1111], 12),
+        ];
+        assert_trie(expected0, result0);
+
+        fn prefixed<V: Clone + Send + Sync + Unpin, Z: ZipperInfallibleSubtries<V>>(
+            rz: &Z,
+            path: &[u8],
+        ) -> PathMap<V> {
+            let mut res = PathMap::new();
+            let mut out = res.write_zipper_at_path(path);
+            out.graft(rz);
+            res
+        }
+
+        let mut map1 = prefixed(&mut r3, &[0]);
+        let mut map2 = prefixed(&mut r4, &[0]);
+        let mut r31 = map1.read_zipper();
+        let mut r32 = map1.read_zipper();
+        let mut r33 = map1.read_zipper();
+        let mut r41 = map2.read_zipper();
+        let mut r42 = map2.read_zipper();
+        let mut r43 = map2.read_zipper();
+
+        // this one simulates X.prefixed(0) /\ X.prefixed(0) ..., where X is shared
+        let mut result1 = PathMap::new();
+        let mut w1 = result1.write_zipper();
+        zipper_meet_n!(r31, r32, r33, r41, r42, r43 => w1);
+        let expected1: Paths = &[
+            (&[0b0, 0b01, 0b0001], 5),
+            (&[0b0, 0b01, 0b0011], 6),
+            (&[0b0, 0b01, 0b0111], 7),
+            (&[0b0, 0b01, 0b1111], 8),
+        ];
+        assert_trie(expected1, result1);
+
+        let mut map3 = prefixed(&mut r5, &[0]);
+        let mut map4 = prefixed(&mut r6, &[1]);
+        let mut r51 = map3.read_zipper();
+        let mut r52 = map3.read_zipper();
+        let mut r53 = map3.read_zipper();
+        let mut r54 = map3.read_zipper();
+        let mut r61 = map4.read_zipper();
+        let mut r62 = map4.read_zipper();
+        let mut r63 = map4.read_zipper();
+
+        // this one simulates X.prefixed(0) \/ X.prefixed(0) ... \/ X.prefixed(1) \/ ..., where X is shared
+        let mut result2 = PathMap::new();
+        let mut w2 = result2.write_zipper();
+        zipper_join_n!(r51, r52, r53, r54, r61, r62, r63 => w2);
+        let expected2: Paths = &[
+            (&[0b0, 0b00, 0b0001], 1),
+            (&[0b0, 0b00, 0b0011], 2),
+            (&[0b0, 0b00, 0b0111], 3),
+            (&[0b0, 0b00, 0b1111], 4),
+            (&[0b1, 0b00, 0b0001], 1),
+            (&[0b1, 0b00, 0b0011], 2),
+            (&[0b1, 0b00, 0b0111], 3),
+            (&[0b1, 0b00, 0b1111], 4),
+        ];
+        assert_trie(expected2, result2);
     }
 }

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -1336,10 +1336,7 @@ where
 
                         // descend and refresh masks and indices
                         for_each_bit(active, |i| {
-                            let mut z = &mut zs[i];
-                            z.descend_to_byte(a);
-                            masks[i] = z.child_mask();
-                            bytes[i] = masks[i].indexed_bit::<true>(0);
+                            zs[i].descend_to_byte(a);
                         });
 
                         // check structural sharing first
@@ -1357,6 +1354,11 @@ where
                         if let Some(v) = P::combine_n(values(zs, active)) {
                             out.set_val(v);
                         }
+
+                        for_each_bit(active, |i| {
+                            masks[i] = zs[i].child_mask();
+                            bytes[i] = masks[i].indexed_bit::<true>(0);
+                        });
 
                         k += 1;
                         continue 'merge_level;

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -1753,6 +1753,8 @@ mod tests {
     type Paths = &'static [(&'static [u8], u64)];
     type BinaryTest = (Paths, Paths);
     type TernaryTest = (Paths, Paths, Paths);
+    type NaryTest = [Paths; N];
+    const N: usize = 6;
 
     fn mk_binary_test(test: &BinaryTest) -> (PathMap<u64>, PathMap<u64>) {
         (PathMap::from_iter(test.0), PathMap::from_iter(test.1))
@@ -1764,6 +1766,10 @@ mod tests {
             PathMap::from_iter(test.1),
             PathMap::from_iter(test.2),
         )
+    }
+
+    fn mk_nary_test(test: &NaryTest) -> [PathMap<u64>; N] {
+        test.map(PathMap::from_iter)
     }
 
     fn check2<
@@ -1816,6 +1822,27 @@ mod tests {
         let mut out = result.write_zipper();
 
         op(&mut lhs, &mut mid, &mut rhs, &mut out);
+
+        assert_trie(expected, result);
+    }
+
+    fn checkn<
+        'x,
+        T: IntoIterator<Item = &'x (&'x [u8], u64)>,
+        F: for<'a> FnOnce([ReadZipperUntracked<'a, 'x, u64>; N], WriteZipperUntracked<'a, 'x, u64>),
+    >(
+        test: &NaryTest,
+        expected: T,
+        op: F,
+    ) {
+        let path_maps = mk_nary_test(test);
+
+        let mut result = PathMap::new();
+
+        op(
+            path_maps.each_ref().map(PathMap::read_zipper),
+            result.write_zipper(),
+        );
 
         assert_trie(expected, result);
     }
@@ -1883,6 +1910,45 @@ mod tests {
         ],
     );
 
+    const DISJOINT_PATHS_N: NaryTest = [
+        &[
+            (&[0x00], 0),
+            (&[0x00, 0x00], 1),
+            (&[0x00, 0x00, 0x00], 2),
+            (&[0x00, 0x00, 0x00, 0x00], 3),
+        ],
+        &[
+            (&[0xC0], 0),
+            (&[0xC0, 0x00], 1),
+            (&[0xC0, 0x00, 0x00], 2),
+            (&[0xC0, 0x00, 0x00, 0x00], 3),
+        ],
+        &[
+            (&[0xD0], 0),
+            (&[0xD0, 0x00], 1),
+            (&[0xD0, 0x00, 0x00], 2),
+            (&[0xD0, 0x00, 0x00, 0x00], 3),
+        ],
+        &[
+            (&[0xE0], 0),
+            (&[0xE0, 0x00], 1),
+            (&[0xE0, 0x00, 0x00], 2),
+            (&[0xE0, 0x00, 0x00, 0x00], 3),
+        ],
+        &[
+            (&[0xF0], 0),
+            (&[0xF0, 0x00], 1),
+            (&[0xF0, 0x00, 0x00], 2),
+            (&[0xF0, 0x00, 0x00, 0x00], 3),
+        ],
+        &[
+            (&[0xFF], 0),
+            (&[0xFF, 0x00], 1),
+            (&[0xFF, 0x00, 0x00], 2),
+            (&[0xFF, 0x00, 0x00, 0x00], 3),
+        ],
+    ];
+
     const PATHS_WITH_SHARED_PREFIX: BinaryTest = (
         &[(b"aaaaa0", 0), (b"bbbbbbbb0", 1)],
         &[(b"aaaaa1", 0), (b"bbbbb1", 1), (b"bbbbbbbb1", 2)],
@@ -1894,6 +1960,15 @@ mod tests {
         &[(b"aaaaa2", 0), (b"bbbbb2", 1), (b"bbbbbbbb2", 2)],
     );
 
+    const PATHS_WITH_SHARED_PREFIX_N: NaryTest = [
+        &[(b"aaaaa0", 0), (b"bbbbbbbb0", 1)],
+        &[(b"aaaaa1", 0), (b"bbbbb1", 1), (b"bbbbbbbb1", 2)],
+        &[(b"aaaaa2", 0), (b"bbbbb2", 1), (b"bbbbbbbb2", 2)],
+        &[(b"aaaaa3", 0), (b"bbbbb3", 1), (b"bbbbbbbb3", 2)],
+        &[(b"aaaaa4", 0), (b"bbbbb4", 1), (b"bbbbbbbb4", 2)],
+        &[(b"aaaaa5", 0), (b"bbbbb5", 1), (b"bbbbbbbb5", 2)],
+    ];
+
     const INTERLEAVING_PATHS: BinaryTest = (
         &[(&[0], 0), (&[2], 1), (&[4], 2), (&[6], 3)],
         &[(&[1], 0), (&[3], 1), (&[5], 2), (&[7], 3)],
@@ -1904,6 +1979,15 @@ mod tests {
         &[(&[1], 0), (&[4], 1), (&[7], 2), (&[10], 3)],
         &[(&[2], 0), (&[5], 1), (&[8], 2), (&[11], 3)],
     );
+
+    const INTERLEAVING_PATHS_N: NaryTest = [
+        &[(&[0], 0), (&[6], 1), (&[12], 2), (&[18], 3)],
+        &[(&[1], 0), (&[7], 1), (&[13], 2), (&[19], 3)],
+        &[(&[2], 0), (&[8], 1), (&[14], 2), (&[20], 3)],
+        &[(&[3], 0), (&[9], 1), (&[15], 2), (&[21], 3)],
+        &[(&[4], 0), (&[10], 1), (&[16], 2), (&[22], 3)],
+        &[(&[5], 0), (&[11], 1), (&[17], 2), (&[23], 3)],
+    ];
 
     const ONE_SIDED_PATHS: BinaryTest = (
         &[
@@ -1945,6 +2029,30 @@ mod tests {
         ],
         &[(&[0x00], 0), (&[0x00, 0x01, 0x02], 1)],
     );
+
+    const ONE_SIDED_PATHS_N: NaryTest = [
+        &[
+            (&[0x00], 0),
+            (&[0x00, 0x01], 1),
+            (&[0x00, 0x01, 0x02], 2),
+            (&[0x00, 0x01, 0x02, 0x03], 3),
+            (&[0x01], 4),
+            (&[0x01, 0x02], 5),
+            (&[0x01, 0x02, 0x03], 6),
+            (&[0x01, 0x02, 0x03, 0x04], 7),
+            (&[0x01, 0x02, 0x03, 0x04, 0x05], 8),
+            (&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06], 9),
+        ],
+        &[
+            (&[0x00], 0),
+            (&[0x00, 0x01, 0x02, 0x03], 1),
+            (&[0x01, 0x02, 0x03, 0x04, 0x05], 2),
+        ],
+        &[(&[0x00], 0), (&[0x00, 0x01, 0x02], 1)],
+        &[(&[0x01], 4)],
+        &[(&[0x01], 4), (&[0x01, 0x02], 5)],
+        &[(&[0x01], 4), (&[0x01, 0x02, 0x03], 5)],
+    ];
 
     const ALMOST_IDENTICAL_PATHS: BinaryTest = (
         &[
@@ -2003,13 +2111,94 @@ mod tests {
         ],
     );
 
+    const ALMOST_IDENTICAL_PATHS_N: NaryTest = [
+        &[
+            (b"abcdefg", 0),
+            (b"hijklmnop", 1),
+            (b"qrstuwvxyz", 2),
+            (b"0", 3),
+            (b"1", 4),
+            (b"2", 5),
+            (b"3", 6),
+            (b"4", 7),
+            (b"5", 8),
+            (b"6789", 9),
+        ],
+        &[
+            (b"abcdefg", 0),
+            (b"qrstuwvxyz", 2),
+            (b"0", 3),
+            (b"1", 4),
+            (b"4", 7),
+            (b"5", 8),
+            (b"6789", 9),
+        ],
+        &[
+            (b"abcdefg", 0),
+            (b"hijklmnop", 1),
+            (b"1", 4),
+            (b"2", 5),
+            (b"3", 6),
+            (b"4", 7),
+            (b"5", 8),
+        ],
+        &[
+            (b"hijklmnop", 1),
+            (b"1", 4),
+            (b"2", 5),
+            (b"3", 6),
+            (b"4", 7),
+            (b"5", 8),
+        ],
+        &[
+            (b"hijklmnop", 1),
+            (b"1", 4),
+            (b"2", 5),
+            (b"3", 6),
+            (b"4", 7),
+            (b"5", 8),
+        ],
+        &[
+            (b"hijklmnop", 1),
+            (b"1", 4),
+            (b"2", 5),
+            (b"3", 6),
+            (b"4", 7),
+            (b"5", 8),
+        ],
+    ];
+
     const LHS_EMPTY: BinaryTest = (&[], &[(&[1], 0), (&[2], 1)]);
     const LHS_EMPTY_3: TernaryTest = (&[], &[(&[1], 0), (&[2], 1)], &[(&[3], 0), (&[4], 1)]);
+    const LHS_EMPTY_N: NaryTest = [
+        &[],
+        &[(&[1], 0), (&[2], 1)],
+        &[(&[3], 0), (&[4], 1)],
+        &[(&[5], 0)],
+        &[(&[6], 0)],
+        &[(&[7], 0), (&[8], 1)],
+    ];
 
     const RHS_EMPTY: BinaryTest = (&[(&[1], 0), (&[2], 1)], &[]);
     const RHS_EMPTY_3: TernaryTest = (&[(&[1], 0), (&[2], 1)], &[(&[3], 0), (&[4], 1)], &[]);
+    const RHS_EMPTY_N: NaryTest = [
+        &[(&[1], 0), (&[2], 1)],
+        &[(&[3], 0), (&[4], 1)],
+        &[(&[5], 0)],
+        &[(&[6], 0)],
+        &[(&[7], 0), (&[8], 1)],
+        &[],
+    ];
 
     const MID_EMPTY: TernaryTest = (&[(&[1], 0), (&[2], 1)], &[], &[(&[3], 0), (&[4], 1)]);
+    const MID_EMPTY_N: NaryTest = [
+        &[(&[1], 0), (&[2], 1)],
+        &[(&[3], 0), (&[4], 1)],
+        &[],
+        &[(&[5], 0)],
+        &[(&[6], 0)],
+        &[(&[7], 0), (&[8], 1)],
+    ];
 
     const PATHS_WITH_SAME_PREFIX_DIFFERENT_CHILDREN: BinaryTest = (
         &[
@@ -2041,6 +2230,39 @@ mod tests {
             (&[1, 2, 3, 10, 11, 1], 22),
         ],
     );
+
+    const PATHS_WITH_SAME_PREFIX_DIFFERENT_CHILDREN_N: NaryTest = [
+        &[
+            (&[1, 2, 3], 0),
+            (&[1, 2, 3, 4], 1),
+            (&[1, 2, 3, 10, 11, 12], 2),
+        ],
+        &[
+            (&[1, 2, 3], 10),
+            (&[1, 2, 3, 5], 11),
+            (&[1, 2, 3, 10, 11, 0], 12),
+        ],
+        &[
+            (&[1, 2, 3], 20),
+            (&[1, 2, 3, 6], 21),
+            (&[1, 2, 3, 10, 11, 1], 22),
+        ],
+        &[
+            (&[1, 2, 3], 30),
+            (&[1, 2, 3, 7], 31),
+            (&[1, 2, 3, 10, 11, 2], 32),
+        ],
+        &[
+            (&[1, 2, 3], 40),
+            (&[1, 2, 3, 8], 41),
+            (&[1, 2, 3, 10, 11, 3], 42),
+        ],
+        &[
+            (&[1, 2, 3], 50),
+            (&[1, 2, 3, 9], 51),
+            (&[1, 2, 3, 10, 11, 4], 52),
+        ],
+    ];
 
     const ZIGZAG_PATHS: BinaryTest = (
         &[
@@ -2099,9 +2321,21 @@ mod tests {
         &[(&[], 3), (&[1], 30)],
     );
 
+    const PATHS_WITH_ROOT_VALS_AND_CHILDREN_N: NaryTest = [
+        &[(&[], 1), (&[1], 10), (&[2], 110)],
+        &[(&[], 2), (&[1], 20), (&[2], 120)],
+        &[(&[], 3), (&[1], 30), (&[2], 130)],
+        &[(&[], 4), (&[1], 40), (&[2], 140)],
+        &[(&[], 5), (&[1], 50), (&[2], 150)],
+        &[(&[], 6), (&[1], 60), (&[2], 160)],
+    ];
+
     mod join {
         use super::*;
-        use crate::experimental::zipper_algebra::{ZipperAlgebraExt, zipper_join, zipper_join3};
+        use crate::experimental::zipper_algebra::{
+            ZipperAlgebraExt, ZipperMergeF, zipper_join, zipper_join3,
+        };
+        use crate::zipper_join_n;
 
         #[test]
         fn test_disjoint() {
@@ -2118,6 +2352,23 @@ mod tests {
                 &DISJOINT_PATHS_3,
                 &[DISJOINT_PATHS_3.0, DISJOINT_PATHS_3.1, DISJOINT_PATHS_3.2].concat(),
                 |lhs, mid, rhs, out| zipper_join3(lhs, mid, rhs, out),
+            );
+        }
+
+        #[test]
+        fn test_disjoint_n() {
+            checkn(
+                &DISJOINT_PATHS_N,
+                &[
+                    DISJOINT_PATHS_N[0],
+                    DISJOINT_PATHS_N[1],
+                    DISJOINT_PATHS_N[2],
+                    DISJOINT_PATHS_N[3],
+                    DISJOINT_PATHS_N[4],
+                    DISJOINT_PATHS_N[5],
+                ]
+                .concat(),
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_join_n!(z0, z1, z2, z3, z4, z5 => out),
             );
         }
 
@@ -2145,6 +2396,23 @@ mod tests {
         }
 
         #[test]
+        fn test_deep_shared_prefix_then_split_n() {
+            checkn(
+                &PATHS_WITH_SHARED_PREFIX_N,
+                &[
+                    PATHS_WITH_SHARED_PREFIX_N[0],
+                    PATHS_WITH_SHARED_PREFIX_N[1],
+                    PATHS_WITH_SHARED_PREFIX_N[2],
+                    PATHS_WITH_SHARED_PREFIX_N[3],
+                    PATHS_WITH_SHARED_PREFIX_N[4],
+                    PATHS_WITH_SHARED_PREFIX_N[5],
+                ]
+                .concat(),
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_join_n!(z0, z1, z2, z3, z4, z5 => out),
+            );
+        }
+
+        #[test]
         fn test_interleaving_paths() {
             check2(
                 &INTERLEAVING_PATHS,
@@ -2168,6 +2436,23 @@ mod tests {
         }
 
         #[test]
+        fn test_interleaving_paths_n() {
+            checkn(
+                &INTERLEAVING_PATHS_N,
+                &[
+                    INTERLEAVING_PATHS_N[0],
+                    INTERLEAVING_PATHS_N[1],
+                    INTERLEAVING_PATHS_N[2],
+                    INTERLEAVING_PATHS_N[3],
+                    INTERLEAVING_PATHS_N[4],
+                    INTERLEAVING_PATHS_N[5],
+                ]
+                .concat(),
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_join_n!(z0, z1, z2, z3, z4, z5 => out),
+            );
+        }
+
+        #[test]
         fn test_one_side_empty_at_many_levels() {
             check2(&ONE_SIDED_PATHS, ONE_SIDED_PATHS.0, |lhs, rhs, out| {
                 lhs.join(rhs, out)
@@ -2180,6 +2465,15 @@ mod tests {
                 &ONE_SIDED_PATHS_3,
                 ONE_SIDED_PATHS_3.0,
                 |lhs, mid, rhs, out| zipper_join3(lhs, mid, rhs, out),
+            );
+        }
+
+        #[test]
+        fn test_one_side_empty_at_many_levels_n() {
+            checkn(
+                &ONE_SIDED_PATHS_N,
+                ONE_SIDED_PATHS_N[0],
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_join_n!(z0, z1, z2, z3, z4, z5 => out),
             );
         }
 
@@ -2198,6 +2492,15 @@ mod tests {
                 &ALMOST_IDENTICAL_PATHS_3,
                 ALMOST_IDENTICAL_PATHS_3.0,
                 |lhs, mid, rhs, out| zipper_join3(lhs, mid, rhs, out),
+            );
+        }
+
+        #[test]
+        fn test_almost_identical_paths_n() {
+            checkn(
+                &ALMOST_IDENTICAL_PATHS_N,
+                ALMOST_IDENTICAL_PATHS_N[0],
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_join_n!(z0, z1, z2, z3, z4, z5 => out),
             );
         }
 
@@ -2223,6 +2526,46 @@ mod tests {
                 &RHS_EMPTY_3,
                 &[RHS_EMPTY_3.0, RHS_EMPTY_3.1].concat(),
                 |lhs, mid, rhs, out| zipper_join3(lhs, mid, rhs, out),
+            );
+        }
+
+        #[test]
+        fn test_one_side_empty_n() {
+            checkn(
+                &LHS_EMPTY_N,
+                &[
+                    LHS_EMPTY_N[1],
+                    LHS_EMPTY_N[2],
+                    LHS_EMPTY_N[3],
+                    LHS_EMPTY_N[4],
+                    LHS_EMPTY_N[5],
+                ]
+                .concat(),
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_join_n!(z0, z1, z2, z3, z4, z5 => out),
+            );
+            checkn(
+                &MID_EMPTY_N,
+                &[
+                    MID_EMPTY_N[0],
+                    MID_EMPTY_N[1],
+                    MID_EMPTY_N[3],
+                    MID_EMPTY_N[4],
+                    MID_EMPTY_N[5],
+                ]
+                .concat(),
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_join_n!(z0, z1, z2, z3, z4, z5 => out),
+            );
+            checkn(
+                &RHS_EMPTY_N,
+                &[
+                    RHS_EMPTY_N[0],
+                    RHS_EMPTY_N[1],
+                    RHS_EMPTY_N[2],
+                    RHS_EMPTY_N[3],
+                    RHS_EMPTY_N[4],
+                ]
+                .concat(),
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_join_n!(z0, z1, z2, z3, z4, z5 => out),
             );
         }
 
@@ -2261,6 +2604,30 @@ mod tests {
         }
 
         #[test]
+        fn test_exact_overlap_divergent_subtries_n() {
+            let expected: Paths = &[
+                (&[1, 2, 3], 0),
+                (&[1, 2, 3, 4], 1),
+                (&[1, 2, 3, 5], 11),
+                (&[1, 2, 3, 6], 21),
+                (&[1, 2, 3, 7], 31),
+                (&[1, 2, 3, 8], 41),
+                (&[1, 2, 3, 9], 51),
+                (&[1, 2, 3, 10, 11, 0], 12),
+                (&[1, 2, 3, 10, 11, 1], 22),
+                (&[1, 2, 3, 10, 11, 2], 32),
+                (&[1, 2, 3, 10, 11, 3], 42),
+                (&[1, 2, 3, 10, 11, 4], 52),
+                (&[1, 2, 3, 10, 11, 12], 2),
+            ];
+            checkn(
+                &PATHS_WITH_SAME_PREFIX_DIFFERENT_CHILDREN_N,
+                expected,
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_join_n!(z0, z1, z2, z3, z4, z5 => out),
+            );
+        }
+
+        #[test]
         fn test_zigzag() {
             check2(
                 &ZIGZAG_PATHS,
@@ -2273,7 +2640,7 @@ mod tests {
         fn test_zigzag3() {
             check3(
                 &ZIGZAG_PATHS_3,
-                &[ZIGZAG_PATHS.0, ZIGZAG_PATHS.1, ZIGZAG_PATHS_3.2].concat(),
+                &[ZIGZAG_PATHS_3.0, ZIGZAG_PATHS_3.1, ZIGZAG_PATHS_3.2].concat(),
                 |lhs, mid, rhs, out| zipper_join3(lhs, mid, rhs, out),
             );
         }
@@ -2295,11 +2662,23 @@ mod tests {
                 |lhs, mid, rhs, out| zipper_join3(lhs, mid, rhs, out),
             );
         }
+
+        #[test]
+        fn test_root_values_n() {
+            checkn(
+                &PATHS_WITH_ROOT_VALS_AND_CHILDREN_N,
+                PATHS_WITH_ROOT_VALS_AND_CHILDREN_N[0],
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_join_n!(z0, z1, z2, z3, z4, z5 => out),
+            );
+        }
     }
 
     mod meet {
         use super::*;
-        use crate::experimental::zipper_algebra::{ZipperAlgebraExt, zipper_meet, zipper_meet3};
+        use crate::experimental::zipper_algebra::{
+            ZipperAlgebraExt, ZipperMergeF, zipper_meet, zipper_meet3,
+        };
+        use crate::zipper_meet_n;
 
         #[test]
         fn test_disjoint() {
@@ -2313,6 +2692,15 @@ mod tests {
             check3(&DISJOINT_PATHS_3, [], |lhs, mid, rhs, out| {
                 zipper_meet3(lhs, mid, rhs, out);
             });
+        }
+
+        #[test]
+        fn test_disjoint_n() {
+            checkn(
+                &DISJOINT_PATHS_N,
+                [],
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_meet_n!(z0, z1, z2, z3, z4, z5 => out),
+            );
         }
 
         #[test]
@@ -2330,6 +2718,15 @@ mod tests {
         }
 
         #[test]
+        fn test_deep_shared_prefix_then_split_n() {
+            checkn(
+                &PATHS_WITH_SHARED_PREFIX_N,
+                [],
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_meet_n!(z0, z1, z2, z3, z4, z5 => out),
+            );
+        }
+
+        #[test]
         fn test_interleaving_paths() {
             check2(&INTERLEAVING_PATHS, [], |lhs, rhs, out| {
                 lhs.meet(rhs, out);
@@ -2341,6 +2738,15 @@ mod tests {
             check3(&INTERLEAVING_PATHS_3, [], |lhs, mid, rhs, out| {
                 zipper_meet3(lhs, mid, rhs, out);
             });
+        }
+
+        #[test]
+        fn test_interleaving_paths_n() {
+            checkn(
+                &INTERLEAVING_PATHS_N,
+                [],
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_meet_n!(z0, z1, z2, z3, z4, z5 => out),
+            );
         }
 
         #[test]
@@ -2364,6 +2770,15 @@ mod tests {
         }
 
         #[test]
+        fn test_one_side_empty_at_many_levels_n() {
+            checkn(
+                &ONE_SIDED_PATHS_N,
+                [],
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_meet_n!(z0, z1, z2, z3, z4, z5 => out),
+            );
+        }
+
+        #[test]
         fn test_almost_identical_paths() {
             check2(
                 &ALMOST_IDENTICAL_PATHS,
@@ -2378,6 +2793,16 @@ mod tests {
             check3(&ALMOST_IDENTICAL_PATHS_3, expected, |lhs, mid, rhs, out| {
                 zipper_meet3(lhs, mid, rhs, out);
             });
+        }
+
+        #[test]
+        fn test_almost_identical_paths_n() {
+            let expected: Paths = &[(b"1", 4), (b"4", 7), (b"5", 8)];
+            checkn(
+                &ALMOST_IDENTICAL_PATHS_N,
+                expected,
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_meet_n!(z0, z1, z2, z3, z4, z5 => out),
+            );
         }
 
         #[test]
@@ -2400,6 +2825,25 @@ mod tests {
         }
 
         #[test]
+        fn test_one_side_empty_n() {
+            checkn(
+                &LHS_EMPTY_N,
+                [],
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_meet_n!(z0, z1, z2, z3, z4, z5 => out),
+            );
+            checkn(
+                &MID_EMPTY_N,
+                [],
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_meet_n!(z0, z1, z2, z3, z4, z5 => out),
+            );
+            checkn(
+                &RHS_EMPTY_N,
+                [],
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_meet_n!(z0, z1, z2, z3, z4, z5 => out),
+            );
+        }
+
+        #[test]
         fn test_exact_overlap_divergent_subtries() {
             let expected: Paths = &[(&[1, 2, 3], 0)];
             check2(
@@ -2416,6 +2860,16 @@ mod tests {
                 &PATHS_WITH_SAME_PREFIX_DIFFERENT_CHILDREN_3,
                 expected,
                 |lhs, mid, rhs, out| zipper_meet3(lhs, mid, rhs, out),
+            );
+        }
+
+        #[test]
+        fn test_exact_overlap_divergent_subtries_n() {
+            let expected: Paths = &[(&[1, 2, 3], 0)];
+            checkn(
+                &PATHS_WITH_SAME_PREFIX_DIFFERENT_CHILDREN_N,
+                expected,
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_meet_n!(z0, z1, z2, z3, z4, z5 => out),
             );
         }
 
@@ -2452,13 +2906,23 @@ mod tests {
                 |lhs, mid, rhs, out| zipper_meet3(lhs, mid, rhs, out),
             );
         }
+
+        #[test]
+        fn test_root_values_n() {
+            checkn(
+                &PATHS_WITH_ROOT_VALS_AND_CHILDREN_N,
+                PATHS_WITH_ROOT_VALS_AND_CHILDREN_N[0],
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_meet_n!(z0, z1, z2, z3, z4, z5 => out),
+            );
+        }
     }
 
     mod subtract {
         use super::*;
         use crate::experimental::zipper_algebra::{
-            ZipperAlgebraExt, zipper_subtract, zipper_subtract3,
+            ZipperAlgebraExt, ZipperMergeF, zipper_subtract, zipper_subtract3,
         };
+        use crate::zipper_subtract_n;
 
         #[test]
         fn test_disjoint() {
@@ -2475,6 +2939,15 @@ mod tests {
                 |lhs, mid, rhs, out| {
                     zipper_subtract3(lhs, mid, rhs, out);
                 },
+            );
+        }
+
+        #[test]
+        fn test_disjoint_n() {
+            checkn(
+                &DISJOINT_PATHS_N,
+                DISJOINT_PATHS_N[0],
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_subtract_n!(z0, z1, z2, z3, z4, z5 => out),
             );
         }
 
@@ -2499,6 +2972,15 @@ mod tests {
         }
 
         #[test]
+        fn test_deep_shared_prefix_then_split_n() {
+            checkn(
+                &PATHS_WITH_SHARED_PREFIX_N,
+                PATHS_WITH_SHARED_PREFIX_N[0],
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_subtract_n!(z0, z1, z2, z3, z4, z5 => out),
+            );
+        }
+
+        #[test]
         fn test_interleaving_paths() {
             check2(
                 &INTERLEAVING_PATHS,
@@ -2515,6 +2997,15 @@ mod tests {
                 |lhs, mid, rhs, out| {
                     zipper_subtract3(lhs, mid, rhs, out);
                 },
+            );
+        }
+
+        #[test]
+        fn test_interleaving_paths_n() {
+            checkn(
+                &INTERLEAVING_PATHS_N,
+                INTERLEAVING_PATHS_N[0],
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_subtract_n!(z0, z1, z2, z3, z4, z5 => out),
             );
         }
 
@@ -2555,6 +3046,24 @@ mod tests {
         }
 
         #[test]
+        fn test_one_side_empty_at_many_levels_n() {
+            let expected: Paths = &[
+                (&[0x00, 0x01], 1),
+                (&[0x00, 0x01, 0x02], 2),
+                (&[0x00, 0x01, 0x02, 0x03], 3),
+                (&[0x01, 0x02, 0x03], 6),
+                (&[0x01, 0x02, 0x03, 0x04], 7),
+                (&[0x01, 0x02, 0x03, 0x04, 0x05], 8),
+                (&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06], 9),
+            ];
+            checkn(
+                &ONE_SIDED_PATHS_N,
+                expected,
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_subtract_n!(z0, z1, z2, z3, z4, z5 => out),
+            );
+        }
+
+        #[test]
         fn test_almost_identical_paths() {
             let expected: Paths = &[(b"hijklmnop", 1), (b"2", 5), (b"3", 6)];
             check2(&ALMOST_IDENTICAL_PATHS, expected, |lhs, rhs, out| {
@@ -2567,6 +3076,15 @@ mod tests {
             check3(&ALMOST_IDENTICAL_PATHS_3, [], |lhs, mid, rhs, out| {
                 zipper_subtract3(lhs, mid, rhs, out);
             });
+        }
+
+        #[test]
+        fn test_almost_identical_paths_n() {
+            checkn(
+                &ALMOST_IDENTICAL_PATHS_N,
+                [],
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_subtract_n!(z0, z1, z2, z3, z4, z5 => out),
+            );
         }
 
         #[test]
@@ -2591,6 +3109,25 @@ mod tests {
         }
 
         #[test]
+        fn test_one_side_empty_n() {
+            checkn(
+                &LHS_EMPTY_N,
+                [],
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_subtract_n!(z0, z1, z2, z3, z4, z5 => out),
+            );
+            checkn(
+                &MID_EMPTY_N,
+                MID_EMPTY_N[0],
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_subtract_n!(z0, z1, z2, z3, z4, z5 => out),
+            );
+            checkn(
+                &RHS_EMPTY_N,
+                RHS_EMPTY_N[0],
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_subtract_n!(z0, z1, z2, z3, z4, z5 => out),
+            );
+        }
+
+        #[test]
         fn test_exact_overlap_divergent_subtries() {
             check2(
                 &PATHS_WITH_SAME_PREFIX_DIFFERENT_CHILDREN,
@@ -2607,6 +3144,15 @@ mod tests {
                 |lhs, mid, rhs, out| {
                     zipper_subtract3(lhs, mid, rhs, out);
                 },
+            );
+        }
+
+        #[test]
+        fn test_exact_overlap_divergent_subtries_n() {
+            checkn(
+                &PATHS_WITH_SAME_PREFIX_DIFFERENT_CHILDREN_N,
+                PATHS_WITH_SAME_PREFIX_DIFFERENT_CHILDREN_N[0],
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_subtract_n!(z0, z1, z2, z3, z4, z5 => out),
             );
         }
 
@@ -2649,6 +3195,15 @@ mod tests {
                 |lhs, mid, rhs, out| {
                     zipper_subtract3(lhs, mid, rhs, out);
                 },
+            );
+        }
+
+        #[test]
+        fn test_root_values_n() {
+            checkn(
+                &PATHS_WITH_ROOT_VALS_AND_CHILDREN_N,
+                PATHS_WITH_ROOT_VALS_AND_CHILDREN_N[0],
+                |[mut z0, mut z1, mut z2, mut z3, mut z4, mut z5], mut out| zipper_subtract_n!(z0, z1, z2, z3, z4, z5 => out),
             );
         }
     }

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -1,13 +1,8 @@
-use pathmap_derive::PolyZipperExplicit;
-
 use crate::{
     alloc::{Allocator, GlobalAlloc},
     ring::{AlgebraicResult, COUNTER_IDENT, DistributiveLattice, Lattice, SELF_IDENT},
     utils::ByteMask,
-    zipper::{
-        ReadZipperTracked, ReadZipperUntracked, Zipper, ZipperInfallibleSubtries, ZipperMoving,
-        ZipperValues, ZipperWriting,
-    },
+    zipper::*,
 };
 
 pub use zipper_algebra_poly::ZipperMergeF;
@@ -930,21 +925,136 @@ fn zipper_merge4<P, V, Z0, Z1, Z2, Z3, Out, A>(
     }
 }
 
-use zipper_algebra_poly::SomeMutRefZ as Z;
+/// Performs an ordered N-way join (least upper bound) of radix-256 trie zippers.
+///
+/// This function merges `N` tries by traversing them simultaneously in lexicographic
+/// order, using a zipper-based depth-first traversal. At each node, child edges are
+/// treated as sorted streams and merged via a frontier-based strategy:
+///
+/// - Edges present in only one input are grafted directly,
+/// - Shared edges trigger descent and recursive merging,
+/// - Fully shared edges use a fast-path descent without recursion.
+///
+/// Values are combined using the lattice join (`∨`).
+///
+/// # Complexity
+///
+/// Let:
+/// - `h` be the maximum key length,
+/// - `f` be the total frontier size across levels,
+/// - `n` be the size of overlapping structure.
+///
+/// Then:
+///
+/// - Best case (disjoint): **O(h)**
+/// - Typical: **O(h + f)**
+/// - Worst case (fully overlapping): **O(n)**
+///
+/// # Notes
+///
+/// This is the most general and least pruning-friendly variant:
+/// joins preserve information, so most structure must be visited.
+///
+pub fn zipper_n_join<V, Z, Out, A, const N: usize>(zs: &mut [Z; N], out: &mut Out)
+where
+    V: Lattice + Clone + Send + Sync + Unpin,
+    Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    Out: ZipperWriting<V, A>,
+    A: Allocator,
+{
+    zipper_merge_n_mono::<Join, _, _, _, _, _>(zs, (1 << N) - 1, out);
+}
 
-// - The function is fully monomorphized over `N` and uses a bitmask (`active`)
+/// Performs an ordered N-way meet (greatest lower bound) of radix-256 trie zippers.
+///
+/// Only keys present in *all* input tries are retained. Traversal is aggressively
+/// pruned: any branch missing from even one input is discarded without descent.
+///
+/// Values are combined using the lattice meet (`∧`) with the convention that `None ∧ x = None`.
+///
+/// # Complexity
+///
+/// Let:
+/// - `h` be the maximum key length,
+/// - `d` be the size of the common intersection.
+///
+/// Then:
+///
+/// - Typical: **O(h + d)**
+/// - Often much smaller than join due to early annihilation of branches.
+///
+/// # Notes
+///
+/// Compared to join, meet is typically **asymptotically faster** on sparse or
+/// partially overlapping inputs, since entire subtries are skipped as soon as
+/// any participant is missing.
+///
+/// In practice, this behaves like intersecting sorted trees with short-circuiting.
+///
+pub fn zipper_n_meet<V, Z, Out, A, const N: usize>(zs: &mut [Z; N], out: &mut Out)
+where
+    V: Lattice + Clone + Send + Sync + Unpin,
+    Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    Out: ZipperWriting<V, A>,
+    A: Allocator,
+{
+    zipper_merge_n_mono::<Meet, _, _, _, _, _>(zs, (1 << N) - 1, out);
+}
+
+/// Performs a left-associative N-way subtraction of radix-256 trie zippers.
+///
+/// Only the leftmost zipper contributes structure; subsequent zippers remove
+/// values and subtries according to lattice subtraction semantics.
+///
+/// - Left-only branches are grafted directly,
+/// - Right-only branches are ignored,
+/// - Shared structure triggers descent when required by the policy.
+///
+/// Values are combined via using distributive
+/// subtraction.
+///
+/// # Complexity
+///
+/// Let:
+/// - `h` be the maximum key length,
+/// - `l` be the size of the left-hand trie,
+/// - `d` be the overlapping portion.
+///
+/// Then:
+///
+/// - Typical: **O(h + l)**
+/// - Often significantly faster than join, since traversal is guided primarily
+///   by the left-hand structure.
+///
+/// # Notes
+///
+/// Subtraction is **structurally biased** toward the leftmost input and benefits
+/// from early pruning when right-hand operands eliminate branches.
+///
+/// This makes it particularly efficient for difference-like workloads,
+/// where large portions of the right-hand tries can be skipped entirely.
+///
+pub fn zipper_n_subtract<V, Z, Out, A, const N: usize>(zs: &mut [Z; N], out: &mut Out)
+where
+    V: DistributiveLattice + Clone + Send + Sync + Unpin,
+    Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    Out: ZipperWriting<V, A>,
+    A: Allocator,
+{
+    zipper_merge_n_mono::<Subtract, _, _, _, _, _>(zs, (1 << N) - 1, out);
+}
+
+// - The function is fully monomorphized over `Z` and `N` and uses a bitmask (`active`)
 //   to track participating zippers.
 // - Small frontiers (`k ≤ 4`) are dispatched to specialized implementations
 //   for improved performance.
 // - Requires `N ≤ 64`.
-fn zipper_merge_n_mono<P, V, Out, A, const N: usize>(
-    zs: &mut [Z<'_, '_, '_, V, A>; N],
-    active: u64,
-    out: &mut Out,
-) where
+fn zipper_merge_n_mono<P, V, Z, Out, A, const N: usize>(zs: &mut [Z; N], active: u64, out: &mut Out)
+where
     V: Clone + Send + Sync + Unpin,
     P: MergePolicy<V> + ValuePolicy<V>,
     A: Allocator,
+    Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
     Out: ZipperWriting<V, A>,
 {
     debug_assert!(N > 0 && N <= 64);
@@ -957,26 +1067,22 @@ fn zipper_merge_n_mono<P, V, Out, A, const N: usize>(
         (0..N).filter(move |i| (active >> i) & 1 != 0)
     }
 
-    fn zippers<'a, 'trie, 'path, V, A, const N: usize>(
-        zs: &'a [Z<'a, 'trie, 'path, V, A>; N],
+    fn only_active<'a, T, const N: usize>(
+        zs: &'a [T; N],
         active: u64,
-    ) -> impl Iterator<Item = (usize, &'a Z<'a, 'trie, 'path, V, A>)>
-    where
-        V: Clone + Send + Sync + Unpin,
-        A: Allocator,
-    {
+    ) -> impl Iterator<Item = (usize, &'a T)> {
         active_bits::<N>(active).map(|i| (i, &zs[i]))
     }
 
-    fn values<'a, V, A, const N: usize>(
-        zs: &'a [Z<'a, '_, '_, V, A>; N],
+    fn values<'a, V, Z, const N: usize>(
+        zs: &'a [Z; N],
         active: u64,
     ) -> impl Iterator<Item = Option<&'a V>>
     where
-        V: Clone + Send + Sync + Unpin,
-        A: Allocator,
+        V: 'a,
+        Z: ZipperValues<V>,
     {
-        zippers(zs, active).map(|(_, z)| z.val())
+        only_active(zs, active).map(|(_, z)| z.val())
     }
 
     // small micro-helpers
@@ -1025,7 +1131,7 @@ fn zipper_merge_n_mono<P, V, Out, A, const N: usize>(
 
     let mut bytes = [None; N];
     let mut masks = [ByteMask::EMPTY; N];
-    for (i, z) in zippers(zs, active) {
+    for (i, z) in only_active(zs, active) {
         masks[i] = z.child_mask();
         bytes[i] = masks[i].indexed_bit::<true>(0);
     }
@@ -1171,7 +1277,7 @@ fn zipper_merge_n_mono<P, V, Out, A, const N: usize>(
                                     for_each_bit(frontier, |i| zs[i].descend_to_byte(a));
 
                                     // recursive call with SAME array, smaller mask
-                                    zipper_merge_n_mono::<P, V, Out, A, N>(zs, frontier, out);
+                                    zipper_merge_n_mono::<P, V, Z, Out, A, N>(zs, frontier, out);
 
                                     //ascend
                                     for_each_bit(frontier, |i| {
@@ -1472,6 +1578,7 @@ mod zipper_algebra_poly {
     use crate::ring::{DistributiveLattice, Lattice};
     use crate::trie_node::*;
     use crate::zipper::*;
+    use pathmap_derive::PolyZipperExplicit;
 
     #[derive(PolyZipperExplicit)]
     #[poly_zipper_explicit(traits(ZipperMoving, ZipperValues))]
@@ -1629,7 +1736,7 @@ mod zipper_algebra_poly {
 
                 let active: u64 = (1 << zs.len()) - 1;
 
-                super::zipper_merge_n_mono::<P, _, _, _, _>(
+                super::zipper_merge_n_mono::<P, _, SomeMutRefZ<'_, 'trie, 'path, V, A>, _, _, _>(
                     &mut zs,
                     active,
                     out,

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -1676,6 +1676,71 @@ mod zipper_algebra_poly {
         Z21, Z22, Z23, Z24, Z25, Z26, Z27, Z28, Z29, Z30, Z31, Z32
     );
 
+    /// Performs an N-ary zipper join by borrowing all inputs mutably
+    /// and forwarding them to [`ZipperMergeF::join_n`].
+    ///
+    /// # Example
+    /// ```
+    /// zipper_join_n!(z1, z2, z3 => out);
+    /// ```
+    ///
+    /// Expands roughly to:
+    /// ```ignore
+    /// (&mut z1, &mut z2, &mut z3).join_n(&mut out)
+    /// ```
+    ///
+    /// # See also
+    /// [`ZipperMergeF::join_n`]
+    #[macro_export]
+    macro_rules! zipper_join_n {
+    ( $($z:ident),+ => $out:ident ) => {{
+        ( $( &mut $z ),+ ).join_n(&mut $out)
+    }};
+}
+
+    /// Performs an N-ary zipper meet by borrowing all inputs mutably
+    /// and forwarding them to [`ZipperMergeF::meet_n`].
+    ///
+    /// # Example
+    /// ```
+    /// zipper_meet_n!(z1, z2, z3 => out);
+    /// ```
+    ///
+    /// Expands roughly to:
+    /// ```ignore
+    /// (&mut z1, &mut z2, &mut z3).meet_n(&mut out)
+    /// ```
+    ///
+    /// # See also
+    /// [`ZipperMergeF::meet_n`]
+    #[macro_export]
+    macro_rules! zipper_meet_n {
+    ( $($z:ident),+ => $out:ident ) => {{
+        ( $( &mut $z ),+ ).meet_n(&mut $out)
+    }};
+}
+
+    /// Performs an N-ary zipper subtract by borrowing all inputs mutably
+    /// and forwarding them to [`ZipperMergeF::subtract_n`].
+    ///
+    /// # Example
+    /// ```
+    /// zipper_subtract_n!(z1, z2, z3 => out);
+    /// ```
+    ///
+    /// Expands roughly to:
+    /// ```ignore
+    /// (&mut z1, &mut z2, &mut z3).subtract_n(&mut out)
+    /// ```
+    ///
+    /// # See also
+    /// [`ZipperMergeF::subtract_n`]
+    #[macro_export]
+    macro_rules! zipper_subtract_n {
+    ( $($z:ident),+ => $out:ident ) => {{
+        ( $( &mut $z ),+ ).subtract_n(&mut $out)
+    }};
+}
 }
 
 #[cfg(test)]

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -386,8 +386,8 @@ where
     let mut k = 0;
     let mut lhs_mask = lhs.child_mask();
     let mut rhs_mask = rhs.child_mask();
-    let mut lhs_idx = 0;
-    let mut rhs_idx = 0;
+    let mut lhs_next = lhs_mask.indexed_bit::<true>(0);
+    let mut rhs_next = rhs_mask.indexed_bit::<true>(0);
 
     // At each node, the algorithm treats the sets of child edges of `lhs` and `rhs` as two sorted
     // sequences and performs a merge-like traversal:
@@ -400,18 +400,15 @@ where
     //   and an explicit depth counter (`k`).
     'ascend: loop {
         'merge_level: loop {
-            let lhs_next = lhs_mask.indexed_bit::<true>(lhs_idx as usize);
-            let rhs_next = rhs_mask.indexed_bit::<true>(rhs_idx as usize);
-
             match lhs_next {
                 Some(lhs_byte) => match rhs_next {
                     Some(rhs_byte) if lhs_byte < rhs_byte => {
                         P::on_left_only(lhs, ByteMask::from_range(lhs_byte..rhs_byte), out);
-                        lhs_idx = lhs_mask.index_of(rhs_byte);
+                        lhs_next = (lhs_mask & ByteMask::from_range(rhs_byte..)).next_bit(0);
                     }
                     Some(rhs_byte) if lhs_byte > rhs_byte => {
                         P::on_right_only(rhs, ByteMask::from_range(rhs_byte..lhs_byte), out);
-                        rhs_idx = rhs_mask.index_of(lhs_byte);
+                        rhs_next = (rhs_mask & ByteMask::from_range(lhs_byte..)).next_bit(0);
                     }
                     Some(rhs_byte) => {
                         // equal → descend
@@ -427,8 +424,8 @@ where
                         lhs_mask = lhs.child_mask();
                         rhs_mask = rhs.child_mask();
 
-                        lhs_idx = 0;
-                        rhs_idx = 0;
+                        lhs_next = lhs_mask.indexed_bit::<true>(0);
+                        rhs_next = rhs_mask.indexed_bit::<true>(0);
 
                         k += 1;
                         continue 'merge_level;
@@ -457,11 +454,11 @@ where
 
         rhs.ascend_byte();
         rhs_mask = rhs.child_mask();
-        rhs_idx = rhs_mask.index_of(byte_from) + 1;
+        rhs_next = rhs_mask.next_bit(byte_from);
 
         lhs.ascend_byte();
         lhs_mask = lhs.child_mask();
-        lhs_idx = lhs_mask.index_of(byte_from) + 1;
+        lhs_next = lhs_mask.next_bit(byte_from);
 
         out.ascend_byte();
         k -= 1;
@@ -528,16 +525,12 @@ where
     let mut lhs_mask = lhs.child_mask();
     let mut mid_mask = mid.child_mask();
     let mut rhs_mask = rhs.child_mask();
-    let mut lhs_idx = 0;
-    let mut mid_idx = 0;
-    let mut rhs_idx = 0;
+    let mut l = lhs_mask.indexed_bit::<true>(0);
+    let mut m = mid_mask.indexed_bit::<true>(0);
+    let mut r = rhs_mask.indexed_bit::<true>(0);
 
     'ascend: loop {
         'merge_level: loop {
-            let l = lhs_mask.indexed_bit::<true>(lhs_idx as usize);
-            let m = mid_mask.indexed_bit::<true>(mid_idx as usize);
-            let r = rhs_mask.indexed_bit::<true>(rhs_idx as usize);
-
             let mut a = l;
             let mut b = m;
             let mut c = r;
@@ -563,7 +556,7 @@ where
                         cmp_swap(&mut b, &mut c);
                         if let Some(next) = b {
                             P::on_single(lhs, L as u64, ByteMask::from_range(min..next), out);
-                            lhs_idx = lhs_mask.index_of(next)
+                            l = (lhs_mask & ByteMask::from_range(next..)).next_bit(0);
                         } else {
                             P::on_single(lhs, L as u64, ByteMask::from_range(min..), out);
                             break 'merge_level;
@@ -573,7 +566,7 @@ where
                         cmp_swap(&mut b, &mut c);
                         if let Some(next) = b {
                             P::on_single(mid, M as u64, ByteMask::from_range(min..next), out);
-                            mid_idx = mid_mask.index_of(next);
+                            m = (mid_mask & ByteMask::from_range(next..)).next_bit(0);
                         } else {
                             P::on_single(mid, M as u64, ByteMask::from_range(min..), out);
                             break 'merge_level;
@@ -583,7 +576,7 @@ where
                         cmp_swap(&mut b, &mut c);
                         if let Some(next) = b {
                             P::on_single(rhs, R as u64, ByteMask::from_range(min..next), out);
-                            rhs_idx = rhs_mask.index_of(next);
+                            r = (rhs_mask & ByteMask::from_range(next..)).next_bit(0);
                         } else {
                             P::on_single(rhs, R as u64, ByteMask::from_range(min..), out);
                             break 'merge_level;
@@ -594,22 +587,22 @@ where
                         if P::descend_on_some_equal(LM as u64) {
                             descend2::<P, V, ZL, ZM, Out, A>(min, lhs, mid, out);
                         }
-                        lhs_idx += 1;
-                        mid_idx += 1;
+                        l = lhs_mask.next_bit(min);
+                        m = mid_mask.next_bit(min);
                     }
                     MR => {
                         if P::descend_on_some_equal(MR as u64) {
                             descend2::<P, V, ZM, ZR, Out, A>(min, mid, rhs, out);
                         }
-                        mid_idx += 1;
-                        rhs_idx += 1;
+                        m = mid_mask.next_bit(min);
+                        r = rhs_mask.next_bit(min);
                     }
                     LR => {
                         if P::descend_on_some_equal(LR as u64) {
                             descend2::<P, V, ZL, ZR, Out, A>(min, lhs, rhs, out);
                         }
-                        lhs_idx += 1;
-                        rhs_idx += 1;
+                        l = lhs_mask.next_bit(min);
+                        r = rhs_mask.next_bit(min);
                     }
                     // full 3-way
                     LMR => {
@@ -627,9 +620,9 @@ where
                         mid_mask = mid.child_mask();
                         rhs_mask = rhs.child_mask();
 
-                        lhs_idx = 0;
-                        mid_idx = 0;
-                        rhs_idx = 0;
+                        l = lhs_mask.indexed_bit::<true>(0);
+                        m = mid_mask.indexed_bit::<true>(0);
+                        r = rhs_mask.indexed_bit::<true>(0);
 
                         k += 1;
                         continue 'merge_level;
@@ -650,15 +643,15 @@ where
 
         rhs.ascend_byte();
         rhs_mask = rhs.child_mask();
-        rhs_idx = rhs_mask.index_of(byte_from) + 1;
+        r = rhs_mask.next_bit(byte_from);
 
         mid.ascend_byte();
         mid_mask = mid.child_mask();
-        mid_idx = mid_mask.index_of(byte_from) + 1;
+        m = mid_mask.next_bit(byte_from);
 
         lhs.ascend_byte();
         lhs_mask = lhs.child_mask();
-        lhs_idx = lhs_mask.index_of(byte_from) + 1;
+        l = lhs_mask.next_bit(byte_from);
 
         out.ascend_byte();
         k -= 1;
@@ -698,19 +691,14 @@ fn zipper_merge4<P, V, Z0, Z1, Z2, Z3, Out, A>(
     let mut m2 = z2.child_mask();
     let mut m3 = z3.child_mask();
 
-    let mut i0 = 0;
-    let mut i1 = 0;
-    let mut i2 = 0;
-    let mut i3 = 0;
+    let mut b0 = m0.indexed_bit::<true>(0);
+    let mut b1 = m1.indexed_bit::<true>(0);
+    let mut b2 = m2.indexed_bit::<true>(0);
+    let mut b3 = m3.indexed_bit::<true>(0);
 
     'ascend: loop {
         'merge_level: loop {
             // min selection
-            let mut b0 = m0.indexed_bit::<true>(i0 as usize);
-            let mut b1 = m1.indexed_bit::<true>(i1 as usize);
-            let mut b2 = m2.indexed_bit::<true>(i2 as usize);
-            let mut b3 = m3.indexed_bit::<true>(i3 as usize);
-
             let mut a = b0;
             let mut b = b1;
             let mut c = b2;
@@ -749,13 +737,13 @@ fn zipper_merge4<P, V, Z0, Z1, Z2, Z3, Out, A>(
                     }
 
                     m0 = z0.child_mask();
-                    i0 = 0;
+                    b0 = m0.indexed_bit::<true>(0);
                     m1 = z1.child_mask();
-                    i1 = 0;
+                    b1 = m1.indexed_bit::<true>(0);
                     m2 = z2.child_mask();
-                    i2 = 0;
+                    b2 = m2.indexed_bit::<true>(0);
                     m3 = z3.child_mask();
-                    i3 = 0;
+                    b3 = m3.indexed_bit::<true>(0);
 
                     k += 1;
                     continue 'merge_level;
@@ -771,7 +759,7 @@ fn zipper_merge4<P, V, Z0, Z1, Z2, Z3, Out, A>(
                         0b0001 => {
                             if let Some(next) = b {
                                 P::on_single(z0, 0b0001, ByteMask::from_range(min..next), out);
-                                i0 = m0.index_of(next);
+                                b0 = (m0 & ByteMask::from_range(next..)).next_bit(0);
                             } else {
                                 P::on_single(z0, 0b0001, ByteMask::from_range(min..), out);
                                 break 'merge_level;
@@ -780,7 +768,7 @@ fn zipper_merge4<P, V, Z0, Z1, Z2, Z3, Out, A>(
                         0b0010 => {
                             if let Some(next) = b {
                                 P::on_single(z1, 0b0010, ByteMask::from_range(min..next), out);
-                                i1 = m1.index_of(next);
+                                b1 = (m1 & ByteMask::from_range(next..)).next_bit(0);
                             } else {
                                 P::on_single(z1, 0b0010, ByteMask::from_range(min..), out);
                                 break 'merge_level;
@@ -789,7 +777,7 @@ fn zipper_merge4<P, V, Z0, Z1, Z2, Z3, Out, A>(
                         0b0100 => {
                             if let Some(next) = b {
                                 P::on_single(z2, 0b0100, ByteMask::from_range(min..next), out);
-                                i2 = m2.index_of(next);
+                                b2 = (m2 & ByteMask::from_range(next..)).next_bit(0);
                             } else {
                                 P::on_single(z2, 0b0100, ByteMask::from_range(min..), out);
                                 break 'merge_level;
@@ -798,7 +786,7 @@ fn zipper_merge4<P, V, Z0, Z1, Z2, Z3, Out, A>(
                         0b1000 => {
                             if let Some(next) = b {
                                 P::on_single(z3, 0b1000, ByteMask::from_range(min..next), out);
-                                i3 = m3.index_of(next);
+                                b3 = (m3 & ByteMask::from_range(next..)).next_bit(0);
                             } else {
                                 P::on_single(z3, 0b1000, ByteMask::from_range(min..), out);
                                 break 'merge_level;
@@ -893,16 +881,16 @@ fn zipper_merge4<P, V, Z0, Z1, Z2, Z3, Out, A>(
                     }
                     // then advance
                     if frontier & 0b0001 != 0 {
-                        i0 += 1;
+                        b0 = m0.next_bit(min);
                     }
                     if frontier & 0b0010 != 0 {
-                        i1 += 1;
+                        b1 = m1.next_bit(min);
                     }
                     if frontier & 0b0100 != 0 {
-                        i2 += 1;
+                        b2 = m2.next_bit(min);
                     }
                     if frontier & 0b1000 != 0 {
-                        i3 += 1;
+                        b3 = m3.next_bit(min);
                     }
                 }
             } else {
@@ -919,19 +907,19 @@ fn zipper_merge4<P, V, Z0, Z1, Z2, Z3, Out, A>(
 
         z0.ascend_byte();
         m0 = z0.child_mask();
-        i0 = m0.index_of(byte_from) + 1;
+        b0 = m0.next_bit(byte_from);
 
         z1.ascend_byte();
         m1 = z1.child_mask();
-        i1 = m1.index_of(byte_from) + 1;
+        b1 = m1.next_bit(byte_from);
 
         z2.ascend_byte();
         m2 = z2.child_mask();
-        i2 = m2.index_of(byte_from) + 1;
+        b2 = m2.next_bit(byte_from);
 
         z3.ascend_byte();
         m3 = z3.child_mask();
-        i3 = m3.index_of(byte_from) + 1;
+        b3 = m3.next_bit(byte_from);
 
         out.ascend_byte();
         k -= 1;
@@ -1031,10 +1019,11 @@ fn zipper_merge_n_mono<P, V, Out, A, const N: usize>(
         out.set_val(v);
     }
 
-    let mut idxs = [0; N];
+    let mut bytes = [None; N];
     let mut masks = [ByteMask::EMPTY; N];
     for (i, z) in zippers(zs, active) {
         masks[i] = z.child_mask();
+        bytes[i] = masks[i].indexed_bit::<true>(0);
     }
 
     // At each node, the algorithm:
@@ -1067,7 +1056,7 @@ fn zipper_merge_n_mono<P, V, Out, A, const N: usize>(
             let mut next = None;
 
             for i in active_bits::<N>(active) {
-                if let Some(b) = masks[i].indexed_bit::<true>(idxs[i] as usize) {
+                if let Some(b) = bytes[i] {
                     match min {
                         None => {
                             min = Some(b);
@@ -1109,7 +1098,7 @@ fn zipper_merge_n_mono<P, V, Out, A, const N: usize>(
                             let mut z = &mut zs[i];
                             z.descend_to_byte(a);
                             masks[i] = z.child_mask();
-                            idxs[i] = 0;
+                            bytes[i] = masks[i].indexed_bit::<true>(0);
                         });
 
                         if let Some(v) = P::combine_n(values(zs, active)) {
@@ -1132,7 +1121,7 @@ fn zipper_merge_n_mono<P, V, Out, A, const N: usize>(
                             Some(b) => {
                                 P::on_single(&mut zs[i], frontier, ByteMask::from_range(a..b), out);
                                 // advance
-                                idxs[i] = masks[i].index_of(b);
+                                bytes[i] = (masks[i] & ByteMask::from_range(b..)).next_bit(0);
                             }
                         }
                     } else {
@@ -1192,7 +1181,7 @@ fn zipper_merge_n_mono<P, V, Out, A, const N: usize>(
 
                         // advance indices
                         for_each_bit(frontier, |i| {
-                            idxs[i] += 1;
+                            bytes[i] = masks[i].next_bit(a);
                         });
                     }
                 }
@@ -1211,7 +1200,7 @@ fn zipper_merge_n_mono<P, V, Out, A, const N: usize>(
             let mut z = &mut zs[i];
             z.ascend_byte();
             masks[i] = z.child_mask();
-            idxs[i] = masks[i].index_of(byte_from) + 1;
+            bytes[i] = masks[i].next_bit(byte_from);
         });
 
         out.ascend_byte();

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -352,20 +352,24 @@ trait MergePolicy<V: Clone + Send + Sync> {
 
 trait ValuePolicy<V> {
     fn combine(l: Option<&V>, r: Option<&V>) -> Option<V>;
+    #[inline]
+    fn combine_acc(l: Option<V>, r: Option<&V>) -> Option<V> {
+        Self::combine(l.as_ref(), r)
+    }
     fn combine3(l: Option<&V>, m: Option<&V>, r: Option<&V>) -> Option<V> {
         // (l op m) op r
-        Self::combine(Self::combine(l, m).as_ref(), r)
+        Self::combine_acc(Self::combine(l, m), r)
     }
     fn combine4(a: Option<&V>, b: Option<&V>, c: Option<&V>, d: Option<&V>) -> Option<V> {
         // ((a op b) op c) op d
-        Self::combine(Self::combine(Self::combine(a, b).as_ref(), c).as_ref(), d)
+        Self::combine_acc(Self::combine_acc(Self::combine(a, b), c), d)
     }
     fn combine_n<'a, I>(vals: I) -> Option<V>
     where
         I: Iterator<Item = Option<&'a V>>,
         V: 'a,
     {
-        vals.fold(None, |acc, v| Self::combine(acc.as_ref(), v))
+        vals.fold(None, |acc, v| Self::combine_acc(acc, v))
     }
 }
 
@@ -1250,6 +1254,28 @@ impl<V: Lattice + Clone> ValuePolicy<V> for Join {
             r.cloned()
         }
     }
+
+    fn combine_acc(l: Option<V>, r: Option<&V>) -> Option<V> {
+        if let Some(lv) = l {
+            if let Some(rv) = r {
+                match lv.pjoin(rv) {
+                    AlgebraicResult::None => None,
+                    AlgebraicResult::Identity(mask) => {
+                        if mask & SELF_IDENT != 0 {
+                            Some(lv)
+                        } else {
+                            r.cloned()
+                        }
+                    }
+                    AlgebraicResult::Element(v) => Some(v),
+                }
+            } else {
+                Some(lv)
+            }
+        } else {
+            r.cloned()
+        }
+    }
 }
 
 // ==================== MEET ====================
@@ -1376,17 +1402,7 @@ impl<V: DistributiveLattice + Clone> ValuePolicy<V> for Subtract {
     fn combine(l: Option<&V>, r: Option<&V>) -> Option<V> {
         l.and_then(|lv| {
             if let Some(rv) = r {
-                match lv.psubtract(rv) {
-                    AlgebraicResult::None => None,
-                    AlgebraicResult::Identity(mask) => {
-                        if mask & SELF_IDENT != 0 {
-                            Some(lv.clone())
-                        } else {
-                            None
-                        }
-                    }
-                    AlgebraicResult::Element(v) => Some(v),
-                }
+                subtract_refs(lv, rv)
             } else {
                 // lhs-only → keep
                 Some(lv.clone())
@@ -1402,19 +1418,49 @@ impl<V: DistributiveLattice + Clone> ValuePolicy<V> for Subtract {
         let mut it = vals;
         let z = it.next()?.cloned()?;
         it.try_fold(z, |acc, v| match v {
-            Some(rv) => match acc.psubtract(rv) {
-                AlgebraicResult::None => None,
-                AlgebraicResult::Identity(mask) => {
-                    if mask & SELF_IDENT != 0 {
-                        Some(acc)
-                    } else {
-                        None
-                    }
-                }
-                AlgebraicResult::Element(x) => Some(x),
-            },
+            Some(rv) => subtract_acc(acc, rv),
             None => Some(acc),
         })
+    }
+
+    fn combine_acc(l: Option<V>, r: Option<&V>) -> Option<V> {
+        l.and_then(|lv| {
+            if let Some(rv) = r {
+                subtract_acc(lv, rv)
+            } else {
+                // lhs-only → keep
+                Some(lv)
+            }
+        })
+    }
+}
+
+#[inline]
+fn subtract_refs<V: DistributiveLattice + Clone>(a: &V, b: &V) -> Option<V> {
+    match a.psubtract(b) {
+        AlgebraicResult::None => None,
+        AlgebraicResult::Identity(mask) => {
+            if mask & SELF_IDENT != 0 {
+                Some(a.clone())
+            } else {
+                None
+            }
+        }
+        AlgebraicResult::Element(v) => Some(v),
+    }
+}
+#[inline]
+fn subtract_acc<V: DistributiveLattice>(a: V, b: &V) -> Option<V> {
+    match a.psubtract(b) {
+        AlgebraicResult::None => None,
+        AlgebraicResult::Identity(mask) => {
+            if mask & SELF_IDENT != 0 {
+                Some(a)
+            } else {
+                None
+            }
+        }
+        AlgebraicResult::Element(v) => Some(v),
     }
 }
 

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -1437,28 +1437,6 @@ mod zipper_algebra_poly {
         RZT(ReadZipperTracked<'trie, 'path, V, A>),
     }
 
-    impl<V: Clone + Send + Sync + Unpin, A: Allocator> zipper_priv::ZipperPriv for SomeZ<'_, '_, V, A> {
-        type V = V;
-
-        type A = A;
-
-        #[inline]
-        fn get_focus(&self) -> AbstractNodeRef<'_, Self::V, Self::A> {
-            match self {
-                SomeZ::RZ(inner) => inner.get_focus(),
-                SomeZ::RZT(inner) => inner.get_focus(),
-            }
-        }
-
-        #[inline]
-        fn try_borrow_focus(&self) -> Option<&TrieNodeODRc<Self::V, Self::A>> {
-            match self {
-                SomeZ::RZ(inner) => inner.try_borrow_focus(),
-                SomeZ::RZT(inner) => inner.try_borrow_focus(),
-            }
-        }
-    }
-
     impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperInfallibleSubtries<V, A>
         for SomeZ<'_, '_, V, A>
     {
@@ -1473,6 +1451,20 @@ mod zipper_algebra_poly {
             match self {
                 SomeZ::RZ(inner) => inner.get_trie_ref(),
                 SomeZ::RZT(inner) => inner.get_trie_ref(),
+            }
+        }
+
+        fn get_focus(&self) -> OpaqueAbstractNodeRef<'_, V, A> {
+            match self {
+                SomeZ::RZ(inner) => inner.get_focus(),
+                SomeZ::RZT(inner) => inner.get_focus(),
+            }
+        }
+
+        fn try_borrow_focus(&self) -> Option<OpaqueTrieNodeRef<'_, V, A>> {
+            match self {
+                SomeZ::RZ(inner) => inner.try_borrow_focus(),
+                SomeZ::RZT(inner) => inner.try_borrow_focus(),
             }
         }
     }

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -347,6 +347,17 @@ trait ValuePolicy<V> {
         // (l op m) op r
         Self::combine(Self::combine(l, m).as_ref(), r)
     }
+    fn combine4(a: Option<&V>, b: Option<&V>, c: Option<&V>, d: Option<&V>) -> Option<V> {
+        // ((a op b) op c) op d
+        Self::combine(Self::combine(Self::combine(a, b).as_ref(), c).as_ref(), d)
+    }
+    fn combine_n<'a, I>(vals: I) -> Option<V>
+    where
+        I: Iterator<Item = Option<&'a V>>,
+        V: 'a,
+    {
+        vals.fold(None, |acc, v| Self::combine(acc.as_ref(), v))
+    }
 }
 
 fn zipper_merge<P, V, ZL, ZR, Out, A>(lhs: &mut ZL, rhs: &mut ZR, out: &mut Out)
@@ -645,6 +656,279 @@ where
     }
 }
 
+// semi-unrolled (bitmask-driven)
+// Beyond 4, the combinatorics start to creak, but k = 4 is a sweet spot:
+// - still manageable (16 frontier cases)
+// - still branch-predictable
+// - still worth it for hot paths
+fn zipper_merge4<P, V, Z0, Z1, Z2, Z3, Out, A>(
+    z0: &mut Z0,
+    z1: &mut Z1,
+    z2: &mut Z2,
+    z3: &mut Z3,
+    out: &mut Out,
+) where
+    V: Clone + Send + Sync,
+    P: MergePolicy<V> + ValuePolicy<V>,
+    A: Allocator,
+    Z0: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    Z1: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    Z2: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    Z3: ZipperInfallibleSubtries<V, A> + ZipperMoving,
+    Out: ZipperWriting<V, A>,
+{
+    // merge root values before descending
+    if let Some(v) = P::combine4(z0.val(), z1.val(), z2.val(), z3.val()) {
+        out.set_val(v);
+    }
+
+    let mut k = 0;
+    // state (fully unrolled)
+    let mut m0 = z0.child_mask();
+    let mut m1 = z1.child_mask();
+    let mut m2 = z2.child_mask();
+    let mut m3 = z3.child_mask();
+
+    let mut i0 = 0;
+    let mut i1 = 0;
+    let mut i2 = 0;
+    let mut i3 = 0;
+
+    'ascend: loop {
+        'merge_level: loop {
+            // min selection
+            let mut b0 = m0.indexed_bit::<true>(i0 as usize);
+            let mut b1 = m1.indexed_bit::<true>(i1 as usize);
+            let mut b2 = m2.indexed_bit::<true>(i2 as usize);
+            let mut b3 = m3.indexed_bit::<true>(i3 as usize);
+
+            let mut a = b0;
+            let mut b = b1;
+            let mut c = b2;
+            let mut d = b3;
+
+            cmp_swap(&mut a, &mut b);
+            cmp_swap(&mut a, &mut c);
+            cmp_swap(&mut a, &mut d);
+
+            if let Some(min) = a {
+                let mut frontier = 0u8;
+                if b0 == a {
+                    frontier |= 0b0001;
+                }
+                if b1 == a {
+                    frontier |= 0b0010;
+                }
+                if b2 == a {
+                    frontier |= 0b0100;
+                }
+                if b3 == a {
+                    frontier |= 0b1000;
+                }
+
+                // full match
+                if frontier == 0b1111 {
+                    out.descend_to_byte(min);
+
+                    z0.descend_to_byte(min);
+                    z1.descend_to_byte(min);
+                    z2.descend_to_byte(min);
+                    z3.descend_to_byte(min);
+
+                    if let Some(v) = P::combine4(z0.val(), z1.val(), z2.val(), z3.val()) {
+                        out.set_val(v);
+                    }
+
+                    m0 = z0.child_mask();
+                    i0 = 0;
+                    m1 = z1.child_mask();
+                    i1 = 0;
+                    m2 = z2.child_mask();
+                    i2 = 0;
+                    m3 = z3.child_mask();
+                    i3 = 0;
+
+                    k += 1;
+                    continue 'merge_level;
+                }
+
+                let cnt = frontier.count_ones();
+                // singleton
+                if cnt == 1 {
+                    cmp_swap(&mut b, &mut c);
+                    cmp_swap(&mut b, &mut d);
+
+                    match frontier {
+                        0b0001 => {
+                            if let Some(next) = b {
+                                P::on_single(z0, 0b0001, ByteMask::from_range(min..next), out);
+                                i0 = m0.index_of(next);
+                            } else {
+                                P::on_single(z0, 0b0001, ByteMask::from_range(min..), out);
+                                break 'merge_level;
+                            }
+                        }
+                        0b0010 => {
+                            if let Some(next) = b {
+                                P::on_single(z1, 0b0010, ByteMask::from_range(min..next), out);
+                                i1 = m1.index_of(next);
+                            } else {
+                                P::on_single(z1, 0b0010, ByteMask::from_range(min..), out);
+                                break 'merge_level;
+                            }
+                        }
+                        0b0100 => {
+                            if let Some(next) = b {
+                                P::on_single(z2, 0b0100, ByteMask::from_range(min..next), out);
+                                i2 = m2.index_of(next);
+                            } else {
+                                P::on_single(z2, 0b0100, ByteMask::from_range(min..), out);
+                                break 'merge_level;
+                            }
+                        }
+                        0b1000 => {
+                            if let Some(next) = b {
+                                P::on_single(z3, 0b1000, ByteMask::from_range(min..next), out);
+                                i3 = m3.index_of(next);
+                            } else {
+                                P::on_single(z3, 0b1000, ByteMask::from_range(min..), out);
+                                break 'merge_level;
+                            }
+                        }
+                        _ => unreachable!(),
+                    };
+                } else {
+                    // partial overlap (2 or 3)
+
+                    // avoid 16 match arms and duplicated logic
+                    if P::descend_on_some_equal(frontier as u64) {
+                        out.descend_to_byte(min);
+
+                        if frontier & 0b0001 != 0 {
+                            z0.descend_to_byte(min);
+                        }
+                        if frontier & 0b0010 != 0 {
+                            z1.descend_to_byte(min);
+                        }
+                        if frontier & 0b0100 != 0 {
+                            z2.descend_to_byte(min);
+                        }
+                        if frontier & 0b1000 != 0 {
+                            z3.descend_to_byte(min);
+                        }
+
+                        // recurse on subset (still using 4-way function, but inactive ones won't match)
+                        if (cnt == 2) {
+                            let i = frontier.trailing_zeros();
+                            let j = (frontier & !(1 << i)).trailing_zeros();
+                            match (i, j) {
+                                (0, 1) => {
+                                    zipper_merge::<P, V, Z0, Z1, Out, A>(z0, z1, out);
+                                }
+                                (0, 2) => {
+                                    zipper_merge::<P, V, Z0, Z2, Out, A>(z0, z2, out);
+                                }
+                                (0, 3) => {
+                                    zipper_merge::<P, V, Z0, Z3, Out, A>(z0, z3, out);
+                                }
+                                (1, 2) => {
+                                    zipper_merge::<P, V, Z1, Z2, Out, A>(z1, z2, out);
+                                }
+                                (1, 3) => {
+                                    zipper_merge::<P, V, Z1, Z3, Out, A>(z1, z3, out);
+                                }
+                                (2, 3) => {
+                                    zipper_merge::<P, V, Z2, Z3, Out, A>(z2, z3, out);
+                                }
+                                _ => unreachable!(),
+                            }
+                        } else {
+                            // cnt == 3
+                            let mut bits = frontier;
+                            let i = bits.trailing_zeros();
+                            bits &= bits - 1; // trick: it removes the lowest bit set from a bitmask
+                            let j = bits.trailing_zeros();
+                            bits &= bits - 1;
+                            let k = bits.trailing_zeros();
+                            match (i, j, k) {
+                                (0, 1, 2) => {
+                                    zipper_merge3::<P, V, Z0, Z1, Z2, Out, A>(z0, z1, z2, out);
+                                }
+                                (0, 1, 3) => {
+                                    zipper_merge3::<P, V, Z0, Z1, Z3, Out, A>(z0, z1, z3, out);
+                                }
+                                (0, 2, 3) => {
+                                    zipper_merge3::<P, V, Z0, Z2, Z3, Out, A>(z0, z2, z3, out);
+                                }
+                                (1, 2, 3) => {
+                                    zipper_merge3::<P, V, Z1, Z2, Z3, Out, A>(z1, z2, z3, out);
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+
+                        if frontier & 0b0001 != 0 {
+                            z0.ascend_byte();
+                        }
+                        if frontier & 0b0010 != 0 {
+                            z1.ascend_byte();
+                        }
+                        if frontier & 0b0100 != 0 {
+                            z2.ascend_byte();
+                        }
+                        if frontier & 0b1000 != 0 {
+                            z3.ascend_byte();
+                        }
+
+                        out.ascend_byte();
+                    }
+                    // then advance
+                    if frontier & 0b0001 != 0 {
+                        i0 += 1;
+                    }
+                    if frontier & 0b0010 != 0 {
+                        i1 += 1;
+                    }
+                    if frontier & 0b0100 != 0 {
+                        i2 += 1;
+                    }
+                    if frontier & 0b1000 != 0 {
+                        i3 += 1;
+                    }
+                }
+            } else {
+                break 'merge_level;
+            }
+        }
+
+        // If we are at root and no deeper recursion pending, we're done
+        if k == 0 {
+            break 'ascend;
+        }
+
+        let byte_from = *z0.path().last().expect("non-empty path when k > 0");
+
+        z0.ascend_byte();
+        m0 = z0.child_mask();
+        i0 = m0.index_of(byte_from) + 1;
+
+        z1.ascend_byte();
+        m1 = z1.child_mask();
+        i1 = m1.index_of(byte_from) + 1;
+
+        z2.ascend_byte();
+        m2 = z2.child_mask();
+        i2 = m2.index_of(byte_from) + 1;
+
+        z3.ascend_byte();
+        m3 = z3.child_mask();
+        i3 = m3.index_of(byte_from) + 1;
+
+        out.ascend_byte();
+        k -= 1;
+    }
+}
+
 // ==================== JOIN ====================
 
 struct Join;
@@ -715,6 +999,27 @@ impl<V: Lattice + Clone> ValuePolicy<V> for Meet {
 
     fn combine3(l: Option<&V>, m: Option<&V>, r: Option<&V>) -> Option<V> {
         l.and_then(|x| m.and_then(|y| r.and_then(|z| meet_acc(meet_refs(x, y)?, z))))
+    }
+
+    fn combine4(a: Option<&V>, b: Option<&V>, c: Option<&V>, d: Option<&V>) -> Option<V> {
+        a.and_then(|w| {
+            b.and_then(|x| {
+                c.and_then(|y| d.and_then(|z| meet_acc(meet_acc(meet_refs(w, x)?, y)?, z)))
+            })
+        })
+    }
+
+    fn combine_n<'a, I>(vals: I) -> Option<V>
+    where
+        I: Iterator<Item = Option<&'a V>>,
+        V: 'a,
+    {
+        let mut it = vals;
+        let z = it.next()?.cloned()?;
+        it.try_fold(z, |acc, v| {
+            let rv = v?;
+            meet_acc(acc, rv)
+        })
     }
 }
 
@@ -807,6 +1112,29 @@ impl<V: DistributiveLattice + Clone> ValuePolicy<V> for Subtract {
                 // lhs-only → keep
                 Some(lv.clone())
             }
+        })
+    }
+
+    fn combine_n<'a, I>(vals: I) -> Option<V>
+    where
+        I: Iterator<Item = Option<&'a V>>,
+        V: 'a,
+    {
+        let mut it = vals;
+        let z = it.next()?.cloned()?;
+        it.try_fold(z, |acc, v| match v {
+            Some(rv) => match acc.psubtract(rv) {
+                AlgebraicResult::None => None,
+                AlgebraicResult::Identity(mask) => {
+                    if mask & SELF_IDENT != 0 {
+                        Some(acc)
+                    } else {
+                        None
+                    }
+                }
+                AlgebraicResult::Element(x) => Some(x),
+            },
+            None => Some(acc),
         })
     }
 }

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -938,7 +938,7 @@ fn zipper_merge4<P, V, Z0, Z1, Z2, Z3, Out, A>(
     }
 }
 
-use zipper_algebra_poly::SomeZ as Z;
+use zipper_algebra_poly::SomeMutRefZ as Z;
 
 // - The function is fully monomorphized over `N` and uses a bitmask (`active`)
 //   to track participating zippers.
@@ -1435,39 +1435,39 @@ mod zipper_algebra_poly {
 
     #[derive(PolyZipperExplicit)]
     #[poly_zipper_explicit(traits(ZipperMoving, ZipperValues))]
-    pub(super) enum SomeZ<'a, 'trie, 'path, V: Clone + Send + Sync + Unpin, A: Allocator> {
+    pub(super) enum SomeMutRefZ<'a, 'trie, 'path, V: Clone + Send + Sync + Unpin, A: Allocator> {
         RZ(&'a mut ReadZipperUntracked<'trie, 'path, V, A>),
         RZT(&'a mut ReadZipperTracked<'trie, 'path, V, A>),
     }
 
     impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperInfallibleSubtries<V, A>
-        for SomeZ<'_, '_, '_, V, A>
+        for SomeMutRefZ<'_, '_, '_, V, A>
     {
         fn make_map(&self) -> PathMap<V, A> {
             match self {
-                SomeZ::RZ(inner) => inner.make_map(),
-                SomeZ::RZT(inner) => inner.make_map(),
+                SomeMutRefZ::RZ(inner) => inner.make_map(),
+                SomeMutRefZ::RZT(inner) => inner.make_map(),
             }
         }
 
         fn get_trie_ref(&self) -> TrieRef<'_, V, A> {
             match self {
-                SomeZ::RZ(inner) => inner.get_trie_ref(),
-                SomeZ::RZT(inner) => inner.get_trie_ref(),
+                SomeMutRefZ::RZ(inner) => inner.get_trie_ref(),
+                SomeMutRefZ::RZT(inner) => inner.get_trie_ref(),
             }
         }
 
         fn get_focus(&self) -> OpaqueAbstractNodeRef<'_, V, A> {
             match self {
-                SomeZ::RZ(inner) => inner.get_focus(),
-                SomeZ::RZT(inner) => inner.get_focus(),
+                SomeMutRefZ::RZ(inner) => inner.get_focus(),
+                SomeMutRefZ::RZT(inner) => inner.get_focus(),
             }
         }
 
         fn try_borrow_focus(&self) -> Option<OpaqueTrieNodeRef<'_, V, A>> {
             match self {
-                SomeZ::RZ(inner) => inner.try_borrow_focus(),
-                SomeZ::RZT(inner) => inner.try_borrow_focus(),
+                SomeMutRefZ::RZ(inner) => inner.try_borrow_focus(),
+                SomeMutRefZ::RZT(inner) => inner.try_borrow_focus(),
             }
         }
     }


### PR DESCRIPTION
This PR introduces a generic N-way merge algorithm, extending the existing 2-way and 3-way implementations to arbitrary arity (well, `<= 64`) while preserving performance characteristics via specialization and careful traversal design.

#### N-way zipper merge (`zipper_merge_n_mono`)
- Fully monomorphized over `const N` and the zipper type (`SomeMutRefZ`)
- Uses a bitmask (`active`) to track participating zippers
- Stackless traversal using zipper movements and explicit depth tracking

#### Frontier-based traversal
- At each step:
- - Compute minimal byte across active zippers
- - Build a frontier (subset sharing that byte)
- - Dispatch based on frontier size:
- - - `|frontier| = 1` → graft (no descent)
- - - `1 < |frontier| < N` → subset recursion / specialization
- - - `|frontier| = N` → fast-path full descent (no recursion)
#### Specialized fast paths
- Dispatch to optimized implementations for:
- - 2-way → `zipper_merge`
- - 3-way → `zipper_merge3`
- - 4-way → `zipper_merge4`
- Larger frontiers recurse into the same function with a reduced mask

### Introduce macro-based “variadic” frontends and tuple-driven helpers for composing multiple zippers in a single call.

- New macros:
- - `zipper_meet_n!`
- - `zipper_join_n!`
- - `zipper_subtract_n!`
- New helpers:
- - `meet_n`, `join_n`, `subtract_n`

##### Syntax

Tuple-based argument passing `(&mut r1, &mut r2, ..., &rN).meet_n(&mut out)` with macro-generated impls up to 64 (current limit: 32)

or

`zipper_join_n!(r1, r2, r3, ... => w);` instead