### PR TITLE
zipper_algebra: support more zippers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,10 @@ harness = false
 name = "multiplicities"
 harness = false
 
+[[bench]]
+name = "graft_masked_branches"
+harness = false
+
 [workspace]
 members = ["pathmap-derive", "examples/sampling", "examples/arena_compact_tests"]
 resolver = "2"

--- a/benches/graft_masked_branches.rs
+++ b/benches/graft_masked_branches.rs
@@ -13,6 +13,8 @@ fn main() {
 }
 
 const BRANCH_COUNTS: [usize; 11] = [1, 2, 3, 4, 6, 8, 15, 30, 60, 100, 200];
+const LOW_DENSITY_DST_BRANCHES: usize = 3;
+const HIGH_DENSITY_DST_BRANCHES: usize = 150;
 
 #[derive(Clone, Copy, Debug)]
 enum MaskDistribution {
@@ -20,8 +22,20 @@ enum MaskDistribution {
     PseudoRandom,
 }
 
-fn make_children(masked_branch_count: usize, distribution: MaskDistribution) -> (Vec<u8>, Vec<u8>) {
-    let extra_branch_count = ((masked_branch_count / 2).max(2)).min(256 - masked_branch_count);
+fn default_extra_branch_count(masked_branch_count: usize) -> usize {
+    ((masked_branch_count / 2).max(2)).min(256 - masked_branch_count)
+}
+
+fn deterministic_permuted_bytes(seed: u64) -> Vec<u8> {
+    let mut bytes: Vec<u8> = (0u8..=255).collect();
+    let mut rng = StdRng::seed_from_u64(seed);
+    bytes.shuffle(&mut rng);
+    bytes
+}
+
+fn make_children(masked_branch_count: usize, extra_branch_count: usize, distribution: MaskDistribution) -> (Vec<u8>, Vec<u8>) {
+    debug_assert!(masked_branch_count <= 256);
+    debug_assert!(extra_branch_count <= 256 - masked_branch_count);
 
     match distribution {
         MaskDistribution::Contiguous => {
@@ -34,9 +48,7 @@ fn make_children(masked_branch_count: usize, distribution: MaskDistribution) -> 
         MaskDistribution::PseudoRandom => {
             // Deterministic shuffle so benchmark inputs are reproducible without the regular
             // spacing artifacts of a linear permutation prefix.
-            let mut permuted_bytes: Vec<u8> = (0u8..=255).collect();
-            let mut rng = StdRng::seed_from_u64(0x5eed_cafe_u64 ^ masked_branch_count as u64);
-            permuted_bytes.shuffle(&mut rng);
+            let permuted_bytes = deterministic_permuted_bytes(0x5eed_cafe_u64 ^ masked_branch_count as u64);
             let masked_children = permuted_bytes[..masked_branch_count].to_vec();
             let extra_children = permuted_bytes[masked_branch_count..masked_branch_count + extra_branch_count].to_vec();
             (masked_children, extra_children)
@@ -59,7 +71,8 @@ fn debug_print_mask(_label: &str, _distribution: MaskDistribution, _child_mask: 
 }
 
 fn make_case(masked_branch_count: usize, distribution: MaskDistribution) -> (PathMap<u32>, PathMap<u32>, ByteMask) {
-    let (masked_children, extra_children) = make_children(masked_branch_count, distribution);
+    let extra_branch_count = default_extra_branch_count(masked_branch_count);
+    let (masked_children, extra_children) = make_children(masked_branch_count, extra_branch_count, distribution);
 
     let mut src = PathMap::new();
     let mut dst = PathMap::new();
@@ -96,7 +109,8 @@ fn make_case(masked_branch_count: usize, distribution: MaskDistribution) -> (Pat
 }
 
 fn make_partial_source_case(masked_branch_count: usize, distribution: MaskDistribution) -> (PathMap<u32>, PathMap<u32>, ByteMask) {
-    let (masked_children, extra_children) = make_children(masked_branch_count, distribution);
+    let extra_branch_count = default_extra_branch_count(masked_branch_count);
+    let (masked_children, extra_children) = make_children(masked_branch_count, extra_branch_count, distribution);
 
     let mut src = PathMap::new();
     let mut dst = PathMap::new();
@@ -130,6 +144,57 @@ fn make_partial_source_case(masked_branch_count: usize, distribution: MaskDistri
     (src, dst, child_mask)
 }
 
+fn make_keep_case_with_dst_branch_count(
+    masked_branch_count: usize,
+    distribution: MaskDistribution,
+    dst_branch_count: usize,
+    full_src: bool,
+) -> (PathMap<u32>, PathMap<u32>, ByteMask) {
+    let src_extra_branch_count = if full_src {
+        default_extra_branch_count(masked_branch_count)
+    } else {
+        0
+    };
+    let dst_branch_count = dst_branch_count.min(256);
+    let src_extra_branch_count = src_extra_branch_count.min(256 - masked_branch_count);
+    let (masked_children, src_extra_children) = make_children(masked_branch_count, src_extra_branch_count, distribution);
+    let dst_existing_children = deterministic_permuted_bytes(0xd57_d157_u64)[..dst_branch_count].to_vec();
+
+    let mut src = PathMap::new();
+    let mut dst = PathMap::new();
+
+    src.set_val_at(b"", 0);
+    dst.set_val_at(b"", 1);
+
+    for (idx, child) in dst_existing_children.iter().copied().enumerate() {
+        let idx = idx as u32;
+
+        dst.set_val_at(&[child], 10_000 + idx);
+        dst.set_val_at(&[child, 1], 10_001 + idx);
+        dst.set_val_at(&[child, 2, 3], 10_002 + idx);
+    }
+
+    for (idx, child) in masked_children.iter().copied().enumerate() {
+        let idx = idx as u32;
+        if full_src {
+            src.set_val_at(&[child], 20_000 + idx);
+        }
+        src.set_val_at(&[child, 4], 20_001 + idx);
+        src.set_val_at(&[child, 5, 6], 20_002 + idx);
+        src.set_val_at(&[child, 7, 8, 9], 20_003 + idx);
+    }
+
+    for (idx, child) in src_extra_children.iter().copied().enumerate() {
+        let idx = idx as u32;
+        src.set_val_at(&[child], 40_000 + idx);
+        src.set_val_at(&[child, 14], 40_001 + idx);
+    }
+
+    let child_mask = ByteMask::from_iter(masked_children);
+    debug_print_mask("keep_dst_branch_count", distribution, child_mask);
+    (src, dst, child_mask)
+}
+
 fn run_graft_bench(bencher: Bencher, src_template: PathMap<u32>, dst_template: PathMap<u32>, child_mask: ByteMask, remove_unset: bool) {
     let out = bencher
         .with_inputs(|| (src_template.clone(), dst_template.clone()))
@@ -142,24 +207,6 @@ fn run_graft_bench(bencher: Bencher, src_template: PathMap<u32>, dst_template: P
         });
 
     divan::black_box_drop(out);
-}
-
-/// - `remove_unset = false`
-/// - `src` contains hundreds of branches, regardless of mask
-/// - the mask bits are a contiguous range
-#[divan::bench(sample_size = 1, args = BRANCH_COUNTS)]
-fn graft_masked_branches_keep_full_src_contiguous(bencher: Bencher, masked_branch_count: usize) {
-    let (src_template, dst_template, child_mask) = make_case(masked_branch_count, MaskDistribution::Contiguous);
-    run_graft_bench(bencher, src_template, dst_template, child_mask, false);
-}
-
-/// - `remove_unset = false`
-/// - `src` contains hundreds of branches, regardless of mask
-/// - mask bits are distributed pseudorandomly
-#[divan::bench(sample_size = 1, args = BRANCH_COUNTS)]
-fn graft_masked_branches_keep_full_src_pseudorandom(bencher: Bencher, masked_branch_count: usize) {
-    let (src_template, dst_template, child_mask) = make_case(masked_branch_count, MaskDistribution::PseudoRandom);
-    run_graft_bench(bencher, src_template, dst_template, child_mask, false);
 }
 
 /// - `remove_unset = true`
@@ -180,24 +227,6 @@ fn graft_masked_branches_remove_full_src_pseudorandom(bencher: Bencher, masked_b
     run_graft_bench(bencher, src_template, dst_template, child_mask, true);
 }
 
-/// - `remove_unset = false`
-/// - `src` contains only the branches we're grafting
-/// - the mask bits are a contiguous range
-#[divan::bench(sample_size = 1, args = BRANCH_COUNTS)]
-fn graft_masked_branches_keep_part_src_contiguous(bencher: Bencher, masked_branch_count: usize) {
-    let (src_template, dst_template, child_mask) = make_partial_source_case(masked_branch_count, MaskDistribution::Contiguous);
-    run_graft_bench(bencher, src_template, dst_template, child_mask, false);
-}
-
-/// - `remove_unset = false`
-/// - `src` contains only the branches we're grafting
-/// - mask bits are distributed pseudorandomly
-#[divan::bench(sample_size = 1, args = BRANCH_COUNTS)]
-fn graft_masked_branches_keep_part_src_pseudorandom(bencher: Bencher, masked_branch_count: usize) {
-    let (src_template, dst_template, child_mask) = make_partial_source_case(masked_branch_count, MaskDistribution::PseudoRandom);
-    run_graft_bench(bencher, src_template, dst_template, child_mask, false);
-}
-
 /// - `remove_unset = true`
 /// - `src` contains only the branches we're grafting,
 /// - the mask bits are a contiguous range
@@ -214,4 +243,124 @@ fn graft_masked_branches_remove_part_src_contiguous(bencher: Bencher, masked_bra
 fn graft_masked_branches_remove_part_src_pseudorandom(bencher: Bencher, masked_branch_count: usize) {
     let (src_template, dst_template, child_mask) = make_partial_source_case(masked_branch_count, MaskDistribution::PseudoRandom);
     run_graft_bench(bencher, src_template, dst_template, child_mask, true);
+}
+
+/// - `remove_unset = false`
+/// - `src` contains hundreds of branches, regardless of mask
+/// - the mask bits are a contiguous range
+/// - destination contains a LOW density of pre-existing branches before the graft operation
+#[divan::bench(sample_size = 1, args = BRANCH_COUNTS)]
+fn graft_masked_branches_keep_full_src_contiguous_low(bencher: Bencher, masked_branch_count: usize) {
+    let (src_template, dst_template, child_mask) = make_keep_case_with_dst_branch_count(
+        masked_branch_count,
+        MaskDistribution::Contiguous,
+        LOW_DENSITY_DST_BRANCHES,
+        true,
+    );
+    run_graft_bench(bencher, src_template, dst_template, child_mask, false);
+}
+
+/// - `remove_unset = false`
+/// - `src` contains hundreds of branches, regardless of mask
+/// - the mask bits are a contiguous range
+/// - destination contains a HIGH density of pre-existing branches before the graft operation
+#[divan::bench(sample_size = 1, args = BRANCH_COUNTS)]
+fn graft_masked_branches_keep_full_src_contiguous_high(bencher: Bencher, masked_branch_count: usize) {
+    let (src_template, dst_template, child_mask) = make_keep_case_with_dst_branch_count(
+        masked_branch_count,
+        MaskDistribution::Contiguous,
+        HIGH_DENSITY_DST_BRANCHES,
+        true,
+    );
+    run_graft_bench(bencher, src_template, dst_template, child_mask, false);
+}
+
+/// - `remove_unset = false`
+/// - `src` contains hundreds of branches, regardless of mask
+/// - mask bits are distributed pseudorandomly
+/// - destination contains a LOW density of pre-existing branches before the graft operation
+#[divan::bench(sample_size = 1, args = BRANCH_COUNTS)]
+fn graft_masked_branches_keep_full_src_pseudorandom_low(bencher: Bencher, masked_branch_count: usize) {
+    let (src_template, dst_template, child_mask) = make_keep_case_with_dst_branch_count(
+        masked_branch_count,
+        MaskDistribution::PseudoRandom,
+        LOW_DENSITY_DST_BRANCHES,
+        true,
+    );
+    run_graft_bench(bencher, src_template, dst_template, child_mask, false);
+}
+
+/// - `remove_unset = false`
+/// - `src` contains hundreds of branches, regardless of mask
+/// - mask bits are distributed pseudorandomly
+/// - destination contains a HIGH density of pre-existing branches before the graft operation
+#[divan::bench(sample_size = 1, args = BRANCH_COUNTS)]
+fn graft_masked_branches_keep_full_src_pseudorandom_high(bencher: Bencher, masked_branch_count: usize) {
+    let (src_template, dst_template, child_mask) = make_keep_case_with_dst_branch_count(
+        masked_branch_count,
+        MaskDistribution::PseudoRandom,
+        HIGH_DENSITY_DST_BRANCHES,
+        true,
+    );
+    run_graft_bench(bencher, src_template, dst_template, child_mask, false);
+}
+
+/// - `remove_unset = false`
+/// - `src` contains only the branches we're grafting
+/// - the mask bits are a contiguous range
+/// - destination contains a LOW density of pre-existing branches before the graft operation
+#[divan::bench(sample_size = 1, args = BRANCH_COUNTS)]
+fn graft_masked_branches_keep_part_src_contiguous_low(bencher: Bencher, masked_branch_count: usize) {
+    let (src_template, dst_template, child_mask) = make_keep_case_with_dst_branch_count(
+        masked_branch_count,
+        MaskDistribution::Contiguous,
+        LOW_DENSITY_DST_BRANCHES,
+        false,
+    );
+    run_graft_bench(bencher, src_template, dst_template, child_mask, false);
+}
+
+/// - `remove_unset = false`
+/// - `src` contains only the branches we're grafting
+/// - the mask bits are a contiguous range
+/// - destination contains a HIGH density of pre-existing branches before the graft operation
+#[divan::bench(sample_size = 1, args = BRANCH_COUNTS)]
+fn graft_masked_branches_keep_part_src_contiguous_high(bencher: Bencher, masked_branch_count: usize) {
+    let (src_template, dst_template, child_mask) = make_keep_case_with_dst_branch_count(
+        masked_branch_count,
+        MaskDistribution::Contiguous,
+        HIGH_DENSITY_DST_BRANCHES,
+        false,
+    );
+    run_graft_bench(bencher, src_template, dst_template, child_mask, false);
+}
+
+/// - `remove_unset = false`
+/// - `src` contains only the branches we're grafting
+/// - mask bits are distributed pseudorandomly
+/// - destination contains a LOW density of pre-existing branches before the graft operation
+#[divan::bench(sample_size = 1, args = BRANCH_COUNTS)]
+fn graft_masked_branches_keep_part_src_pseudorandom_low(bencher: Bencher, masked_branch_count: usize) {
+    let (src_template, dst_template, child_mask) = make_keep_case_with_dst_branch_count(
+        masked_branch_count,
+        MaskDistribution::PseudoRandom,
+        LOW_DENSITY_DST_BRANCHES,
+        false,
+    );
+    run_graft_bench(bencher, src_template, dst_template, child_mask, false);
+}
+
+/// - `remove_unset = false`
+/// - `src` contains only the branches we're grafting
+/// - mask bits are distributed pseudorandomly
+/// - destination contains a HIGH density of pre-existing branches before the graft operation
+#[divan::bench(sample_size = 1, args = BRANCH_COUNTS)]
+fn graft_masked_branches_keep_part_src_pseudorandom_high(bencher: Bencher, masked_branch_count: usize) {
+    let (src_template, dst_template, child_mask) = make_keep_case_with_dst_branch_count(
+        masked_branch_count,
+        MaskDistribution::PseudoRandom,
+        HIGH_DENSITY_DST_BRANCHES,
+        false,
+    );
+    run_graft_bench(bencher, src_template, dst_template, child_mask, false);
 }

--- a/benches/graft_masked_branches.rs
+++ b/benches/graft_masked_branches.rs
@@ -1,0 +1,86 @@
+use divan::{Bencher, Divan};
+
+use pathmap::PathMap;
+use pathmap::utils::ByteMask;
+use pathmap::zipper::*;
+
+fn main() {
+    let divan = Divan::from_args().sample_count(1000);
+
+    divan.main();
+}
+
+const BRANCH_COUNTS: [usize; 11] = [1, 2, 3, 4, 6, 8, 15, 30, 60, 100, 200];
+
+fn make_case(masked_branch_count: usize) -> (PathMap<u32>, PathMap<u32>, ByteMask) {
+    let masked_children: Vec<u8> = (0..masked_branch_count).map(|idx| idx as u8).collect();
+    let extra_branch_count = (masked_branch_count / 2).max(2);
+    let extra_children: Vec<u8> = (masked_branch_count..(masked_branch_count + extra_branch_count))
+        .map(|idx| idx as u8)
+        .collect();
+
+    let mut src = PathMap::new();
+    let mut dst = PathMap::new();
+
+    src.set_val_at(b"", 0);
+    dst.set_val_at(b"", 1);
+
+    for (idx, child) in masked_children.iter().copied().enumerate() {
+        let idx = idx as u32;
+
+        dst.set_val_at(&[child], 10_000 + idx);
+        dst.set_val_at(&[child, 1], 10_001 + idx);
+        dst.set_val_at(&[child, 2, 3], 10_002 + idx);
+
+        src.set_val_at(&[child], 20_000 + idx);
+        src.set_val_at(&[child, 4], 20_001 + idx);
+        src.set_val_at(&[child, 5, 6], 20_002 + idx);
+        src.set_val_at(&[child, 7, 8, 9], 20_003 + idx);
+    }
+
+    for (idx, child) in extra_children.iter().copied().enumerate() {
+        let idx = idx as u32;
+        dst.set_val_at(&[child], 30_000 + idx);
+        dst.set_val_at(&[child, 11], 30_001 + idx);
+        dst.set_val_at(&[child, 12, 13], 30_002 + idx);
+
+        src.set_val_at(&[child], 40_000 + idx);
+        src.set_val_at(&[child, 14], 40_001 + idx);
+    }
+
+    (src, dst, ByteMask::from_iter(masked_children))
+}
+
+#[divan::bench(sample_size = 1, args = BRANCH_COUNTS)]
+fn graft_masked_branches_keep_unset(bencher: Bencher, masked_branch_count: usize) {
+    let (src_template, dst_template, child_mask) = make_case(masked_branch_count);
+
+    let out = bencher
+        .with_inputs(|| (src_template.clone(), dst_template.clone()))
+        .bench_local_values(|(src, mut dst)| {
+            let mut wz = dst.write_zipper_at_path(b"");
+            let rz = src.read_zipper_at_path(b"");
+            wz.graft_masked_branches(&rz, child_mask, false);
+            drop(wz);
+            dst
+        });
+
+    divan::black_box_drop(out);
+}
+
+#[divan::bench(sample_size = 1, args = BRANCH_COUNTS)]
+fn graft_masked_branches_remove_unset(bencher: Bencher, masked_branch_count: usize) {
+    let (src_template, dst_template, child_mask) = make_case(masked_branch_count);
+
+    let out = bencher
+        .with_inputs(|| (src_template.clone(), dst_template.clone()))
+        .bench_local_values(|(src, mut dst)| {
+            let mut wz = dst.write_zipper_at_path(b"");
+            let rz = src.read_zipper_at_path(b"");
+            wz.graft_masked_branches(&rz, child_mask, true);
+            drop(wz);
+            dst
+        });
+
+    divan::black_box_drop(out);
+}

--- a/benches/graft_masked_branches.rs
+++ b/benches/graft_masked_branches.rs
@@ -51,8 +51,45 @@ fn make_case(masked_branch_count: usize) -> (PathMap<u32>, PathMap<u32>, ByteMas
     (src, dst, ByteMask::from_iter(masked_children))
 }
 
+fn make_partial_source_case(masked_branch_count: usize) -> (PathMap<u32>, PathMap<u32>, ByteMask) {
+    let masked_children: Vec<u8> = (0..masked_branch_count).map(|idx| idx as u8).collect();
+    let extra_branch_count = (masked_branch_count / 2).max(2);
+    let extra_children: Vec<u8> = (masked_branch_count..(masked_branch_count + extra_branch_count))
+        .map(|idx| idx as u8)
+        .collect();
+
+    let mut src = PathMap::new();
+    let mut dst = PathMap::new();
+
+    src.set_val_at(b"", 0);
+    dst.set_val_at(b"", 1);
+
+    for (idx, child) in masked_children.iter().copied().enumerate() {
+        let idx = idx as u32;
+
+        dst.set_val_at(&[child], 10_000 + idx);
+        dst.set_val_at(&[child, 1], 10_001 + idx);
+        dst.set_val_at(&[child, 2, 3], 10_002 + idx);
+
+        src.set_val_at(&[child], 20_000 + idx);
+        src.set_val_at(&[child, 4], 20_001 + idx);
+        src.set_val_at(&[child, 5, 6], 20_002 + idx);
+        src.set_val_at(&[child, 7, 8, 9], 20_003 + idx);
+    }
+
+    for (idx, child) in extra_children.iter().copied().enumerate() {
+        let idx = idx as u32;
+        dst.set_val_at(&[child], 30_000 + idx);
+        dst.set_val_at(&[child, 11], 30_001 + idx);
+        dst.set_val_at(&[child, 12, 13], 30_002 + idx);
+    }
+
+    (src, dst, ByteMask::from_iter(masked_children))
+}
+
+/// `remove_unset = false`, `src` contains hundreds of branches, regardless of mask
 #[divan::bench(sample_size = 1, args = BRANCH_COUNTS)]
-fn graft_masked_branches_keep_unset(bencher: Bencher, masked_branch_count: usize) {
+fn graft_masked_branches_keep_full_src(bencher: Bencher, masked_branch_count: usize) {
     let (src_template, dst_template, child_mask) = make_case(masked_branch_count);
 
     let out = bencher
@@ -68,9 +105,52 @@ fn graft_masked_branches_keep_unset(bencher: Bencher, masked_branch_count: usize
     divan::black_box_drop(out);
 }
 
+/// `remove_unset = true`, `src` contains hundreds of branches, regardless of mask
 #[divan::bench(sample_size = 1, args = BRANCH_COUNTS)]
-fn graft_masked_branches_remove_unset(bencher: Bencher, masked_branch_count: usize) {
+fn graft_masked_branches_remove_full_src(bencher: Bencher, masked_branch_count: usize) {
     let (src_template, dst_template, child_mask) = make_case(masked_branch_count);
+
+    let out = bencher
+        .with_inputs(|| (src_template.clone(), dst_template.clone()))
+        .bench_local_values(|(src, mut dst)| {
+            let mut wz = dst.write_zipper_at_path(b"");
+            let rz = src.read_zipper_at_path(b"");
+            wz.graft_masked_branches(&rz, child_mask, true);
+            drop(wz);
+            dst
+        });
+
+    divan::black_box_drop(out);
+}
+
+/// `remove_unset = false`, `src` contains only the branches we're grafting
+#[divan::bench(sample_size = 1, args = BRANCH_COUNTS)]
+fn graft_masked_branches_keep_part_src(
+    bencher: Bencher,
+    masked_branch_count: usize,
+) {
+    let (src_template, dst_template, child_mask) = make_partial_source_case(masked_branch_count);
+
+    let out = bencher
+        .with_inputs(|| (src_template.clone(), dst_template.clone()))
+        .bench_local_values(|(src, mut dst)| {
+            let mut wz = dst.write_zipper_at_path(b"");
+            let rz = src.read_zipper_at_path(b"");
+            wz.graft_masked_branches(&rz, child_mask, false);
+            drop(wz);
+            dst
+        });
+
+    divan::black_box_drop(out);
+}
+
+/// `remove_unset = true`, `src` contains only the branches we're grafting
+#[divan::bench(sample_size = 1, args = BRANCH_COUNTS)]
+fn graft_masked_branches_remove_part_src(
+    bencher: Bencher,
+    masked_branch_count: usize,
+) {
+    let (src_template, dst_template, child_mask) = make_partial_source_case(masked_branch_count);
 
     let out = bencher
         .with_inputs(|| (src_template.clone(), dst_template.clone()))

--- a/benches/graft_masked_branches.rs
+++ b/benches/graft_masked_branches.rs
@@ -71,7 +71,8 @@ fn make_partial_source_case(masked_branch_count: usize) -> (PathMap<u32>, PathMa
         dst.set_val_at(&[child, 1], 10_001 + idx);
         dst.set_val_at(&[child, 2, 3], 10_002 + idx);
 
-        src.set_val_at(&[child], 20_000 + idx);
+        //Having both a value and onward branch forces an early upgrade from the PairNode to a ByteNode
+        // src.set_val_at(&[child], 20_000 + idx);
         src.set_val_at(&[child, 4], 20_001 + idx);
         src.set_val_at(&[child, 5, 6], 20_002 + idx);
         src.set_val_at(&[child, 7, 8, 9], 20_003 + idx);

--- a/benches/graft_masked_branches.rs
+++ b/benches/graft_masked_branches.rs
@@ -1,4 +1,6 @@
 use divan::{Bencher, Divan};
+use rand::seq::SliceRandom;
+use rand::{SeedableRng, rngs::StdRng};
 
 use pathmap::PathMap;
 use pathmap::utils::ByteMask;
@@ -12,12 +14,52 @@ fn main() {
 
 const BRANCH_COUNTS: [usize; 11] = [1, 2, 3, 4, 6, 8, 15, 30, 60, 100, 200];
 
-fn make_case(masked_branch_count: usize) -> (PathMap<u32>, PathMap<u32>, ByteMask) {
-    let masked_children: Vec<u8> = (0..masked_branch_count).map(|idx| idx as u8).collect();
-    let extra_branch_count = (masked_branch_count / 2).max(2);
-    let extra_children: Vec<u8> = (masked_branch_count..(masked_branch_count + extra_branch_count))
-        .map(|idx| idx as u8)
-        .collect();
+#[derive(Clone, Copy, Debug)]
+enum MaskDistribution {
+    Contiguous,
+    PseudoRandom,
+}
+
+fn make_children(masked_branch_count: usize, distribution: MaskDistribution) -> (Vec<u8>, Vec<u8>) {
+    let extra_branch_count = ((masked_branch_count / 2).max(2)).min(256 - masked_branch_count);
+
+    match distribution {
+        MaskDistribution::Contiguous => {
+            let masked_children: Vec<u8> = (0..masked_branch_count).map(|idx| idx as u8).collect();
+            let extra_children: Vec<u8> = (masked_branch_count..(masked_branch_count + extra_branch_count))
+                .map(|idx| idx as u8)
+                .collect();
+            (masked_children, extra_children)
+        }
+        MaskDistribution::PseudoRandom => {
+            // Deterministic shuffle so benchmark inputs are reproducible without the regular
+            // spacing artifacts of a linear permutation prefix.
+            let mut permuted_bytes: Vec<u8> = (0u8..=255).collect();
+            let mut rng = StdRng::seed_from_u64(0x5eed_cafe_u64 ^ masked_branch_count as u64);
+            permuted_bytes.shuffle(&mut rng);
+            let masked_children = permuted_bytes[..masked_branch_count].to_vec();
+            let extra_children = permuted_bytes[masked_branch_count..masked_branch_count + extra_branch_count].to_vec();
+            (masked_children, extra_children)
+        }
+    }
+}
+
+fn debug_print_mask(_label: &str, _distribution: MaskDistribution, _child_mask: ByteMask) {
+    //NOTE: Uncomment this function body to inspect the masks
+    // let ranges: Vec<(u8, u8)> = _child_mask
+    //     .range_iter()
+    //     .map(|range| (*range.start(), *range.end()))
+    //     .collect();
+    // let ranges_cnt = ranges.len();
+    // println!(
+    //     "[graft_masked_branches bench] case={_label} distribution={_distribution:?} bits={} ranges={ranges_cnt} mask={}",
+    //     pathmap::utils::BitMask::count_bits(&_child_mask),
+    //     _child_mask.fmt_binary(),
+    // );
+}
+
+fn make_case(masked_branch_count: usize, distribution: MaskDistribution) -> (PathMap<u32>, PathMap<u32>, ByteMask) {
+    let (masked_children, extra_children) = make_children(masked_branch_count, distribution);
 
     let mut src = PathMap::new();
     let mut dst = PathMap::new();
@@ -48,15 +90,13 @@ fn make_case(masked_branch_count: usize) -> (PathMap<u32>, PathMap<u32>, ByteMas
         src.set_val_at(&[child, 14], 40_001 + idx);
     }
 
-    (src, dst, ByteMask::from_iter(masked_children))
+    let child_mask = ByteMask::from_iter(masked_children);
+    debug_print_mask("full_src", distribution, child_mask);
+    (src, dst, child_mask)
 }
 
-fn make_partial_source_case(masked_branch_count: usize) -> (PathMap<u32>, PathMap<u32>, ByteMask) {
-    let masked_children: Vec<u8> = (0..masked_branch_count).map(|idx| idx as u8).collect();
-    let extra_branch_count = (masked_branch_count / 2).max(2);
-    let extra_children: Vec<u8> = (masked_branch_count..(masked_branch_count + extra_branch_count))
-        .map(|idx| idx as u8)
-        .collect();
+fn make_partial_source_case(masked_branch_count: usize, distribution: MaskDistribution) -> (PathMap<u32>, PathMap<u32>, ByteMask) {
+    let (masked_children, extra_children) = make_children(masked_branch_count, distribution);
 
     let mut src = PathMap::new();
     let mut dst = PathMap::new();
@@ -85,20 +125,18 @@ fn make_partial_source_case(masked_branch_count: usize) -> (PathMap<u32>, PathMa
         dst.set_val_at(&[child, 12, 13], 30_002 + idx);
     }
 
-    (src, dst, ByteMask::from_iter(masked_children))
+    let child_mask = ByteMask::from_iter(masked_children);
+    debug_print_mask("part_src", distribution, child_mask);
+    (src, dst, child_mask)
 }
 
-/// `remove_unset = false`, `src` contains hundreds of branches, regardless of mask
-#[divan::bench(sample_size = 1, args = BRANCH_COUNTS)]
-fn graft_masked_branches_keep_full_src(bencher: Bencher, masked_branch_count: usize) {
-    let (src_template, dst_template, child_mask) = make_case(masked_branch_count);
-
+fn run_graft_bench(bencher: Bencher, src_template: PathMap<u32>, dst_template: PathMap<u32>, child_mask: ByteMask, remove_unset: bool) {
     let out = bencher
         .with_inputs(|| (src_template.clone(), dst_template.clone()))
         .bench_local_values(|(src, mut dst)| {
             let mut wz = dst.write_zipper_at_path(b"");
             let rz = src.read_zipper_at_path(b"");
-            wz.graft_masked_branches(&rz, child_mask, false);
+            wz.graft_masked_branches(&rz, child_mask, remove_unset);
             drop(wz);
             dst
         });
@@ -106,62 +144,74 @@ fn graft_masked_branches_keep_full_src(bencher: Bencher, masked_branch_count: us
     divan::black_box_drop(out);
 }
 
-/// `remove_unset = true`, `src` contains hundreds of branches, regardless of mask
+/// - `remove_unset = false`
+/// - `src` contains hundreds of branches, regardless of mask
+/// - the mask bits are a contiguous range
 #[divan::bench(sample_size = 1, args = BRANCH_COUNTS)]
-fn graft_masked_branches_remove_full_src(bencher: Bencher, masked_branch_count: usize) {
-    let (src_template, dst_template, child_mask) = make_case(masked_branch_count);
-
-    let out = bencher
-        .with_inputs(|| (src_template.clone(), dst_template.clone()))
-        .bench_local_values(|(src, mut dst)| {
-            let mut wz = dst.write_zipper_at_path(b"");
-            let rz = src.read_zipper_at_path(b"");
-            wz.graft_masked_branches(&rz, child_mask, true);
-            drop(wz);
-            dst
-        });
-
-    divan::black_box_drop(out);
+fn graft_masked_branches_keep_full_src_contiguous(bencher: Bencher, masked_branch_count: usize) {
+    let (src_template, dst_template, child_mask) = make_case(masked_branch_count, MaskDistribution::Contiguous);
+    run_graft_bench(bencher, src_template, dst_template, child_mask, false);
 }
 
-/// `remove_unset = false`, `src` contains only the branches we're grafting
+/// - `remove_unset = false`
+/// - `src` contains hundreds of branches, regardless of mask
+/// - mask bits are distributed pseudorandomly
 #[divan::bench(sample_size = 1, args = BRANCH_COUNTS)]
-fn graft_masked_branches_keep_part_src(
-    bencher: Bencher,
-    masked_branch_count: usize,
-) {
-    let (src_template, dst_template, child_mask) = make_partial_source_case(masked_branch_count);
-
-    let out = bencher
-        .with_inputs(|| (src_template.clone(), dst_template.clone()))
-        .bench_local_values(|(src, mut dst)| {
-            let mut wz = dst.write_zipper_at_path(b"");
-            let rz = src.read_zipper_at_path(b"");
-            wz.graft_masked_branches(&rz, child_mask, false);
-            drop(wz);
-            dst
-        });
-
-    divan::black_box_drop(out);
+fn graft_masked_branches_keep_full_src_pseudorandom(bencher: Bencher, masked_branch_count: usize) {
+    let (src_template, dst_template, child_mask) = make_case(masked_branch_count, MaskDistribution::PseudoRandom);
+    run_graft_bench(bencher, src_template, dst_template, child_mask, false);
 }
 
-/// `remove_unset = true`, `src` contains only the branches we're grafting
+/// - `remove_unset = true`
+/// - `src` contains hundreds of branches, regardless of mask
+/// - the mask bits are a contiguous range
 #[divan::bench(sample_size = 1, args = BRANCH_COUNTS)]
-fn graft_masked_branches_remove_part_src(
-    bencher: Bencher,
-    masked_branch_count: usize,
-) {
-    let (src_template, dst_template, child_mask) = make_partial_source_case(masked_branch_count);
+fn graft_masked_branches_remove_full_src_contiguous(bencher: Bencher, masked_branch_count: usize) {
+    let (src_template, dst_template, child_mask) = make_case(masked_branch_count, MaskDistribution::Contiguous);
+    run_graft_bench(bencher, src_template, dst_template, child_mask, true);
+}
 
-    let out = bencher
-        .with_inputs(|| (src_template.clone(), dst_template.clone()))
-        .bench_local_values(|(src, mut dst)| {
-            let mut wz = dst.write_zipper_at_path(b"");
-            let rz = src.read_zipper_at_path(b"");
-            wz.graft_masked_branches(&rz, child_mask, true);
-            drop(wz);
-            dst
-        });
+/// - `remove_unset = true`
+/// - `src` contains hundreds of branches, regardless of mask
+/// - mask bits are distributed pseudorandomly
+#[divan::bench(sample_size = 1, args = BRANCH_COUNTS)]
+fn graft_masked_branches_remove_full_src_pseudorandom(bencher: Bencher, masked_branch_count: usize) {
+    let (src_template, dst_template, child_mask) = make_case(masked_branch_count, MaskDistribution::PseudoRandom);
+    run_graft_bench(bencher, src_template, dst_template, child_mask, true);
+}
 
-    divan::black_box_drop(out);
+/// - `remove_unset = false`
+/// - `src` contains only the branches we're grafting
+/// - the mask bits are a contiguous range
+#[divan::bench(sample_size = 1, args = BRANCH_COUNTS)]
+fn graft_masked_branches_keep_part_src_contiguous(bencher: Bencher, masked_branch_count: usize) {
+    let (src_template, dst_template, child_mask) = make_partial_source_case(masked_branch_count, MaskDistribution::Contiguous);
+    run_graft_bench(bencher, src_template, dst_template, child_mask, false);
+}
+
+/// - `remove_unset = false`
+/// - `src` contains only the branches we're grafting
+/// - mask bits are distributed pseudorandomly
+#[divan::bench(sample_size = 1, args = BRANCH_COUNTS)]
+fn graft_masked_branches_keep_part_src_pseudorandom(bencher: Bencher, masked_branch_count: usize) {
+    let (src_template, dst_template, child_mask) = make_partial_source_case(masked_branch_count, MaskDistribution::PseudoRandom);
+    run_graft_bench(bencher, src_template, dst_template, child_mask, false);
+}
+
+/// - `remove_unset = true`
+/// - `src` contains only the branches we're grafting,
+/// - the mask bits are a contiguous range
+#[divan::bench(sample_size = 1, args = BRANCH_COUNTS)]
+fn graft_masked_branches_remove_part_src_contiguous(bencher: Bencher, masked_branch_count: usize) {
+    let (src_template, dst_template, child_mask) = make_partial_source_case(masked_branch_count, MaskDistribution::Contiguous);
+    run_graft_bench(bencher, src_template, dst_template, child_mask, true);
+}
+
+/// - `remove_unset = true`
+/// - `src` contains only the branches we're grafting
+/// - mask bits are distributed pseudorandomly
+#[divan::bench(sample_size = 1, args = BRANCH_COUNTS)]
+fn graft_masked_branches_remove_part_src_pseudorandom(bencher: Bencher, masked_branch_count: usize) {
+    let (src_template, dst_template, child_mask) = make_partial_source_case(masked_branch_count, MaskDistribution::PseudoRandom);
+    run_graft_bench(bencher, src_template, dst_template, child_mask, true);
 }

--- a/pathmap-derive/src/lib.rs
+++ b/pathmap-derive/src/lib.rs
@@ -312,6 +312,12 @@ fn derive_poly_zipper_with_traits(
                         #(#variant_arms => inner.val(),)*
                     }
                 }
+
+                fn val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&V> {
+                    match self {
+                        #(#variant_arms => inner.val_at(path),)*
+                    }
+                }
             }
         })
     } else {
@@ -337,6 +343,12 @@ fn derive_poly_zipper_with_traits(
                 fn get_val(&self) -> Option<&'trie V> {
                     match self {
                         #(#variant_arms => inner.get_val(),)*
+                    }
+                }
+
+                fn get_val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&'trie V> {
+                    match self {
+                        #(#variant_arms => inner.get_val_at(path),)*
                     }
                 }
             }
@@ -789,6 +801,12 @@ fn derive_poly_zipper_with_traits(
                 fn get_focus(&self) -> pathmap::zipper::OpaqueAbstractNodeRef<'_, V, pathmap::alloc::GlobalAlloc> {
                     match self {
                         #(#variant_arms => inner.get_focus(),)*
+                    }
+                }
+
+                fn get_focus_at<K: AsRef<[u8]>>(&self, path: K) -> pathmap::zipper::OpaqueAbstractNodeRef<'_, V, pathmap::alloc::GlobalAlloc> {
+                    match self {
+                        #(#variant_arms => inner.get_focus_at(path),)*
                     }
                 }
 

--- a/src/arena_compact.rs
+++ b/src/arena_compact.rs
@@ -1497,8 +1497,12 @@ where Storage: AsRef<[u8]>
         let value = read_varint_u64(&data[1..]).0;
         Some(value)
     }
+
     /// Internal method to facilitate traversing to a path without needing to clone the zipper
-    fn get_value_at(&self, path: &[u8]) -> Option<u64> {
+    fn with_lookup_from_focus<R, F>(&self, path: &[u8], mut f: F) -> Option<R>
+    where
+        F: FnMut(Node, usize) -> Option<R>,
+    {
         if self.invalid > 0 {
             return None;
         }
@@ -1508,18 +1512,17 @@ where Storage: AsRef<[u8]>
         let mut node_depth = self.stack.last()?.node_depth;
 
         loop {
-            match &cur_node {
+            match cur_node {
                 Node::Branch(node) => {
                     if path.is_empty() {
-                        return node.value;
+                        return f(Node::Branch(node), node_depth);
                     }
                     if !node.bytemask.test_bit(path[0]) {
                         return None;
                     }
                     let first_child = node.first_child?;
                     let idx = node.bytemask.index_of(path[0]) as usize;
-                    let (node, _, _) = self.tree.nth_node(first_child, idx);
-                    cur_node = node;
+                    cur_node = self.tree.nth_node(first_child, idx).0;
                     node_depth = 0;
                     path = &path[1..];
                 }
@@ -1529,10 +1532,14 @@ where Storage: AsRef<[u8]>
                     if !starts_with(path, rest_path) {
                         return None;
                     }
+                    if path.len() < rest_path.len() {
+                        node_depth += path.len();
+                        return f(Node::Line(line), node_depth);
+                    }
                     path = &path[rest_path.len()..];
                     if path.is_empty() {
                         if line.value.is_some() {
-                            return line.value;
+                            return f(Node::Line(line), line_path.len());
                         }
                         cur_node = self.tree.get_node(line.child?).0;
                         node_depth = 0;
@@ -1543,6 +1550,21 @@ where Storage: AsRef<[u8]>
                 }
             }
         }
+    }
+    fn get_value_at(&self, path: &[u8]) -> Option<u64> {
+        self.with_lookup_from_focus(path, |node, node_depth| {
+            match node {
+                Node::Branch(node) => node.value,
+                Node::Line(line) => {
+                    let line_path = self.tree.get_line(line.path);
+                    if node_depth < line_path.len() {
+                        None
+                    } else {
+                        line.value
+                    }
+                }
+            }
+        })
     }
 
     fn ascend_invalid(&mut self, limit: Option<&mut usize>) -> bool {

--- a/src/arena_compact.rs
+++ b/src/arena_compact.rs
@@ -1655,6 +1655,10 @@ where Storage: AsRef<[u8]>
     fn val(&self) -> Option<&()> {
         self.get_value().map(|_x| &())
     }
+    fn val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&()> {
+//GOAT
+        panic!()
+    }
 }
 
 impl<'tree, Storage> ZipperValues<u64> for ACTZipper<'tree, Storage, u64>
@@ -1663,7 +1667,7 @@ where Storage: AsRef<[u8]>
     fn val(&self) -> Option<&u64> {
         let value = self.get_value()?;
         if self.tree.value.get() != value {
-            self.tree.value.set(value);            
+            self.tree.value.set(value);
         }
         let ptr = self.tree.value.as_ptr();
         // technically if someone borrows the value twice, they will hit UB
@@ -1672,6 +1676,10 @@ where Storage: AsRef<[u8]>
         // all of this is done so that the value can be borrowed with the same
         // lifetime as the tree.
         Some(unsafe { &*ptr })
+    }
+    fn val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&u64> {
+//GOAT
+        panic!()
     }
 }
 
@@ -1699,6 +1707,10 @@ where Storage: AsRef<[u8]>
     fn get_val(&self) -> Option<&'tree ()> {
         self.get_value().map(|_x| &())
     }
+    fn get_val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&'tree ()> {
+//GOAT
+        panic!()
+    }
 }
 
 impl<'tree, Storage> ZipperReadOnlyValues<'tree, u64> for ACTZipper<'tree, Storage, u64>
@@ -1711,6 +1723,10 @@ where Storage: AsRef<[u8]>
         }
         let ptr = self.tree.value.as_ptr();
         Some(unsafe { &*ptr })
+    }
+    fn get_val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&'tree u64> {
+//GOAT
+        panic!()
     }
 }
 

--- a/src/arena_compact.rs
+++ b/src/arena_compact.rs
@@ -1497,6 +1497,53 @@ where Storage: AsRef<[u8]>
         let value = read_varint_u64(&data[1..]).0;
         Some(value)
     }
+    /// Internal method to facilitate traversing to a path without needing to clone the zipper
+    fn get_value_at(&self, path: &[u8]) -> Option<u64> {
+        if self.invalid > 0 {
+            return None;
+        }
+
+        let mut path = path;
+        let mut cur_node = self.cur_node.clone();
+        let mut node_depth = self.stack.last()?.node_depth;
+
+        loop {
+            match &cur_node {
+                Node::Branch(node) => {
+                    if path.is_empty() {
+                        return node.value;
+                    }
+                    if !node.bytemask.test_bit(path[0]) {
+                        return None;
+                    }
+                    let first_child = node.first_child?;
+                    let idx = node.bytemask.index_of(path[0]) as usize;
+                    let (node, _, _) = self.tree.nth_node(first_child, idx);
+                    cur_node = node;
+                    node_depth = 0;
+                    path = &path[1..];
+                }
+                Node::Line(line) => {
+                    let line_path = self.tree.get_line(line.path);
+                    let rest_path = &line_path[node_depth..];
+                    if !starts_with(path, rest_path) {
+                        return None;
+                    }
+                    path = &path[rest_path.len()..];
+                    if path.is_empty() {
+                        if line.value.is_some() {
+                            return line.value;
+                        }
+                        cur_node = self.tree.get_node(line.child?).0;
+                        node_depth = 0;
+                        continue;
+                    }
+                    cur_node = self.tree.get_node(line.child?).0;
+                    node_depth = 0;
+                }
+            }
+        }
+    }
 
     fn ascend_invalid(&mut self, limit: Option<&mut usize>) -> bool {
         if self.invalid == 0 {
@@ -1656,8 +1703,7 @@ where Storage: AsRef<[u8]>
         self.get_value().map(|_x| &())
     }
     fn val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&()> {
-//GOAT
-        panic!()
+        self.get_value_at(path.as_ref()).map(|_x| &())
     }
 }
 
@@ -1665,21 +1711,12 @@ impl<'tree, Storage> ZipperValues<u64> for ACTZipper<'tree, Storage, u64>
 where Storage: AsRef<[u8]>
 {
     fn val(&self) -> Option<&u64> {
-        let value = self.get_value()?;
-        if self.tree.value.get() != value {
-            self.tree.value.set(value);
-        }
-        let ptr = self.tree.value.as_ptr();
-        // technically if someone borrows the value twice, they will hit UB
-        // since we provided a read-only reference to the value, and we ALSO
-        // can update it.
-        // all of this is done so that the value can be borrowed with the same
-        // lifetime as the tree.
-        Some(unsafe { &*ptr })
+        //GOAT, see soundness discussion in ZipperReadOnlyValues impl below
+        self.get_val()
     }
     fn val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&u64> {
-//GOAT
-        panic!()
+        //GOAT, see soundness discussion in ZipperReadOnlyValues impl below
+        self.get_val_at(path)
     }
 }
 
@@ -1708,8 +1745,7 @@ where Storage: AsRef<[u8]>
         self.get_value().map(|_x| &())
     }
     fn get_val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&'tree ()> {
-//GOAT
-        panic!()
+        self.get_value_at(path.as_ref()).map(|_x| &())
     }
 }
 
@@ -1722,11 +1758,26 @@ where Storage: AsRef<[u8]>
             self.tree.value.set(value);
         }
         let ptr = self.tree.value.as_ptr();
+        // technically if someone borrows the value twice, they will hit UB
+        // since we provided a read-only reference to the value, and we ALSO
+        // can update it.
+        // all of this is done so that the value can be borrowed with the same
+        // lifetime as the tree.
+        //
+        //LP: GOAT, UNSOUND!!, this seems like a pretty horrible soundness hole
+        // For `val()` the simple fix is to move the temporary value Cell onto the zipper, but that doesn't
+        // address `get_val()`, `val_at()`, nor `get_val_at()`.  It seems like the only comprehensive fix is
+        // to split the ZipperValues trait into one that can return borrowed values and one that returns
+        // cloned values.  And ZipperReadOnlyValues simply could not be implemented on ACTZipper.
         Some(unsafe { &*ptr })
     }
     fn get_val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&'tree u64> {
-//GOAT
-        panic!()
+        let value = self.get_value_at(path.as_ref())?;
+        if self.tree.value.get() != value {
+            self.tree.value.set(value);
+        }
+        let ptr = self.tree.value.as_ptr();
+        Some(unsafe { &*ptr })
     }
 }
 

--- a/src/dense_byte_node.rs
+++ b/src/dense_byte_node.rs
@@ -1462,6 +1462,51 @@ impl<V: Clone + Send + Sync, A: Allocator> TrieNodeDowncast<V, A> for ByteNode<C
     }
 }
 
+/// Used in the optimized implementation of `graft_masked_branches`
+pub(crate) fn merge_branches_into_byte_node<V: Clone + Send + Sync, A: Allocator, Cf: CoFree<V=V, A=A>>(
+    dst_node: &mut ByteNode<Cf, A>,
+    src_node: &DenseByteNode<V, A>,
+    child_mask: ByteMask,
+    remove_unset: bool,
+) {
+    let old_mask = dst_node.mask;
+    let mut old_values = ValuesVec::default_in(dst_node.alloc.clone());
+    core::mem::swap(&mut old_values.v, &mut dst_node.values);
+
+    let mut new_values = ValuesVec::with_capacity_in(old_values.v.len() + child_mask.count_bits(), dst_node.alloc.clone());
+    let mut old_values = old_values.v.into_iter();
+    let mut new_mask = ByteMask::EMPTY;
+
+    for child_byte in ALL_BYTES {
+        let old_cf = if old_mask.test_bit(child_byte) {
+            Some(old_values.next().unwrap())
+        } else {
+            None
+        };
+        let (mut rec, mut val) = match old_cf {
+            Some(cf) => cf.into_both(),
+            None => (None, None)
+        };
+
+        if child_mask.test_bit(child_byte) {
+            rec = src_node.get(child_byte).and_then(|cf| cf.rec()).cloned();
+            val = src_node.get(child_byte).and_then(|cf| cf.val()).cloned();
+        } else if remove_unset {
+            rec = None;
+            val = None;
+        }
+
+        if rec.is_some() || val.is_some() {
+            new_mask.set_bit(child_byte);
+            new_values.v.push(Cf::new(rec, val));
+        }
+    }
+
+    debug_assert!(old_values.next().is_none());
+    dst_node.mask = new_mask;
+    dst_node.values = new_values.v;
+}
+
 /// returns the position of the next/previous active bit in x
 /// if there is no next/previous bit, returns the argument position
 /// assumes that pos is active in x

--- a/src/dense_byte_node.rs
+++ b/src/dense_byte_node.rs
@@ -1463,46 +1463,54 @@ impl<V: Clone + Send + Sync, A: Allocator> TrieNodeDowncast<V, A> for ByteNode<C
 }
 
 /// Used in the optimized implementation of `graft_masked_branches`
-pub(crate) fn merge_branches_into_byte_node<V: Clone + Send + Sync, A: Allocator, Cf: CoFree<V=V, A=A>>(
+pub(crate) fn merge_branches_into_byte_node<V: Clone + Send + Sync, A: Allocator, Cf: CoFree<V=V, A=A>, const REMOVE_UNSET: bool>(
     dst_node: &mut ByteNode<Cf, A>,
     src_node: &DenseByteNode<V, A>,
-    child_mask: ByteMask,
-    remove_unset: bool,
+    child_mask: ByteMask
 ) {
     let old_mask = dst_node.mask;
     let mut old_values = ValuesVec::default_in(dst_node.alloc.clone());
     core::mem::swap(&mut old_values.v, &mut dst_node.values);
 
-    let mut new_values = ValuesVec::with_capacity_in(old_values.v.len() + child_mask.count_bits(), dst_node.alloc.clone());
+    let combined_mask = if REMOVE_UNSET {
+        child_mask
+    } else {
+        child_mask | old_mask
+    };
+
+    let mut new_values = ValuesVec::with_capacity_in(combined_mask.count_bits(), dst_node.alloc.clone());
     let mut old_values = old_values.v.into_iter();
-    let mut new_mask = ByteMask::EMPTY;
+    let mut new_mask = combined_mask;
 
-    for child_byte in ALL_BYTES {
-        let old_cf = if old_mask.test_bit(child_byte) {
-            Some(old_values.next().unwrap())
+    for child_byte in combined_mask.iter() {
+        let (rec, val) = if REMOVE_UNSET {
+            let rec = src_node.get(child_byte).and_then(|cf| cf.rec()).cloned();
+            let val = src_node.get(child_byte).and_then(|cf| cf.val()).cloned();
+            (rec, val)
         } else {
-            None
+            let old_cf = if old_mask.test_bit(child_byte) {
+                Some(old_values.next().unwrap())
+            } else {
+                None
+            };
+            if child_mask.test_bit(child_byte) {
+                let rec = src_node.get(child_byte).and_then(|cf| cf.rec()).cloned();
+                let val = src_node.get(child_byte).and_then(|cf| cf.val()).cloned();
+                (rec, val)
+            } else {
+                match old_cf {
+                    Some(cf) => cf.into_both(),
+                    None => (None, None)
+                }
+            }
         };
-        let (mut rec, mut val) = match old_cf {
-            Some(cf) => cf.into_both(),
-            None => (None, None)
-        };
-
-        if child_mask.test_bit(child_byte) {
-            rec = src_node.get(child_byte).and_then(|cf| cf.rec()).cloned();
-            val = src_node.get(child_byte).and_then(|cf| cf.val()).cloned();
-        } else if remove_unset {
-            rec = None;
-            val = None;
-        }
-
         if rec.is_some() || val.is_some() {
-            new_mask.set_bit(child_byte);
             new_values.v.push(Cf::new(rec, val));
+        } else {
+            new_mask.clear_bit(child_byte);
         }
     }
 
-    debug_assert!(old_values.next().is_none());
     dst_node.mask = new_mask;
     dst_node.values = new_values.v;
 }

--- a/src/dense_byte_node.rs
+++ b/src/dense_byte_node.rs
@@ -1464,19 +1464,18 @@ impl<V: Clone + Send + Sync, A: Allocator> TrieNodeDowncast<V, A> for ByteNode<C
 
 /// Used in the optimized implementation of `graft_masked_branches`
 pub(crate) fn merge_branches_into_byte_node<V: Clone + Send + Sync, A: Allocator, CfDst: CoFree<V=V, A=A>, CfSrc: CoFree<V=V, A=A>, const REMOVE_UNSET: bool>(
-    dst_node: &mut ByteNode<CfDst, A>,
+    dst_node: &ByteNode<CfDst, A>,
     src_node: &ByteNode<CfSrc, A>,
     child_mask: ByteMask
-) {
+) -> TrieNodeODRc<V, A>
+where
+    ByteNode<CfDst, A>: TrieNodeDowncast<V, A>,
+{
     let old_mask = dst_node.mask;
-    let mut old_values = ValuesVec::default_in(dst_node.alloc.clone());
-    core::mem::swap(&mut old_values.v, &mut dst_node.values);
-    let mut old_values = old_values.v.into_iter();
     let combined_mask = if REMOVE_UNSET { child_mask } else { child_mask | old_mask };
     let mut new_values = ValuesVec::with_capacity_in(combined_mask.count_bits(), dst_node.alloc.clone());
     let mut prev_end = 0;
     let mut new_mask = ByteMask::EMPTY;
-    let mut old_values_consumed = 0usize;
 
     //Loop over each contiguous range in `child_mask`
     for range in child_mask.range_iter() {
@@ -1488,21 +1487,12 @@ pub(crate) fn merge_branches_into_byte_node<V: Clone + Send + Sync, A: Allocator
             let gap_mask = old_mask & ByteMask::from_range(gap_start..range_start);
             let gap_len = gap_mask.count_bits();
             if gap_len > 0 {
-                for _ in 0..gap_len {
-                    new_values.v.push(old_values.next().unwrap());
+                let gap_ix = old_mask.index_of(gap_start) as usize;
+                for cf in &dst_node.values[gap_ix..gap_ix + gap_len] {
+                    new_values.v.push(CfDst::from_cf(cf.clone()));
                 }
-                old_values_consumed += gap_len;
                 new_mask = new_mask | gap_mask;
             }
-        }
-
-        if !REMOVE_UNSET {
-            let old_range_mask = old_mask & ByteMask::from_range(range_start..=range_end);
-            let old_range_len = old_range_mask.count_bits();
-            for _ in 0..old_range_len {
-                let _ = old_values.next().unwrap();
-            }
-            old_values_consumed += old_range_len;
         }
 
         let src_range_mask = src_node.mask & ByteMask::from_range(range_start..=range_end);
@@ -1525,22 +1515,15 @@ pub(crate) fn merge_branches_into_byte_node<V: Clone + Send + Sync, A: Allocator
         let tail_mask = old_mask & ByteMask::from_range(tail_start..);
         let tail_len = tail_mask.count_bits();
         if tail_len > 0 {
-            debug_assert_eq!(old_values_consumed, old_mask.index_of(tail_start) as usize);
-            for _ in 0..tail_len {
-                new_values.v.push(old_values.next().unwrap());
+            let tail_ix = old_mask.index_of(tail_start) as usize;
+            for cf in &dst_node.values[tail_ix..tail_ix + tail_len] {
+                new_values.v.push(CfDst::from_cf(cf.clone()));
             }
-            old_values_consumed += tail_len;
             new_mask = new_mask | tail_mask;
         }
     }
 
-    if !REMOVE_UNSET {
-        debug_assert_eq!(old_values_consumed, old_mask.count_bits());
-        debug_assert!(old_values.next().is_none());
-    }
-
-    dst_node.mask = new_mask;
-    dst_node.values = new_values.v;
+    TrieNodeODRc::new_in(ByteNode::new_with_fields_in(new_mask, new_values, dst_node.alloc.clone()), dst_node.alloc.clone())
 }
 
 /// returns the position of the next/previous active bit in x

--- a/src/dense_byte_node.rs
+++ b/src/dense_byte_node.rs
@@ -1471,46 +1471,72 @@ pub(crate) fn merge_branches_into_byte_node<V: Clone + Send + Sync, A: Allocator
     let old_mask = dst_node.mask;
     let mut old_values = ValuesVec::default_in(dst_node.alloc.clone());
     core::mem::swap(&mut old_values.v, &mut dst_node.values);
-
-    let combined_mask = if REMOVE_UNSET {
-        child_mask
-    } else {
-        child_mask | old_mask
-    };
-
-    let mut new_values = ValuesVec::with_capacity_in(combined_mask.count_bits(), dst_node.alloc.clone());
     let mut old_values = old_values.v.into_iter();
-    let mut new_mask = combined_mask;
+    let combined_mask = if REMOVE_UNSET { child_mask } else { child_mask | old_mask };
+    let mut new_values = ValuesVec::with_capacity_in(combined_mask.count_bits(), dst_node.alloc.clone());
+    let mut prev_end = 0;
+    let mut new_mask = ByteMask::EMPTY;
+    let mut old_values_consumed = 0usize;
 
-    for child_byte in combined_mask.iter() {
-        let (rec, val) = if REMOVE_UNSET {
-            match src_node.get(child_byte) {
-                Some(cf) => (cf.rec().cloned(), cf.val().cloned()),
-                None => (None, None)
-            }
-        } else {
-            let old_cf = if old_mask.test_bit(child_byte) {
-                Some(old_values.next().unwrap())
-            } else {
-                None
-            };
-            if child_mask.test_bit(child_byte) {
-                match src_node.get(child_byte) {
-                    Some(cf) => (cf.rec().cloned(), cf.val().cloned()),
-                    None => (None, None)
+    //Loop over each contiguous range in `child_mask`
+    for range in child_mask.range_iter() {
+        let range_start = *range.start();
+        let range_end = *range.end();
+
+        if !REMOVE_UNSET && prev_end < range_start as usize {
+            let gap_start = prev_end as u8;
+            let gap_mask = old_mask & ByteMask::from_range(gap_start..range_start);
+            let gap_len = gap_mask.count_bits();
+            if gap_len > 0 {
+                for _ in 0..gap_len {
+                    new_values.v.push(old_values.next().unwrap());
                 }
-            } else {
-                match old_cf {
-                    Some(cf) => cf.into_both(),
-                    None => (None, None)
-                }
+                old_values_consumed += gap_len;
+                new_mask = new_mask | gap_mask;
             }
-        };
-        if rec.is_some() || val.is_some() {
-            new_values.v.push(CfDst::new(rec, val));
-        } else {
-            new_mask.clear_bit(child_byte);
         }
+
+        if !REMOVE_UNSET {
+            let old_range_mask = old_mask & ByteMask::from_range(range_start..=range_end);
+            let old_range_len = old_range_mask.count_bits();
+            for _ in 0..old_range_len {
+                let _ = old_values.next().unwrap();
+            }
+            old_values_consumed += old_range_len;
+        }
+
+        let src_range_mask = src_node.mask & ByteMask::from_range(range_start..=range_end);
+        let mut src_ix = src_node.mask.index_of(range_start) as usize;
+        for child_byte in src_range_mask.iter() {
+            let cf = unsafe { src_node.values.get_unchecked(src_ix) };
+            src_ix += 1;
+
+            if cf.has_rec() || cf.has_val() {
+                new_values.v.push(CfDst::from_cf(cf.clone()));
+                new_mask.set_bit(child_byte);
+            }
+        }
+
+        prev_end = range_end as usize + 1;
+    }
+
+    if !REMOVE_UNSET && prev_end < 256 {
+        let tail_start = prev_end as u8;
+        let tail_mask = old_mask & ByteMask::from_range(tail_start..);
+        let tail_len = tail_mask.count_bits();
+        if tail_len > 0 {
+            debug_assert_eq!(old_values_consumed, old_mask.index_of(tail_start) as usize);
+            for _ in 0..tail_len {
+                new_values.v.push(old_values.next().unwrap());
+            }
+            old_values_consumed += tail_len;
+            new_mask = new_mask | tail_mask;
+        }
+    }
+
+    if !REMOVE_UNSET {
+        debug_assert_eq!(old_values_consumed, old_mask.count_bits());
+        debug_assert!(old_values.next().is_none());
     }
 
     dst_node.mask = new_mask;

--- a/src/dense_byte_node.rs
+++ b/src/dense_byte_node.rs
@@ -1463,9 +1463,9 @@ impl<V: Clone + Send + Sync, A: Allocator> TrieNodeDowncast<V, A> for ByteNode<C
 }
 
 /// Used in the optimized implementation of `graft_masked_branches`
-pub(crate) fn merge_branches_into_byte_node<V: Clone + Send + Sync, A: Allocator, Cf: CoFree<V=V, A=A>, const REMOVE_UNSET: bool>(
-    dst_node: &mut ByteNode<Cf, A>,
-    src_node: &DenseByteNode<V, A>,
+pub(crate) fn merge_branches_into_byte_node<V: Clone + Send + Sync, A: Allocator, CfDst: CoFree<V=V, A=A>, CfSrc: CoFree<V=V, A=A>, const REMOVE_UNSET: bool>(
+    dst_node: &mut ByteNode<CfDst, A>,
+    src_node: &ByteNode<CfSrc, A>,
     child_mask: ByteMask
 ) {
     let old_mask = dst_node.mask;
@@ -1507,7 +1507,7 @@ pub(crate) fn merge_branches_into_byte_node<V: Clone + Send + Sync, A: Allocator
             }
         };
         if rec.is_some() || val.is_some() {
-            new_values.v.push(Cf::new(rec, val));
+            new_values.v.push(CfDst::new(rec, val));
         } else {
             new_mask.clear_bit(child_byte);
         }

--- a/src/dense_byte_node.rs
+++ b/src/dense_byte_node.rs
@@ -1484,9 +1484,10 @@ pub(crate) fn merge_branches_into_byte_node<V: Clone + Send + Sync, A: Allocator
 
     for child_byte in combined_mask.iter() {
         let (rec, val) = if REMOVE_UNSET {
-            let rec = src_node.get(child_byte).and_then(|cf| cf.rec()).cloned();
-            let val = src_node.get(child_byte).and_then(|cf| cf.val()).cloned();
-            (rec, val)
+            match src_node.get(child_byte) {
+                Some(cf) => (cf.rec().cloned(), cf.val().cloned()),
+                None => (None, None)
+            }
         } else {
             let old_cf = if old_mask.test_bit(child_byte) {
                 Some(old_values.next().unwrap())
@@ -1494,9 +1495,10 @@ pub(crate) fn merge_branches_into_byte_node<V: Clone + Send + Sync, A: Allocator
                 None
             };
             if child_mask.test_bit(child_byte) {
-                let rec = src_node.get(child_byte).and_then(|cf| cf.rec()).cloned();
-                let val = src_node.get(child_byte).and_then(|cf| cf.val()).cloned();
-                (rec, val)
+                match src_node.get(child_byte) {
+                    Some(cf) => (cf.rec().cloned(), cf.val().cloned()),
+                    None => (None, None)
+                }
             } else {
                 match old_cf {
                     Some(cf) => cf.into_both(),

--- a/src/dependent_zipper.rs
+++ b/src/dependent_zipper.rs
@@ -241,6 +241,13 @@ impl<'trie, PrimaryZ, SecondaryZ, V, C, F : Clone + for <'a> FnOnce(C, &'a [u8],
             self.primary.val()
         }
     }
+    fn val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&V> {
+        if let Some(idx) = self.factor_idx(true) {
+            self.secondary[idx].val_at(path)
+        } else {
+            self.primary.val_at(path)
+        }
+    }
 }
 
 impl<'trie, PrimaryZ, SecondaryZ, V, C, F : Clone + for <'a> FnOnce(C, &'a [u8], usize) -> (C, Option<SecondaryZ>)> ZipperReadOnlyValues<'trie, V>
@@ -255,6 +262,13 @@ impl<'trie, PrimaryZ, SecondaryZ, V, C, F : Clone + for <'a> FnOnce(C, &'a [u8],
             self.secondary[idx].get_val()
         } else {
             self.primary.get_val()
+        }
+    }
+    fn get_val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&'trie V> {
+        if let Some(idx) = self.factor_idx(true) {
+            self.secondary[idx].get_val_at(path)
+        } else {
+            self.primary.get_val_at(path)
         }
     }
 }

--- a/src/empty_zipper.rs
+++ b/src/empty_zipper.rs
@@ -90,6 +90,7 @@ impl ZipperIteration for EmptyZipper {
 
 impl<V> ZipperValues<V> for EmptyZipper {
     fn val(&self) -> Option<&V> { None }
+    fn val_at<K: AsRef<[u8]>>(&self, _path: K) -> Option<&V> { None }
 }
 
 impl<V> ZipperForking<V> for EmptyZipper {
@@ -99,6 +100,7 @@ impl<V> ZipperForking<V> for EmptyZipper {
 
 impl<'a, V: Clone + Send + Sync> ZipperReadOnlyValues<'a, V> for EmptyZipper {
     fn get_val(&self) -> Option<&'a V> { None }
+    fn get_val_at<K: AsRef<[u8]>>(&self, _path: K) -> Option<&'a V> { None }
 }
 
 impl<'a, V: Clone + Send + Sync> ZipperReadOnlyConditionalValues<'a, V> for EmptyZipper {

--- a/src/experimental.rs
+++ b/src/experimental.rs
@@ -155,6 +155,7 @@ impl <V: TrieValue + 'static, A: Allocator> ZipperWriting<V, A> for NullZipper {
     fn remove_val(&mut self, _prune: bool) -> Option<V> { None }
     fn zipper_head<'z>(&'z mut self) -> Self::ZipperHead<'z> { todo!() }
     fn graft<Z: ZipperInfallibleSubtries<V, A>>(&mut self, _read_zipper: &Z) {}
+    fn graft_src_at<Z: ZipperInfallibleSubtries<V, A>, K: AsRef<[u8]>>(&mut self, src: &Z, path: K) {}
     fn graft_map(&mut self, _map: PathMap<V, A>) {}
     fn join_into<Z: ZipperInfallibleSubtries<V, A>>(&mut self, _read_zipper: &Z) -> AlgebraicStatus where V: Lattice { AlgebraicStatus::Element }
     fn join_map_into(&mut self, _map: PathMap<V, A>) -> AlgebraicStatus where V: Lattice { AlgebraicStatus::Element }

--- a/src/experimental/serialization.rs
+++ b/src/experimental/serialization.rs
@@ -853,7 +853,7 @@ pub fn deserialize_file<V: TrieValue>(file_path : impl AsRef<std::path::Path>, d
                              let [mask_idx, branches_idx] = node_buf.map(|x| x as usize);
 
                              let Deserialized::ChildMask(mask) = &deserialized[mask_idx] else { return Err(std::io::Error::other("Malformed serialized ByteTrie, expected childmask as `(/?<hex_top><Hex_bot>)*`")); };
-                             let iter = crate::utils::ByteMaskIter::new(*mask);
+                             let iter: crate::utils::ByteMaskIter = (*mask).into();
 
                              let Deserialized::Branches(r) = &deserialized[branches_idx] else { return Err(std::io::Error::other("Malformed serialized ByteTrie, expected branches")); };
                              let branches = &branches_buffer[r.start..r.end];

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -1485,7 +1485,7 @@ impl<V: Clone + Send + Sync> MergePolicy<V> for Join {
         Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
         Out: ZipperWriting<V, A>,
     {
-        out.graft_children(z, range);
+        out.graft_masked_branches(z, range, false)
     }
 
     #[inline]
@@ -1500,7 +1500,7 @@ impl<V: Clone + Send + Sync> MergePolicy<V> for Join {
         Z: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
         Out: ZipperWriting<V, A>,
     {
-        out.graft_children(z, ByteMask::FULL);
+        out.graft_masked_branches(z, ByteMask::FULL, false)
     }
 }
 
@@ -1575,7 +1575,7 @@ impl<V: Clone + Send + Sync> MergePolicy<V> for Meet {
         Z: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
         Out: ZipperWriting<V, A>,
     {
-        out.graft_children(z, ByteMask::FULL);
+        out.graft_masked_branches(z, ByteMask::FULL, false);
     }
 }
 
@@ -1650,7 +1650,7 @@ impl<V: Clone + Send + Sync> MergePolicy<V> for Subtract {
         Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
         Out: ZipperWriting<V, A>,
     {
-        out.graft_children(z, range);
+        out.graft_masked_branches(z, range, false);
     }
 
     #[inline]
@@ -1670,7 +1670,7 @@ impl<V: Clone + Send + Sync> MergePolicy<V> for Subtract {
         Out: ZipperWriting<V, A>,
     {
         if mask == 1 {
-            out.graft_children(z, range);
+            out.graft_masked_branches(z, range, false)
         }
     }
 

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -1786,6 +1786,13 @@ mod zipper_algebra_poly {
             }
         }
 
+        fn get_focus_at<K: AsRef<[u8]>>(&self, path: K) -> OpaqueAbstractNodeRef<'_, V, A> {
+            match self {
+                SomeMutRefZ::RZ(inner) => inner.get_focus_at(path),
+                SomeMutRefZ::RZT(inner) => inner.get_focus_at(path),
+            }
+        }
+
         fn try_borrow_focus(&self) -> Option<OpaqueTrieNodeRef<'_, V, A>> {
             match self {
                 SomeMutRefZ::RZ(inner) => inner.try_borrow_focus(),

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -98,6 +98,16 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperAlgebraExt<V, A>
 {
 }
 
+impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperAlgebraExt<V, A>
+    for ReadZipperOwned<V, A>
+{
+}
+
+impl<Z, V: Clone + Send + Sync + Unpin, A: Allocator> ZipperAlgebraExt<V, A> for PrefixZipper<'_, Z> where
+    Z: ZipperInfallibleSubtries<V, A> + ZipperSubtries<V, A> + ZipperConcrete + ZipperMoving
+{
+}
+
 /// Performs an ordered join (least upper bound) of two radix-256 tries using zipper traversal.
 ///
 /// This function merges two tries by simultaneously traversing them in lexicographic order,
@@ -1760,6 +1770,8 @@ mod zipper_algebra_poly {
     pub(super) enum SomeMutRefZ<'a, 'trie, 'path, V: Clone + Send + Sync + Unpin, A: Allocator> {
         RZ(&'a mut ReadZipperUntracked<'trie, 'path, V, A>),
         RZT(&'a mut ReadZipperTracked<'trie, 'path, V, A>),
+        PZRZ(&'a mut PrefixZipper<'a, ReadZipperUntracked<'trie, 'path, V, A>>),
+        PZRZT(&'a mut PrefixZipper<'a, ReadZipperTracked<'trie, 'path, V, A>>),
     }
 
     impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperInfallibleSubtries<V, A>
@@ -1769,6 +1781,8 @@ mod zipper_algebra_poly {
             match self {
                 SomeMutRefZ::RZ(inner) => inner.make_map(),
                 SomeMutRefZ::RZT(inner) => inner.make_map(),
+                SomeMutRefZ::PZRZ(inner) => inner.make_map(),
+                SomeMutRefZ::PZRZT(inner) => inner.make_map(),
             }
         }
 
@@ -1776,6 +1790,8 @@ mod zipper_algebra_poly {
             match self {
                 SomeMutRefZ::RZ(inner) => inner.get_trie_ref(),
                 SomeMutRefZ::RZT(inner) => inner.get_trie_ref(),
+                SomeMutRefZ::PZRZ(inner) => inner.get_trie_ref(),
+                SomeMutRefZ::PZRZT(inner) => inner.get_trie_ref(),
             }
         }
 
@@ -1783,6 +1799,8 @@ mod zipper_algebra_poly {
             match self {
                 SomeMutRefZ::RZ(inner) => inner.get_focus(),
                 SomeMutRefZ::RZT(inner) => inner.get_focus(),
+                SomeMutRefZ::PZRZ(inner) => inner.get_focus(),
+                SomeMutRefZ::PZRZT(inner) => inner.get_focus(),
             }
         }
 
@@ -1790,6 +1808,8 @@ mod zipper_algebra_poly {
             match self {
                 SomeMutRefZ::RZ(inner) => inner.get_focus_at(path),
                 SomeMutRefZ::RZT(inner) => inner.get_focus_at(path),
+                SomeMutRefZ::PZRZ(inner) => inner.get_focus_at(path),
+                SomeMutRefZ::PZRZT(inner) => inner.get_focus_at(path),
             }
         }
 
@@ -1797,6 +1817,8 @@ mod zipper_algebra_poly {
             match self {
                 SomeMutRefZ::RZ(inner) => inner.try_borrow_focus(),
                 SomeMutRefZ::RZT(inner) => inner.try_borrow_focus(),
+                SomeMutRefZ::PZRZ(inner) => inner.try_borrow_focus(),
+                SomeMutRefZ::PZRZT(inner) => inner.try_borrow_focus(),
             }
         }
     }

--- a/src/overlay_zipper.rs
+++ b/src/overlay_zipper.rs
@@ -104,6 +104,9 @@ impl<AV, BV, OutV, AZipper, BZipper, Mapping> ZipperValues<OutV>
     fn val(&self) -> Option<&OutV> {
         (self.mapping)(self.a.val(), self.b.val())
     }
+    fn val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&OutV> {
+        (self.mapping)(self.a.val_at(&path), self.b.val_at(&path))
+    }
 }
 
 impl<AV, BV, OutV, AZipper, BZipper, Mapping> Zipper

--- a/src/poly_zipper.rs
+++ b/src/poly_zipper.rs
@@ -142,7 +142,7 @@ mod tests {
     // ======================================================================================
     // Cocktail of recursive zipper madness
     #[derive(PolyZipperExplicit)]
-    #[poly_zipper_explicit(traits(Zipper, ZipperMoving, ZipperIteration))]
+    #[poly_zipper_explicit(traits(Zipper, ZipperValues, ZipperMoving, ZipperIteration))]
     pub enum ExprFactor<'trie, V: Clone + Send + Sync + Unpin + 'static = ()> {
         Specific(ReadZipperOwned<V>),
         Generic(PrefixZipper<'trie,

--- a/src/prefix_zipper.rs
+++ b/src/prefix_zipper.rs
@@ -226,6 +226,15 @@ impl<'prefix, Z, V> ZipperValues<V> for PrefixZipper<'prefix, Z>
         }
         self.source.val()
     }
+    fn val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&V> {
+        if self.position.is_source() {
+            self.source.val_at(path)
+        } else {
+//GOAT, If path is a valid continuation of the prefix then adjust it appropriately and fall through to a call to `val_at`, otherwise return None
+//Make sure there is a test to exercise all 3 branches through this code
+            panic!()
+        }
+    }
 }
 
 impl<'prefix, 'source, Z, V> ZipperReadOnlyValues<'source, V>
@@ -238,6 +247,15 @@ impl<'prefix, 'source, Z, V> ZipperReadOnlyValues<'source, V>
             return None;
         }
         self.source.get_val()
+    }
+    fn get_val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&'source V> {
+        if self.position.is_source() {
+            self.source.get_val_at(path)
+        } else {
+//GOAT, If path is a valid continuation of the prefix then adjust it appropriately and fall through to a call to `get_val_at`, otherwise return None
+//Make sure there is a test to exercise all 3 branches through this code
+            panic!()
+        }
     }
 }
 
@@ -634,6 +652,7 @@ impl<'prefix, V: Clone + Send + Sync + Unpin, Z, A: Allocator> ZipperInfallibleS
         }
     }
     fn get_focus(&self) -> OpaqueAbstractNodeRef<'_, V, A> { self.source.get_focus() }
+    fn get_focus_at<K: AsRef<[u8]>>(&self, path: K) -> OpaqueAbstractNodeRef<'_, V, A> { self.source.get_focus_at(path) }
     fn try_borrow_focus(&self) -> Option<OpaqueTrieNodeRef<'_, V, A>> { self.source.try_borrow_focus() }
 }
 

--- a/src/prefix_zipper.rs
+++ b/src/prefix_zipper.rs
@@ -186,6 +186,22 @@ impl<'prefix, Z>  PrefixZipper<'prefix, Z>
 }
 
 impl<'prefix, Z>  PrefixZipper<'prefix, Z> {
+    /// Private function to deal with `at` methods, that take paths relative to the zipper focus
+    #[inline]
+    fn adjust_lookup_path<'a>(&'a self, path: &'a [u8]) -> Option<&'a [u8]> {
+        match self.position {
+            PrefixPos::Source => Some(path),
+            PrefixPos::Prefix { valid } => {
+                let rest_prefix = &self.prefix[self.origin_depth + valid..];
+                if !starts_with(path, rest_prefix) {
+                    return None;
+                }
+                Some(&path[rest_prefix.len()..])
+            }
+            PrefixPos::PrefixOff { .. } => None,
+        }
+    }
+
     /// Returns the path that must be descended before the PrefixZipper's focus is at the root of the inner zipper, or
     /// `None` if the focus is no longer along the prefix path
     #[inline]
@@ -227,13 +243,8 @@ impl<'prefix, Z, V> ZipperValues<V> for PrefixZipper<'prefix, Z>
         self.source.val()
     }
     fn val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&V> {
-        if self.position.is_source() {
-            self.source.val_at(path)
-        } else {
-//GOAT, If path is a valid continuation of the prefix then adjust it appropriately and fall through to a call to `val_at`, otherwise return None
-//Make sure there is a test to exercise all 3 branches through this code
-            panic!()
-        }
+        let path = self.adjust_lookup_path(path.as_ref())?;
+        self.source.val_at(path)
     }
 }
 
@@ -243,19 +254,15 @@ impl<'prefix, 'source, Z, V> ZipperReadOnlyValues<'source, V>
         Z: ZipperReadOnlyValues<'source, V>
 {
     fn get_val(&self) -> Option<&'source V> {
+        //NOTE: This impl mirrors `val`
         if !self.position.is_source() {
             return None;
         }
         self.source.get_val()
     }
     fn get_val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&'source V> {
-        if self.position.is_source() {
-            self.source.get_val_at(path)
-        } else {
-//GOAT, If path is a valid continuation of the prefix then adjust it appropriately and fall through to a call to `get_val_at`, otherwise return None
-//Make sure there is a test to exercise all 3 branches through this code
-            panic!()
-        }
+        let path = self.adjust_lookup_path(path.as_ref())?;
+        self.source.get_val_at(path)
     }
 }
 

--- a/src/prefix_zipper.rs
+++ b/src/prefix_zipper.rs
@@ -672,6 +672,8 @@ mod tests {
     use crate::trie_map::PathMap;
     use crate::zipper::ZipperMoving;
     use crate::zipper::ZipperAbsolutePath;
+    use crate::zipper::ZipperReadOnlyValues;
+    use crate::zipper::ZipperValues;
     const PATHS1: &[(&[u8], u64)] = &[
         (b"0000", 0),
         (b"00000", 1),
@@ -683,6 +685,10 @@ mod tests {
         (b"000", 0),
         (b"00000", 0),
         (b"00111", 1),
+    ];
+    const PATHS3: &[(&[u8], u64)] = &[
+        (b"", 0),
+        (b"0000", 4),
     ];
 
     #[test]
@@ -726,5 +732,27 @@ mod tests {
         assert_eq!(rz.path(), b"");
         assert_eq!(rz.origin_path(), b"pre");
         assert_eq!(rz.ascend_until_branch(), false);
+    }
+
+    #[test]
+    fn prefix_zipper_val_at_test() {
+        let map = PathMap::from_iter(PATHS3.iter().map(|&x| x));
+        let mut rz = PrefixZipper::new(b"prefix", map.read_zipper());
+
+        //Validate that `val_at` and `get_val_at` do the right thing when the focus is in the wrapped zipper
+        rz.descend_to(b"prefix");
+        assert_eq!(rz.val_at(b"0000"), Some(&4));
+        assert_eq!(rz.get_val_at(b"0000"), Some(&4));
+
+        //Now make sure the right thing happens when we are coming from the prefix
+        rz.reset();
+        assert_eq!(rz.val_at(b"0000"), None);
+        assert_eq!(rz.get_val_at(b"0000"), None);
+        assert_eq!(rz.val_at(b"prefix0000"), Some(&4));
+        assert_eq!(rz.get_val_at(b"prefix0000"), Some(&4));
+        assert_eq!(rz.val_at(b"prefix"), Some(&0));
+        assert_eq!(rz.get_val_at(b"prefix"), Some(&0));
+        assert_eq!(rz.val_at(b"prefoo"), None);
+        assert_eq!(rz.get_val_at(b"prefoo"), None);
     }
 }

--- a/src/product_zipper.rs
+++ b/src/product_zipper.rs
@@ -15,7 +15,7 @@ pub struct ProductZipper<'factor_z, 'trie, V: Clone + Send + Sync, A: Allocator 
     /// which is conceptually the same as the end-point of each indexed factor
     factor_paths: Vec<usize>,
     /// We need to hang onto the zippers for the life of this object, so their trackers stay alive
-    source_zippers: Vec<Box<dyn ZipperSubtries<V, A> + 'factor_z>>
+    source_zippers: Vec<Box<dyn Zipper + 'factor_z>>
 }
 
 impl<V: Clone + Send + Sync + Unpin, A: Allocator> core::fmt::Debug for ProductZipper<'_, '_, V, A> {
@@ -54,7 +54,7 @@ impl<'factor_z, 'trie, V: Clone + Send + Sync + Unpin, A: Allocator> ProductZipp
         //Get the core out of the primary zipper
         //This unwrap won't fail because all the types that implement `ZipperMoving` have cores
         let core_z = primary_z.take_core().unwrap();
-        source_zippers.push(Box::new(primary_z) as Box<dyn ZipperSubtries<V, A>>);
+        source_zippers.push(Box::new(primary_z) as Box<dyn Zipper>);
 
         //Get TrieRefs for the remaining zippers
         for other_z in other_z_iter {
@@ -77,7 +77,7 @@ impl<'factor_z, 'trie, V: Clone + Send + Sync + Unpin, A: Allocator> ProductZipp
         //Get the core out of the primary zipper
         //This unwrap won't fail because all the types that implement `ZipperMoving` have cores
         let core_z = primary_z.take_core().unwrap();
-        source_zippers.push(Box::new(primary_z) as Box<dyn ZipperSubtries<V, A>>);
+        source_zippers.push(Box::new(primary_z) as Box<dyn Zipper>);
 
         Self{z: core_z, factor_paths: Vec::new(), secondaries: vec![], source_zippers}
     }
@@ -307,6 +307,9 @@ impl<'trie, V: Clone + Send + Sync + Unpin + 'trie, A: Allocator + 'trie> Zipper
 impl<'trie, V: Clone + Send + Sync + Unpin + 'trie, A: Allocator + 'trie> ZipperValues<V> for ProductZipper<'_, 'trie, V, A> {
     fn val(&self) -> Option<&V> {
         unsafe{ self.z.get_val() }
+    }
+    fn val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&V> {
+        unsafe{ self.z.get_val_at(path) }
     }
 }
 
@@ -559,6 +562,13 @@ impl<'trie, PrimaryZ, SecondaryZ, V> ZipperValues<V>
             self.primary.val()
         }
     }
+    fn val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&V> {
+        if let Some(idx) = self.factor_idx(true) {
+            self.secondary[idx].val_at(path)
+        } else {
+            self.primary.val_at(path)
+        }
+    }
 }
 
 impl<'trie, PrimaryZ, SecondaryZ, V> ZipperReadOnlyValues<'trie, V>
@@ -573,6 +583,13 @@ impl<'trie, PrimaryZ, SecondaryZ, V> ZipperReadOnlyValues<'trie, V>
             self.secondary[idx].get_val()
         } else {
             self.primary.get_val()
+        }
+    }
+    fn get_val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&'trie V> {
+        if let Some(idx) = self.factor_idx(true) {
+            self.secondary[idx].get_val_at(path)
+        } else {
+            self.primary.get_val_at(path)
         }
     }
 }

--- a/src/trie_map.rs
+++ b/src/trie_map.rs
@@ -219,7 +219,7 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> PathMap<V, A> {
     pub fn trie_ref_at_path<K: AsRef<[u8]>>(&self, path: K) -> TrieRefBorrowed<'_, V, A> {
         self.ensure_root();
         let path = path.as_ref();
-        TrieRefBorrowed::new_with_key_and_path_in(self.root().unwrap(), self.root_val(), &[], path, self.alloc.clone())
+        TrieRefBorrowed::new_with_key_and_path_in(self.root().unwrap(), || self.root_val(), &[], path, self.alloc.clone())
     }
 
     /// Creates a new read-only [Zipper], starting at the root of a `PathMap`

--- a/src/trie_ref.rs
+++ b/src/trie_ref.rs
@@ -125,8 +125,16 @@ impl<'a, V: Clone + Send + Sync + 'a, A: Allocator + 'a> TrieRefBorrowed<'a, V, 
     }
 
     /// Internal function to implement [ZipperReadOnlySubtries::trie_ref_at_path] for all the types that need it
-    pub(crate) fn new_with_key_and_path_in<'paths>(mut node: &'a TrieNodeODRc<V, A>, root_val: Option<&'a V>, node_key: &'paths [u8], mut path: &'paths [u8], alloc: A) -> Self {
-
+    ///
+    /// The root value is computed lazily because it is only needed if the combined `node_key + path`
+    /// resolves to the current node root rather than to a non-empty key within that node.
+    pub(crate) fn new_with_key_and_path_in<'paths>(
+        mut node: &'a TrieNodeODRc<V, A>,
+        root_val_f: impl FnOnce() -> Option<&'a V>,
+        node_key: &'paths [u8],
+        mut path: &'paths [u8],
+        alloc: A,
+    ) -> Self {
         // A temporary buffer on the stack, if we need to assemble a combined key from both the `node_key` and `path`
         let mut temp_key_buf: [MaybeUninit<u8>; MAX_NODE_KEY_BYTES] = [MaybeUninit::uninit(); MAX_NODE_KEY_BYTES];
 
@@ -137,6 +145,10 @@ impl<'a, V: Clone + Send + Sync + 'a, A: Allocator + 'a> TrieRefBorrowed<'a, V, 
         // descend one step
         if node_key_len > 0 && path_len > 0 {
             let next_node_path = unsafe {
+                // SAFETY: `temp_key_buf` has capacity for `MAX_NODE_KEY_BYTES` bytes. We copy exactly
+                // `node_key_len` bytes from `node_key`, which is a valid slice, then append at most the
+                // remaining buffer capacity from the valid slice `path`. Both destination ranges are
+                // within the stack buffer and do not overlap the sources.
                 let src_ptr = node_key.as_ptr();
                 let dst_ptr = temp_key_buf.as_mut_ptr().cast::<u8>();
                 core::ptr::copy_nonoverlapping(src_ptr, dst_ptr, node_key_len);
@@ -147,6 +159,9 @@ impl<'a, V: Clone + Send + Sync + 'a, A: Allocator + 'a> TrieRefBorrowed<'a, V, 
                 core::ptr::copy_nonoverlapping(src_ptr, dst_ptr, remaining_len);
 
                 let total_buf_len = node_key_len + remaining_len;
+                // SAFETY: The first `total_buf_len` bytes of `temp_key_buf` were initialized by the
+                // copies above, and `total_buf_len <= MAX_NODE_KEY_BYTES`, so this slice is valid for
+                // reads for the duration of this function.
                 core::slice::from_raw_parts(temp_key_buf.as_mut_ptr().cast::<u8>(), total_buf_len)
             };
 
@@ -163,8 +178,12 @@ impl<'a, V: Clone + Send + Sync + 'a, A: Allocator + 'a> TrieRefBorrowed<'a, V, 
             }
         }
 
-        //Descend the rest of the way along the path
-        let (node, key, val) = node_along_path(node, path, root_val, true);
+        let (node, key, val) = if path.is_empty() {
+            (node, &[] as &[u8], root_val_f())
+        } else {
+            //Descend the rest of the way along the path
+            node_along_path(node, path, None, true)
+        };
 
         TrieRefBorrowed::new_with_node_and_path_in(node, val, key, alloc)
     }
@@ -331,9 +350,15 @@ impl<'a, V: Clone + Send + Sync + Unpin + 'a, A: Allocator + 'a> ZipperReadOnlyS
             let path = path.as_ref();
             let node_key = self.node_key();
             if node_key.len() > 0 {
-                Self::new_with_key_and_path_in(self.focus_node.unwrap(), None, node_key, path, self.alloc.clone())
+                Self::new_with_key_and_path_in(self.focus_node.unwrap(), || None, node_key, path, self.alloc.clone())
             } else {
-                Self::new_with_key_and_path_in(self.focus_node.unwrap(), self.get_val(), &[], path, self.alloc.clone())
+                Self::new_with_key_and_path_in(
+                    self.focus_node.unwrap(),
+                    || self.get_val(),
+                    &[],
+                    path,
+                    self.alloc.clone(),
+                )
             }
         } else {
             Self::new_invalid_in(self.alloc.clone())

--- a/src/trie_ref.rs
+++ b/src/trie_ref.rs
@@ -855,8 +855,10 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperInfallibleSubtries<V, A
         }
     }
     fn get_focus_at<K: AsRef<[u8]>>(&self, path: K) -> OpaqueAbstractNodeRef<'_, V, A> {
-//GOAT
-        panic!()
+        match self {
+            TrieRef::Borrowed(trie_ref) => trie_ref.get_focus_at(path),
+            TrieRef::Owned(trie_ref) => trie_ref.get_focus_at(path),
+        }
     }
     fn try_borrow_focus(&self) -> Option<OpaqueTrieNodeRef<'_, V, A>> {
         match self {
@@ -1096,5 +1098,154 @@ mod tests {
         assert_eq!(map.get_val_at(b"path"), None);
 
         assert_eq!(tr.val(), Some(&42));
+    }
+
+    #[test]
+    fn trie_ref_borrowed_val_at_test() {
+        let mut map = PathMap::<i32>::new();
+        map.set_val_at(b"root:a:new_a", 10);
+        map.set_val_at(b"root:a:nested:deep", 11);
+        map.set_val_at(b"root:c:new_c", 30);
+
+        let trie_ref = map.trie_ref_at_path(b"root");
+        assert_eq!(trie_ref.val(), None);
+        assert_eq!(trie_ref.val_at(b":a:new_a"), Some(&10));
+        assert_eq!(trie_ref.val_at(b":a:nested:deep"), Some(&11));
+        assert_eq!(trie_ref.val_at(b":b:missing"), None);
+    }
+
+    #[test]
+    fn trie_ref_borrowed_get_focus_at_test() {
+        let mut src = PathMap::<i32>::new();
+        src.set_val_at(b"root:a:new_a", 10);
+        src.set_val_at(b"root:a:nested:deep", 11);
+        src.set_val_at(b"root:branch:mid:leaf", 40);
+        src.set_val_at(b"root:c:new_c", 30);
+
+        let src_ref = src.trie_ref_at_path(b"root");
+        let src_ref_colon = src.trie_ref_at_path(b"root:");
+
+        let mut dst = PathMap::<i32>::new();
+        dst.set_val_at(b"root:p:old_p", 1);
+        dst.set_val_at(b"root:q:old_q", 2);
+        dst.set_val_at(b"root:r:old_r", 3);
+        dst.set_val_at(b"root:s:old_s", 4);
+        dst.set_val_at(b"root:t:old_t", 5);
+        dst.set_val_at(b"root:u:old_u", 6);
+        dst.set_val_at(b"root:v:old_v", 7);
+
+        dst.write_zipper_at_path(b"root:p").graft_src_at(&src_ref_colon, b"");
+        dst.write_zipper_at_path(b"root:q").graft_src_at(&src_ref, b":");
+        dst.write_zipper_at_path(b"root:r").graft_src_at(&src_ref, b":a");
+        dst.write_zipper_at_path(b"root:s").graft_src_at(&src_ref, b":a:nested");
+        dst.write_zipper_at_path(b"root:t").graft_src_at(&src_ref, b":missing");
+        dst.write_zipper_at_path(b"root:u").graft_src_at(&src_ref, b":branch:mid");
+
+        assert_eq!(dst.get_val_at(b"root:p:old_p"), None);
+        assert_eq!(dst.get_val_at(b"root:p:a:new_a"), Some(&10));
+        assert_eq!(dst.get_val_at(b"root:p:a:nested:deep"), Some(&11));
+        assert_eq!(dst.get_val_at(b"root:p:branch:mid:leaf"), Some(&40));
+        assert_eq!(dst.get_val_at(b"root:p:c:new_c"), Some(&30));
+
+        assert_eq!(dst.get_val_at(b"root:q:old_q"), None);
+        assert_eq!(dst.get_val_at(b"root:q:a:new_a"), Some(&10));
+        assert_eq!(dst.get_val_at(b"root:q:branch:mid:leaf"), Some(&40));
+        assert_eq!(dst.get_val_at(b"root:q:c:new_c"), Some(&30));
+
+        assert_eq!(dst.get_val_at(b"root:r:old_r"), None);
+        assert_eq!(dst.get_val_at(b"root:r:new_a"), Some(&10));
+        assert_eq!(dst.get_val_at(b"root:r:nested:deep"), Some(&11));
+        assert_eq!(dst.get_val_at(b"root:r:branch:mid:leaf"), None);
+
+        assert_eq!(dst.get_val_at(b"root:s:old_s"), None);
+        assert_eq!(dst.get_val_at(b"root:s:deep"), Some(&11));
+        assert_eq!(dst.get_val_at(b"root:s:new_a"), None);
+
+        assert_eq!(dst.get_val_at(b"root:t"), None);
+        assert_eq!(dst.get_val_at(b"root:t:old_t"), None);
+
+        assert_eq!(dst.get_val_at(b"root:u:old_u"), None);
+        assert_eq!(dst.get_val_at(b"root:u:leaf"), Some(&40));
+
+        assert_eq!(dst.get_val_at(b"root:v:old_v"), Some(&7));
+    }
+
+    #[test]
+    fn trie_ref_owned_val_at_test() {
+        let mut map = PathMap::<i32>::new();
+        map.set_val_at(b"root:a:new_a", 10);
+        map.set_val_at(b"root:a:nested:deep", 11);
+        map.set_val_at(b"root:c:new_c", 30);
+
+        let trie_ref = TrieRef::from(map);
+        let owned = match trie_ref {
+            TrieRef::Owned(trie_ref) => trie_ref,
+            TrieRef::Borrowed(_) => unreachable!(),
+        };
+
+        assert_eq!(owned.val(), None);
+        assert_eq!(owned.val_at(b"root:a:new_a"), Some(&10));
+        assert_eq!(owned.val_at(b"root:a:nested:deep"), Some(&11));
+        assert_eq!(owned.val_at(b"root:b:missing"), None);
+    }
+
+    #[test]
+    fn trie_ref_owned_get_focus_at_test() {
+        let mut src = PathMap::<i32>::new();
+        src.set_val_at(b"root:a:new_a", 10);
+        src.set_val_at(b"root:a:nested:deep", 11);
+        src.set_val_at(b"root:branch:mid:leaf", 40);
+        src.set_val_at(b"root:c:new_c", 30);
+
+        let src_ref = TrieRef::from(src);
+        let owned = match src_ref {
+            TrieRef::Owned(trie_ref) => trie_ref,
+            TrieRef::Borrowed(_) => unreachable!(),
+        };
+        let owned_colon = owned.trie_ref_at_path(b":");
+
+        let mut dst = PathMap::<i32>::new();
+        dst.set_val_at(b"root:p:old_p", 1);
+        dst.set_val_at(b"root:q:old_q", 2);
+        dst.set_val_at(b"root:r:old_r", 3);
+        dst.set_val_at(b"root:s:old_s", 4);
+        dst.set_val_at(b"root:t:old_t", 5);
+        dst.set_val_at(b"root:u:old_u", 6);
+        dst.set_val_at(b"root:v:old_v", 7);
+
+        dst.write_zipper_at_path(b"root:p").graft_src_at(&owned_colon, b"");
+        dst.write_zipper_at_path(b"root:q").graft_src_at(&owned, b":");
+        dst.write_zipper_at_path(b"root:r").graft_src_at(&owned, b":a");
+        dst.write_zipper_at_path(b"root:s").graft_src_at(&owned, b":a:nested");
+        dst.write_zipper_at_path(b"root:t").graft_src_at(&owned, b":missing");
+        dst.write_zipper_at_path(b"root:u").graft_src_at(&owned, b":branch:mid");
+
+        assert_eq!(dst.get_val_at(b"root:p:old_p"), None);
+        assert_eq!(dst.get_val_at(b"root:p:a:new_a"), Some(&10));
+        assert_eq!(dst.get_val_at(b"root:p:a:nested:deep"), Some(&11));
+        assert_eq!(dst.get_val_at(b"root:p:branch:mid:leaf"), Some(&40));
+        assert_eq!(dst.get_val_at(b"root:p:c:new_c"), Some(&30));
+
+        assert_eq!(dst.get_val_at(b"root:q:old_q"), None);
+        assert_eq!(dst.get_val_at(b"root:q:a:new_a"), Some(&10));
+        assert_eq!(dst.get_val_at(b"root:q:branch:mid:leaf"), Some(&40));
+        assert_eq!(dst.get_val_at(b"root:q:c:new_c"), Some(&30));
+
+        assert_eq!(dst.get_val_at(b"root:r:old_r"), None);
+        assert_eq!(dst.get_val_at(b"root:r:new_a"), Some(&10));
+        assert_eq!(dst.get_val_at(b"root:r:nested:deep"), Some(&11));
+        assert_eq!(dst.get_val_at(b"root:r:branch:mid:leaf"), None);
+
+        assert_eq!(dst.get_val_at(b"root:s:old_s"), None);
+        assert_eq!(dst.get_val_at(b"root:s:deep"), Some(&11));
+        assert_eq!(dst.get_val_at(b"root:s:new_a"), None);
+
+        assert_eq!(dst.get_val_at(b"root:t"), None);
+        assert_eq!(dst.get_val_at(b"root:t:old_t"), None);
+
+        assert_eq!(dst.get_val_at(b"root:u:old_u"), None);
+        assert_eq!(dst.get_val_at(b"root:u:leaf"), Some(&40));
+
+        assert_eq!(dst.get_val_at(b"root:v:old_v"), Some(&7));
     }
 }

--- a/src/trie_ref.rs
+++ b/src/trie_ref.rs
@@ -1101,151 +1101,99 @@ mod tests {
     }
 
     #[test]
-    fn trie_ref_borrowed_val_at_test() {
-        let mut map = PathMap::<i32>::new();
-        map.set_val_at(b"root:a:new_a", 10);
-        map.set_val_at(b"root:a:nested:deep", 11);
-        map.set_val_at(b"root:c:new_c", 30);
+    fn trie_ref_val_at_test() {
+        fn assert_val_at<T: ZipperValues<i32>>(trie_ref: T) {
+            assert_eq!(trie_ref.val(), None);
+            assert_eq!(trie_ref.val_at(b"root:a:new_a"), Some(&10));
+            assert_eq!(trie_ref.val_at(b"root:a:nested:deep"), Some(&11));
+            assert_eq!(trie_ref.val_at(b"root:b:missing"), None);
+        }
 
-        let trie_ref = map.trie_ref_at_path(b"root");
-        assert_eq!(trie_ref.val(), None);
-        assert_eq!(trie_ref.val_at(b":a:new_a"), Some(&10));
-        assert_eq!(trie_ref.val_at(b":a:nested:deep"), Some(&11));
-        assert_eq!(trie_ref.val_at(b":b:missing"), None);
-    }
+        let mut borrowed_map = PathMap::<i32>::new();
+        borrowed_map.set_val_at(b"root:a:new_a", 10);
+        borrowed_map.set_val_at(b"root:a:nested:deep", 11);
+        borrowed_map.set_val_at(b"root:c:new_c", 30);
+        assert_val_at(borrowed_map.trie_ref_at_path(b""));
 
-    #[test]
-    fn trie_ref_borrowed_get_focus_at_test() {
-        let mut src = PathMap::<i32>::new();
-        src.set_val_at(b"root:a:new_a", 10);
-        src.set_val_at(b"root:a:nested:deep", 11);
-        src.set_val_at(b"root:branch:mid:leaf", 40);
-        src.set_val_at(b"root:c:new_c", 30);
-
-        let src_ref = src.trie_ref_at_path(b"root");
-        let src_ref_colon = src.trie_ref_at_path(b"root:");
-
-        let mut dst = PathMap::<i32>::new();
-        dst.set_val_at(b"root:p:old_p", 1);
-        dst.set_val_at(b"root:q:old_q", 2);
-        dst.set_val_at(b"root:r:old_r", 3);
-        dst.set_val_at(b"root:s:old_s", 4);
-        dst.set_val_at(b"root:t:old_t", 5);
-        dst.set_val_at(b"root:u:old_u", 6);
-        dst.set_val_at(b"root:v:old_v", 7);
-
-        dst.write_zipper_at_path(b"root:p").graft_src_at(&src_ref_colon, b"");
-        dst.write_zipper_at_path(b"root:q").graft_src_at(&src_ref, b":");
-        dst.write_zipper_at_path(b"root:r").graft_src_at(&src_ref, b":a");
-        dst.write_zipper_at_path(b"root:s").graft_src_at(&src_ref, b":a:nested");
-        dst.write_zipper_at_path(b"root:t").graft_src_at(&src_ref, b":missing");
-        dst.write_zipper_at_path(b"root:u").graft_src_at(&src_ref, b":branch:mid");
-
-        assert_eq!(dst.get_val_at(b"root:p:old_p"), None);
-        assert_eq!(dst.get_val_at(b"root:p:a:new_a"), Some(&10));
-        assert_eq!(dst.get_val_at(b"root:p:a:nested:deep"), Some(&11));
-        assert_eq!(dst.get_val_at(b"root:p:branch:mid:leaf"), Some(&40));
-        assert_eq!(dst.get_val_at(b"root:p:c:new_c"), Some(&30));
-
-        assert_eq!(dst.get_val_at(b"root:q:old_q"), None);
-        assert_eq!(dst.get_val_at(b"root:q:a:new_a"), Some(&10));
-        assert_eq!(dst.get_val_at(b"root:q:branch:mid:leaf"), Some(&40));
-        assert_eq!(dst.get_val_at(b"root:q:c:new_c"), Some(&30));
-
-        assert_eq!(dst.get_val_at(b"root:r:old_r"), None);
-        assert_eq!(dst.get_val_at(b"root:r:new_a"), Some(&10));
-        assert_eq!(dst.get_val_at(b"root:r:nested:deep"), Some(&11));
-        assert_eq!(dst.get_val_at(b"root:r:branch:mid:leaf"), None);
-
-        assert_eq!(dst.get_val_at(b"root:s:old_s"), None);
-        assert_eq!(dst.get_val_at(b"root:s:deep"), Some(&11));
-        assert_eq!(dst.get_val_at(b"root:s:new_a"), None);
-
-        assert_eq!(dst.get_val_at(b"root:t"), None);
-        assert_eq!(dst.get_val_at(b"root:t:old_t"), None);
-
-        assert_eq!(dst.get_val_at(b"root:u:old_u"), None);
-        assert_eq!(dst.get_val_at(b"root:u:leaf"), Some(&40));
-
-        assert_eq!(dst.get_val_at(b"root:v:old_v"), Some(&7));
-    }
-
-    #[test]
-    fn trie_ref_owned_val_at_test() {
-        let mut map = PathMap::<i32>::new();
-        map.set_val_at(b"root:a:new_a", 10);
-        map.set_val_at(b"root:a:nested:deep", 11);
-        map.set_val_at(b"root:c:new_c", 30);
-
-        let trie_ref = TrieRef::from(map);
-        let owned = match trie_ref {
+        let mut owned_map = PathMap::<i32>::new();
+        owned_map.set_val_at(b"root:a:new_a", 10);
+        owned_map.set_val_at(b"root:a:nested:deep", 11);
+        owned_map.set_val_at(b"root:c:new_c", 30);
+        let owned = match TrieRef::from(owned_map) {
             TrieRef::Owned(trie_ref) => trie_ref,
             TrieRef::Borrowed(_) => unreachable!(),
         };
-
-        assert_eq!(owned.val(), None);
-        assert_eq!(owned.val_at(b"root:a:new_a"), Some(&10));
-        assert_eq!(owned.val_at(b"root:a:nested:deep"), Some(&11));
-        assert_eq!(owned.val_at(b"root:b:missing"), None);
+        assert_val_at(owned);
     }
 
     #[test]
-    fn trie_ref_owned_get_focus_at_test() {
-        let mut src = PathMap::<i32>::new();
-        src.set_val_at(b"root:a:new_a", 10);
-        src.set_val_at(b"root:a:nested:deep", 11);
-        src.set_val_at(b"root:branch:mid:leaf", 40);
-        src.set_val_at(b"root:c:new_c", 30);
+    fn trie_ref_graft_src_at_test() {
+        fn assert_graft_src_at<S: ZipperInfallibleSubtries<i32>>(src_ref: S, src_ref_colon: S) {
+            let mut dst = PathMap::<i32>::new();
+            dst.set_val_at(b"root:p:old_p", 1);
+            dst.set_val_at(b"root:q:old_q", 2);
+            dst.set_val_at(b"root:r:old_r", 3);
+            dst.set_val_at(b"root:s:old_s", 4);
+            dst.set_val_at(b"root:t:old_t", 5);
+            dst.set_val_at(b"root:u:old_u", 6);
+            dst.set_val_at(b"root:v:old_v", 7);
 
-        let src_ref = TrieRef::from(src);
-        let owned = match src_ref {
+            dst.write_zipper_at_path(b"root:p").graft_src_at(&src_ref_colon, b"");
+            dst.write_zipper_at_path(b"root:q").graft_src_at(&src_ref, b":");
+            dst.write_zipper_at_path(b"root:r").graft_src_at(&src_ref, b":a");
+            dst.write_zipper_at_path(b"root:s").graft_src_at(&src_ref, b":a:nested");
+            dst.write_zipper_at_path(b"root:t").graft_src_at(&src_ref, b":missing");
+            dst.write_zipper_at_path(b"root:u").graft_src_at(&src_ref, b":branch:mid");
+
+            assert_eq!(dst.get_val_at(b"root:p:old_p"), None);
+            assert_eq!(dst.get_val_at(b"root:p:a:new_a"), Some(&10));
+            assert_eq!(dst.get_val_at(b"root:p:a:nested:deep"), Some(&11));
+            assert_eq!(dst.get_val_at(b"root:p:branch:mid:leaf"), Some(&40));
+            assert_eq!(dst.get_val_at(b"root:p:c:new_c"), Some(&30));
+
+            assert_eq!(dst.get_val_at(b"root:q:old_q"), None);
+            assert_eq!(dst.get_val_at(b"root:q:a:new_a"), Some(&10));
+            assert_eq!(dst.get_val_at(b"root:q:branch:mid:leaf"), Some(&40));
+            assert_eq!(dst.get_val_at(b"root:q:c:new_c"), Some(&30));
+
+            assert_eq!(dst.get_val_at(b"root:r:old_r"), None);
+            assert_eq!(dst.get_val_at(b"root:r:new_a"), Some(&10));
+            assert_eq!(dst.get_val_at(b"root:r:nested:deep"), Some(&11));
+            assert_eq!(dst.get_val_at(b"root:r:branch:mid:leaf"), None);
+
+            assert_eq!(dst.get_val_at(b"root:s:old_s"), None);
+            assert_eq!(dst.get_val_at(b"root:s:deep"), Some(&11));
+            assert_eq!(dst.get_val_at(b"root:s:new_a"), None);
+
+            assert_eq!(dst.get_val_at(b"root:t"), None);
+            assert_eq!(dst.get_val_at(b"root:t:old_t"), None);
+
+            assert_eq!(dst.get_val_at(b"root:u:old_u"), None);
+            assert_eq!(dst.get_val_at(b"root:u:leaf"), Some(&40));
+
+            assert_eq!(dst.get_val_at(b"root:v:old_v"), Some(&7));
+        }
+
+        let mut borrowed_src = PathMap::<i32>::new();
+        borrowed_src.set_val_at(b"root:a:new_a", 10);
+        borrowed_src.set_val_at(b"root:a:nested:deep", 11);
+        borrowed_src.set_val_at(b"root:branch:mid:leaf", 40);
+        borrowed_src.set_val_at(b"root:c:new_c", 30);
+        assert_graft_src_at(
+            borrowed_src.trie_ref_at_path(b"root"),
+            borrowed_src.trie_ref_at_path(b"root:"),
+        );
+
+        let mut owned_src = PathMap::<i32>::new();
+        owned_src.set_val_at(b"root:a:new_a", 10);
+        owned_src.set_val_at(b"root:a:nested:deep", 11);
+        owned_src.set_val_at(b"root:branch:mid:leaf", 40);
+        owned_src.set_val_at(b"root:c:new_c", 30);
+        let owned = match TrieRef::from(owned_src) {
             TrieRef::Owned(trie_ref) => trie_ref,
             TrieRef::Borrowed(_) => unreachable!(),
         };
         let owned_colon = owned.trie_ref_at_path(b":");
-
-        let mut dst = PathMap::<i32>::new();
-        dst.set_val_at(b"root:p:old_p", 1);
-        dst.set_val_at(b"root:q:old_q", 2);
-        dst.set_val_at(b"root:r:old_r", 3);
-        dst.set_val_at(b"root:s:old_s", 4);
-        dst.set_val_at(b"root:t:old_t", 5);
-        dst.set_val_at(b"root:u:old_u", 6);
-        dst.set_val_at(b"root:v:old_v", 7);
-
-        dst.write_zipper_at_path(b"root:p").graft_src_at(&owned_colon, b"");
-        dst.write_zipper_at_path(b"root:q").graft_src_at(&owned, b":");
-        dst.write_zipper_at_path(b"root:r").graft_src_at(&owned, b":a");
-        dst.write_zipper_at_path(b"root:s").graft_src_at(&owned, b":a:nested");
-        dst.write_zipper_at_path(b"root:t").graft_src_at(&owned, b":missing");
-        dst.write_zipper_at_path(b"root:u").graft_src_at(&owned, b":branch:mid");
-
-        assert_eq!(dst.get_val_at(b"root:p:old_p"), None);
-        assert_eq!(dst.get_val_at(b"root:p:a:new_a"), Some(&10));
-        assert_eq!(dst.get_val_at(b"root:p:a:nested:deep"), Some(&11));
-        assert_eq!(dst.get_val_at(b"root:p:branch:mid:leaf"), Some(&40));
-        assert_eq!(dst.get_val_at(b"root:p:c:new_c"), Some(&30));
-
-        assert_eq!(dst.get_val_at(b"root:q:old_q"), None);
-        assert_eq!(dst.get_val_at(b"root:q:a:new_a"), Some(&10));
-        assert_eq!(dst.get_val_at(b"root:q:branch:mid:leaf"), Some(&40));
-        assert_eq!(dst.get_val_at(b"root:q:c:new_c"), Some(&30));
-
-        assert_eq!(dst.get_val_at(b"root:r:old_r"), None);
-        assert_eq!(dst.get_val_at(b"root:r:new_a"), Some(&10));
-        assert_eq!(dst.get_val_at(b"root:r:nested:deep"), Some(&11));
-        assert_eq!(dst.get_val_at(b"root:r:branch:mid:leaf"), None);
-
-        assert_eq!(dst.get_val_at(b"root:s:old_s"), None);
-        assert_eq!(dst.get_val_at(b"root:s:deep"), Some(&11));
-        assert_eq!(dst.get_val_at(b"root:s:new_a"), None);
-
-        assert_eq!(dst.get_val_at(b"root:t"), None);
-        assert_eq!(dst.get_val_at(b"root:t:old_t"), None);
-
-        assert_eq!(dst.get_val_at(b"root:u:old_u"), None);
-        assert_eq!(dst.get_val_at(b"root:u:leaf"), Some(&40));
-
-        assert_eq!(dst.get_val_at(b"root:v:old_v"), Some(&7));
+        assert_graft_src_at(owned, owned_colon);
     }
 }

--- a/src/trie_ref.rs
+++ b/src/trie_ref.rs
@@ -312,8 +312,17 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperInfallibleSubtries<V, A
         }
     }
     fn get_focus_at<K: AsRef<[u8]>>(&self, path: K) -> OpaqueAbstractNodeRef<'_, V, A> {
-//GOAT
-        panic!()
+        if self.is_valid() {
+            OpaqueAbstractNodeRef(TrieRefBorrowed::new_with_key_and_path_in(
+                self.focus_node.unwrap(),
+                || self.get_val(),
+                self.node_key(),
+                path.as_ref(),
+                self.alloc.clone(),
+            ).into_focus())
+        } else {
+            OpaqueAbstractNodeRef(AbstractNodeRef::None)
+        }
     }
     fn try_borrow_focus(&self) -> Option<OpaqueTrieNodeRef<'_, V, A>> {
         if self.is_valid() {
@@ -353,8 +362,17 @@ impl<'a, V: Clone + Send + Sync + Unpin + 'a, A: Allocator + 'a> ZipperReadOnlyV
         }
     }
     fn get_val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&'a V> {
-//GOAT
-        panic!()
+        if self.is_valid() {
+            TrieRefBorrowed::new_with_key_and_path_in(
+                self.focus_node.unwrap(),
+                || self.get_val(),
+                self.node_key(),
+                path.as_ref(),
+                self.alloc.clone(),
+            ).get_val()
+        } else {
+            None
+        }
     }
 }
 
@@ -629,8 +647,17 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperValues<V> for TrieRefOw
         }
     }
     fn val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&V> {
-//GOAT
-        panic!()
+        if self.is_valid() {
+            TrieRefBorrowed::new_with_key_and_path_in(
+                self.focus_node.as_ref().unwrap(),
+                || self.val(),
+                self.node_key(),
+                path.as_ref(),
+                self.alloc.clone(),
+            ).get_val()
+        } else {
+            None
+        }
     }
 }
 
@@ -675,8 +702,17 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperInfallibleSubtries<V, A
         }
     }
     fn get_focus_at<K: AsRef<[u8]>>(&self, path: K) -> OpaqueAbstractNodeRef<'_, V, A> {
-//GOAT
-        panic!()
+        if self.is_valid() {
+            OpaqueAbstractNodeRef(TrieRefBorrowed::new_with_key_and_path_in(
+                self.focus_node.as_ref().unwrap(),
+                || self.val(),
+                self.node_key(),
+                path.as_ref(),
+                self.alloc.clone(),
+            ).into_focus())
+        } else {
+            OpaqueAbstractNodeRef(AbstractNodeRef::None)
+        }
     }
     fn try_borrow_focus(&self) -> Option<OpaqueTrieNodeRef<'_, V, A>> {
         if self.is_valid() {
@@ -1128,50 +1164,38 @@ mod tests {
 
     #[test]
     fn trie_ref_graft_src_at_test() {
-        fn assert_graft_src_at<S: ZipperInfallibleSubtries<i32>>(src_ref: S, src_ref_colon: S) {
+        fn assert_graft_src_at<S: ZipperInfallibleSubtries<i32>>(src_ref: S) {
             let mut dst = PathMap::<i32>::new();
             dst.set_val_at(b"root:p:old_p", 1);
             dst.set_val_at(b"root:q:old_q", 2);
             dst.set_val_at(b"root:r:old_r", 3);
             dst.set_val_at(b"root:s:old_s", 4);
             dst.set_val_at(b"root:t:old_t", 5);
-            dst.set_val_at(b"root:u:old_u", 6);
-            dst.set_val_at(b"root:v:old_v", 7);
 
-            dst.write_zipper_at_path(b"root:p").graft_src_at(&src_ref_colon, b"");
-            dst.write_zipper_at_path(b"root:q").graft_src_at(&src_ref, b":");
-            dst.write_zipper_at_path(b"root:r").graft_src_at(&src_ref, b":a");
-            dst.write_zipper_at_path(b"root:s").graft_src_at(&src_ref, b":a:nested");
-            dst.write_zipper_at_path(b"root:t").graft_src_at(&src_ref, b":missing");
-            dst.write_zipper_at_path(b"root:u").graft_src_at(&src_ref, b":branch:mid");
+            dst.write_zipper_at_path(b"root:p").graft_src_at(&src_ref, b"a");
+            dst.write_zipper_at_path(b"root:q").graft_src_at(&src_ref, b"a:nested");
+            dst.write_zipper_at_path(b"root:r").graft_src_at(&src_ref, b"branch:mid");
+            dst.write_zipper_at_path(b"root:s").graft_src_at(&src_ref, b"missing");
 
             assert_eq!(dst.get_val_at(b"root:p:old_p"), None);
-            assert_eq!(dst.get_val_at(b"root:p:a:new_a"), Some(&10));
-            assert_eq!(dst.get_val_at(b"root:p:a:nested:deep"), Some(&11));
-            assert_eq!(dst.get_val_at(b"root:p:branch:mid:leaf"), Some(&40));
-            assert_eq!(dst.get_val_at(b"root:p:c:new_c"), Some(&30));
+            assert_eq!(dst.get_val_at(b"root:p:new_a"), Some(&10));
+            assert_eq!(dst.get_val_at(b"root:p:nested:deep"), Some(&11));
+            assert_eq!(dst.get_val_at(b"root:p:branch:mid:leaf"), None);
+            assert_eq!(dst.get_val_at(b"root:p:c:new_c"), None);
 
             assert_eq!(dst.get_val_at(b"root:q:old_q"), None);
-            assert_eq!(dst.get_val_at(b"root:q:a:new_a"), Some(&10));
-            assert_eq!(dst.get_val_at(b"root:q:branch:mid:leaf"), Some(&40));
-            assert_eq!(dst.get_val_at(b"root:q:c:new_c"), Some(&30));
+            assert_eq!(dst.get_val_at(b"root:q:deep"), Some(&11));
+            assert_eq!(dst.get_val_at(b"root:q:new_a"), None);
 
             assert_eq!(dst.get_val_at(b"root:r:old_r"), None);
-            assert_eq!(dst.get_val_at(b"root:r:new_a"), Some(&10));
-            assert_eq!(dst.get_val_at(b"root:r:nested:deep"), Some(&11));
-            assert_eq!(dst.get_val_at(b"root:r:branch:mid:leaf"), None);
+            assert_eq!(dst.get_val_at(b"root:r:leaf"), Some(&40));
+            assert_eq!(dst.get_val_at(b"root:r:deep"), None);
 
             assert_eq!(dst.get_val_at(b"root:s:old_s"), None);
-            assert_eq!(dst.get_val_at(b"root:s:deep"), Some(&11));
-            assert_eq!(dst.get_val_at(b"root:s:new_a"), None);
+            assert_eq!(dst.get_val_at(b"root:s"), None);
+            assert_eq!(dst.get_val_at(b"root:s:old_s"), None);
 
-            assert_eq!(dst.get_val_at(b"root:t"), None);
-            assert_eq!(dst.get_val_at(b"root:t:old_t"), None);
-
-            assert_eq!(dst.get_val_at(b"root:u:old_u"), None);
-            assert_eq!(dst.get_val_at(b"root:u:leaf"), Some(&40));
-
-            assert_eq!(dst.get_val_at(b"root:v:old_v"), Some(&7));
+            assert_eq!(dst.get_val_at(b"root:t:old_t"), Some(&5));
         }
 
         let mut borrowed_src = PathMap::<i32>::new();
@@ -1179,10 +1203,7 @@ mod tests {
         borrowed_src.set_val_at(b"root:a:nested:deep", 11);
         borrowed_src.set_val_at(b"root:branch:mid:leaf", 40);
         borrowed_src.set_val_at(b"root:c:new_c", 30);
-        assert_graft_src_at(
-            borrowed_src.trie_ref_at_path(b"root"),
-            borrowed_src.trie_ref_at_path(b"root:"),
-        );
+        assert_graft_src_at(borrowed_src.trie_ref_at_path(b"root:"));
 
         let mut owned_src = PathMap::<i32>::new();
         owned_src.set_val_at(b"root:a:new_a", 10);
@@ -1193,7 +1214,6 @@ mod tests {
             TrieRef::Owned(trie_ref) => trie_ref,
             TrieRef::Borrowed(_) => unreachable!(),
         };
-        let owned_colon = owned.trie_ref_at_path(b":");
-        assert_graft_src_at(owned, owned_colon);
+        assert_graft_src_at(owned.trie_ref_at_path(b"root:"));
     }
 }

--- a/src/trie_ref.rs
+++ b/src/trie_ref.rs
@@ -188,6 +188,21 @@ impl<'a, V: Clone + Send + Sync + 'a, A: Allocator + 'a> TrieRefBorrowed<'a, V, 
         TrieRefBorrowed::new_with_node_and_path_in(node, val, key, alloc)
     }
 
+    /// Internal Method to convert a trie ref into an [AbstractNodeRef]
+    #[inline]
+    pub(crate) fn into_focus(self) -> AbstractNodeRef<'a, V, A> {
+        if let Some(focus_node) = self.focus_node {
+            let node_key = self.node_key();
+            if node_key.len() > 0 {
+                focus_node.as_tagged().get_node_at_key(node_key)
+            } else {
+                AbstractNodeRef::BorrowedRc(focus_node)
+            }
+        } else {
+            AbstractNodeRef::None
+        }
+    }
+
     /// Internal.  Checks if the `TrieRef` is valid, which is a prerequisite to see if it's pointing
     /// at an existing path
     #[inline]

--- a/src/trie_ref.rs
+++ b/src/trie_ref.rs
@@ -232,6 +232,9 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperValues<V> for TrieRefBo
     fn val(&self) -> Option<&V> {
         self.get_val()
     }
+    fn val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&V> {
+        self.get_val_at(path)
+    }
 }
 
 impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperForking<V> for TrieRefBorrowed<'_, V, A> {
@@ -274,6 +277,10 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperInfallibleSubtries<V, A
             OpaqueAbstractNodeRef(AbstractNodeRef::None)
         }
     }
+    fn get_focus_at<K: AsRef<[u8]>>(&self, path: K) -> OpaqueAbstractNodeRef<'_, V, A> {
+//GOAT
+        panic!()
+    }
     fn try_borrow_focus(&self) -> Option<OpaqueTrieNodeRef<'_, V, A>> {
         if self.is_valid() {
             let node_key = self.node_key();
@@ -310,6 +317,10 @@ impl<'a, V: Clone + Send + Sync + Unpin + 'a, A: Allocator + 'a> ZipperReadOnlyV
         } else {
             None
         }
+    }
+    fn get_val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&'a V> {
+//GOAT
+        panic!()
     }
 }
 
@@ -577,6 +588,10 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperValues<V> for TrieRefOw
             None
         }
     }
+    fn val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&V> {
+//GOAT
+        panic!()
+    }
 }
 
 impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperForking<V> for TrieRefOwned<V, A> {
@@ -618,6 +633,10 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperInfallibleSubtries<V, A
         } else {
             OpaqueAbstractNodeRef(AbstractNodeRef::None)
         }
+    }
+    fn get_focus_at<K: AsRef<[u8]>>(&self, path: K) -> OpaqueAbstractNodeRef<'_, V, A> {
+//GOAT
+        panic!()
     }
     fn try_borrow_focus(&self) -> Option<OpaqueTrieNodeRef<'_, V, A>> {
         if self.is_valid() {
@@ -749,6 +768,12 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperValues<V> for TrieRef<'
             TrieRef::Owned(trie_ref) => trie_ref.val(),
         }
     }
+    fn val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&V> {
+        match self {
+            TrieRef::Borrowed(trie_ref) => trie_ref.val_at(path),
+            TrieRef::Owned(trie_ref) => trie_ref.val_at(path),
+        }
+    }
 }
 
 impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperForking<V> for TrieRef<'_, V, A> {
@@ -788,6 +813,10 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperInfallibleSubtries<V, A
             TrieRef::Borrowed(trie_ref) => trie_ref.get_focus(),
             TrieRef::Owned(trie_ref) => trie_ref.get_focus(),
         }
+    }
+    fn get_focus_at<K: AsRef<[u8]>>(&self, path: K) -> OpaqueAbstractNodeRef<'_, V, A> {
+//GOAT
+        panic!()
     }
     fn try_borrow_focus(&self) -> Option<OpaqueTrieNodeRef<'_, V, A>> {
         match self {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -17,6 +17,10 @@ pub use fast_slice_utils::find_prefix_overlap;
 #[repr(transparent)]
 pub struct ByteMask(pub [u64; 4]);
 
+/// Alternate formatter for displaying a [`ByteMask`] as binary instead of as a set of byte indices.
+#[derive(Clone, Copy)]
+pub struct ByteMaskBinaryFmt(ByteMask);
+
 impl ByteMask {
     pub const EMPTY: ByteMask = Self([0u64; 4]);
     pub const FULL: ByteMask = Self([!0u64; 4]);
@@ -139,6 +143,12 @@ impl ByteMask {
     #[inline]
     pub fn range_iter(&self) -> ByteMaskRangeIter {
         ByteMaskRangeIter::from(self.0)
+    }
+
+    /// Returns a wrapper that renders this mask as 256 bits of binary text.
+    #[inline]
+    pub fn fmt_binary(&self) -> ByteMaskBinaryFmt {
+        ByteMaskBinaryFmt(self.clone())
     }
 
     /// Returns how many set bits precede the requested bit
@@ -296,6 +306,32 @@ impl ByteMask {
 impl core::fmt::Debug for ByteMask {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_set().entries(self.iter()).finish()
+    }
+}
+
+impl core::fmt::Debug for ByteMaskBinaryFmt {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        for word in self.0.0.iter().rev() {
+            write!(f, "{word:064b}")?;
+        }
+        Ok(())
+    }
+}
+
+impl core::fmt::Display for ByteMaskBinaryFmt {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut bit_count = 0usize;
+        for word in self.0.0.iter().rev() {
+            for shift in (0..64).rev() {
+                let bit = (word >> shift) & 1;
+                write!(f, "{bit}")?;
+                bit_count += 1;
+                if bit_count < 256 && bit_count % 8 == 0 {
+                    write!(f, " ")?;
+                }
+            }
+        }
+        Ok(())
     }
 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -120,7 +120,7 @@ impl ByteMask {
             // last partial word
             mask[end_word] = u64::MAX >> (63 - end_bit);
         }
-        
+
         ByteMask(mask)
     }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,5 @@
 
-use std::ops::{RangeBounds, Bound};
+use std::ops::{Bound, Range, RangeBounds, RangeInclusive};
 
 use crate::ring::*;
 
@@ -133,6 +133,12 @@ impl ByteMask {
     #[inline]
     pub fn iter(&self) -> ByteMaskIter {
         ByteMaskIter::from(self.0)
+    }
+
+    /// Create an iterator over contiguous ranges of set bits, in ascending order
+    #[inline]
+    pub fn range_iter(&self) -> ByteMaskRangeIter {
+        ByteMaskRangeIter::from(self.0)
     }
 
     /// Returns how many set bits precede the requested bit
@@ -336,6 +342,20 @@ impl From<u8> for ByteMask {
         let mut new_mask = Self::new();
         new_mask.set_bit(singleton_byte);
         new_mask
+    }
+}
+
+impl From<Range<u8>> for ByteMask {
+    #[inline]
+    fn from(range: Range<u8>) -> Self {
+        Self::from_range(range)
+    }
+}
+
+impl From<RangeInclusive<u8>> for ByteMask {
+    #[inline]
+    fn from(range: RangeInclusive<u8>) -> Self {
+        Self::from_range(range)
     }
 }
 
@@ -575,6 +595,16 @@ crate::impl_name_only_debug!(
     impl core::fmt::Debug for ByteMaskIter
 );
 
+/// An iterator to visit contiguous ranges of set bytes in ascending order.
+pub struct ByteMaskRangeIter {
+    i: u8,
+    mask: [u64; 4],
+}
+
+crate::impl_name_only_debug!(
+    impl core::fmt::Debug for ByteMaskRangeIter
+);
+
 /// Iterate over a [u64; 4].  Deprecated in favor [`ByteMask`]
 #[deprecated]
 pub trait IntoByteMaskIter {
@@ -597,23 +627,44 @@ impl IntoByteMaskIter for &[u64; 4] {
 
 impl From<[u64; 4]> for ByteMaskIter {
     fn from(mask: [u64; 4]) -> Self {
+        Self::new(ByteMask(mask))
+    }
+}
+
+impl From<ByteMask> for ByteMaskIter {
+    fn from(mask: ByteMask) -> Self {
+        Self::new(mask)
+    }
+}
+
+impl From<[u64; 4]> for ByteMaskRangeIter {
+    fn from(mask: [u64; 4]) -> Self {
+        Self::new(ByteMask(mask))
+    }
+}
+
+impl From<ByteMask> for ByteMaskRangeIter {
+    fn from(mask: ByteMask) -> Self {
         Self::new(mask)
     }
 }
 
 impl ByteMaskIter {
-    /// Make a new `ByteMaskIter` from a mask, as you might get from [child_mask](crate::zipper::Zipper::child_mask)
-    pub fn new(mask: [u64; 4]) -> Self {
-        Self {
-            i: 0,
-            mask,
-        }
+    pub fn new(mask: ByteMask) -> Self {
+        Self { i: 0, mask: mask.0 }
+    }
+}
+
+impl ByteMaskRangeIter {
+    pub fn new(mask: ByteMask) -> Self {
+        Self { i: 0, mask: mask.0 }
     }
 }
 
 impl Iterator for ByteMaskIter {
     type Item = u8;
 
+    #[inline]
     fn next(&mut self) -> Option<u8> {
         loop {
             let w = &mut self.mask[self.i as usize];
@@ -628,6 +679,63 @@ impl Iterator for ByteMaskIter {
                 return None
             }
         }
+    }
+}
+
+impl Iterator for ByteMaskRangeIter {
+    type Item = RangeInclusive<u8>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        // Skip empty words until we find the first set bit of the next range.
+        let start_bit;
+        let start = loop {
+            let w = self.mask[self.i as usize];
+            if w != 0 {
+                start_bit = w.trailing_zeros() as u8;
+                break self.i * 64 + start_bit;
+            } else if self.i < 3 {
+                self.i += 1;
+            } else {
+                return None;
+            }
+        };
+
+        let run_len = (self.mask[self.i as usize] >> start_bit).trailing_ones() as u8;
+        // The range ends inside the current word, so clear just that span and return it.
+        if run_len < 64 - start_bit {
+            let clear_mask = ((1u64 << run_len) - 1) << start_bit;
+            self.mask[self.i as usize] &= !clear_mask;
+            return Some(start..=(start + run_len - 1));
+        }
+
+        // The range consumes the rest of the current word, so clear it before advancing.
+        self.mask[self.i as usize] = 0;
+
+        //Find the end of the range
+        while self.i < 3 {
+            self.i += 1;
+            let next_word = self.mask[self.i as usize];
+
+            // The range covers this entire next word, so clear it and continue forward.
+            if next_word == u64::MAX {
+                self.mask[self.i as usize] = 0;
+                continue;
+            }
+
+            let next_run_len = next_word.trailing_ones() as u8;
+            // The next word starts with a zero bit, so the range ended at the prior word boundary.
+            if next_run_len == 0 {
+                return Some(start..=((self.i - 1) * 64 + 63));
+            }
+
+            // The range ends inside the prefix of the next word, so clear that prefix and return it.
+            self.mask[self.i as usize] &= !((1u64 << next_run_len) - 1);
+            return Some(start..=(self.i * 64 + next_run_len - 1));
+        }
+
+        // The range runs through the end of the mask after clearing every fully covered word.
+        Some(start..=(self.i * 64 + 63))
     }
 }
 
@@ -779,4 +887,50 @@ fn from_range_test() {
     assert_eq!(ByteMask::from_range(0..=0), ByteMask::from(0));
     assert_eq!(ByteMask::from_range(255..255), ByteMask::EMPTY);
     assert_eq!(ByteMask::from_range(255..=255), ByteMask::from(255));
+}
+
+#[test]
+fn range_iter_test() {
+    fn next_once(mask: ByteMask) -> Option<RangeInclusive<u8>> {
+        let mut iter = mask.range_iter();
+        iter.next()
+    }
+
+    // Returns from the short in-word path.
+    assert_eq!(next_once(ByteMask::from(10..12)), Some(10..=11));
+
+    // Returns at a word boundary when the next word starts with zero.
+    assert_eq!(next_once(ByteMask::from(62..=63)), Some(62..=63));
+
+    // Returns from the next-word prefix path.
+    assert_eq!(next_once(ByteMask::from(62..=66)), Some(62..=66));
+
+    // Returns from the full-word continuation path after spanning a whole intermediate word.
+    assert_eq!(next_once(ByteMask::from(62..=130)), Some(62..=130));
+
+    // Returns from the end-of-mask path.
+    assert_eq!(next_once(ByteMask::from(250..=255)), Some(250..=255));
+
+    // Iterates multiple disjoint ranges in ascending order.
+    let mask = ByteMask::from(0..=3)
+        | ByteMask::from(10..12)
+        | ByteMask::from(64..=64)
+        | ByteMask::from(126..=130)
+        | ByteMask::from(255..=255);
+    let ranges: Vec<RangeInclusive<u8>> = mask.range_iter().collect();
+    assert_eq!(ranges, vec![0..=3, 10..=11, 64..=64, 126..=130, 255..=255]);
+
+    // Span multiple words
+    let mask = ByteMask::from(2..=4)
+        | ByteMask::from(30..220);
+    let ranges: Vec<RangeInclusive<u8>> = mask.range_iter().collect();
+    assert_eq!(ranges, vec![2..=4, 30..=219]);
+
+    // Empty mask
+    let mut iter = ByteMask::EMPTY.range_iter();
+    assert_eq!(iter.next(), None);
+
+    // Full mask
+    let mut iter = ByteMask::FULL.range_iter();
+    assert_eq!(iter.next(), Some(0..=255));
 }

--- a/src/write_zipper.rs
+++ b/src/write_zipper.rs
@@ -1479,12 +1479,33 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
             None => self.remove_val(false)
         };
     }
+    /// Internal helper called by graft_masked_branches
+    fn merge_branches_into_focus<CfSrc: crate::dense_byte_node::CoFree<V=V, A=A>, const REMOVE_UNSET: bool>(
+        focus_node: &mut TrieNodeODRc<V, A>,
+        src_node: &crate::dense_byte_node::ByteNode<CfSrc, A>,
+        child_mask: ByteMask,
+    ) {
+        use crate::dense_byte_node::{merge_branches_into_byte_node, OrdinaryCoFree};
+
+        match focus_node.make_mut() {
+            TaggedNodeRefMut::DenseByteNode(node) => {
+                merge_branches_into_byte_node::<_, _, _, _, REMOVE_UNSET>(node, src_node, child_mask)
+            },
+            TaggedNodeRefMut::CellByteNode(node) => {
+                merge_branches_into_byte_node::<_, _, _, _, REMOVE_UNSET>(node, src_node, child_mask)
+            },
+            TaggedNodeRefMut::LineListNode(node) => {
+                let replacement = node.convert_to_dense::<OrdinaryCoFree<V, A>>(child_mask.count_bits() + 2);
+                *focus_node = replacement;
+                let node = focus_node.make_mut().into_dense().unwrap();
+                merge_branches_into_byte_node::<_, _, _, _, REMOVE_UNSET>(node, src_node, child_mask)
+            },
+        }
+    }
     /// See [ZipperWriting::graft_masked_branches]
     pub fn graft_masked_branches<Z: ZipperInfallibleSubtries<V, A>>(&mut self, src: &Z, child_mask: ByteMask, remove_unset: bool) {
-        use crate::dense_byte_node::merge_branches_into_byte_node;
-
-        match src.get_focus().try_as_tagged().and_then(|node| node.as_dense()) {
-            Some(src_node) => {
+        match src.get_focus().try_as_tagged() {
+            Some(src_tagged) => {
                 // Split the focus if we're in the middle of another node
                 let self_focus_node = match self.try_borrow_focus_mut() {
                     Some(node) => node,
@@ -1493,43 +1514,56 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
                         self.try_borrow_focus_mut().unwrap()
                     }
                 };
-
-                match self_focus_node.make_mut() {
-                    TaggedNodeRefMut::DenseByteNode(node) => {
+                match src_tagged {
+                    TaggedNodeRef::DenseByteNode(src_node) => {
                         if remove_unset {
-                            merge_branches_into_byte_node::<_, _, _, true>(node, src_node, child_mask)
+                            Self::merge_branches_into_focus::<crate::dense_byte_node::OrdinaryCoFree<V, A>, true>(self_focus_node, src_node, child_mask);
                         } else {
-                            merge_branches_into_byte_node::<_, _, _, false>(node, src_node, child_mask)
+                            Self::merge_branches_into_focus::<crate::dense_byte_node::OrdinaryCoFree<V, A>, false>(self_focus_node, src_node, child_mask);
                         }
                     },
-                    TaggedNodeRefMut::CellByteNode(node) => {
+                    TaggedNodeRef::CellByteNode(src_node) => {
                         if remove_unset {
-                            merge_branches_into_byte_node::<_, _, _, true>(node, src_node, child_mask)
+                            Self::merge_branches_into_focus::<crate::dense_byte_node::CellCoFree<V, A>, true>(self_focus_node, src_node, child_mask);
                         } else {
-                            merge_branches_into_byte_node::<_, _, _, false>(node, src_node, child_mask)
+                            Self::merge_branches_into_focus::<crate::dense_byte_node::CellCoFree<V, A>, false>(self_focus_node, src_node, child_mask);
                         }
                     },
-                    TaggedNodeRefMut::LineListNode(node) => {
-                        // Upgrade the focus to a dense node, if it's currently a list node
-                        let replacement = node.convert_to_dense::<crate::dense_byte_node::OrdinaryCoFree<V, A>>(child_mask.count_bits() + 2);
-                        *self_focus_node = replacement;
-                        let node = self_focus_node.make_mut().into_dense().unwrap();
+                    TaggedNodeRef::LineListNode(src_node) => {
+                        let mut src_node = src_node.clone();
+                        let src_dense = src_node.convert_to_dense::<crate::dense_byte_node::OrdinaryCoFree<V, A>>(3);
+                        let src_dense = src_dense.as_tagged().as_dense().unwrap();
                         if remove_unset {
-                            merge_branches_into_byte_node::<_, _, _, true>(node, src_node, child_mask)
+                            Self::merge_branches_into_focus::<crate::dense_byte_node::OrdinaryCoFree<V, A>, true>(self_focus_node, src_dense, child_mask);
                         } else {
-                            merge_branches_into_byte_node::<_, _, _, false>(node, src_node, child_mask)
+                            Self::merge_branches_into_focus::<crate::dense_byte_node::OrdinaryCoFree<V, A>, false>(self_focus_node, src_dense, child_mask);
+                        }
+                    },
+                    TaggedNodeRef::TinyRefNode(src_node) => {
+                        let mut src_node = src_node.into_full().unwrap();
+                        let src_dense = src_node.convert_to_dense::<crate::dense_byte_node::OrdinaryCoFree<V, A>>(3);
+                        let src_dense = src_dense.as_tagged().as_dense().unwrap();
+                        if remove_unset {
+                            Self::merge_branches_into_focus::<crate::dense_byte_node::OrdinaryCoFree<V, A>, true>(self_focus_node, src_dense, child_mask);
+                        } else {
+                            Self::merge_branches_into_focus::<crate::dense_byte_node::OrdinaryCoFree<V, A>, false>(self_focus_node, src_dense, child_mask);
+                        }
+                    },
+                    TaggedNodeRef::EmptyNode => {
+                        if remove_unset {
+                            self.remove_branches(false);
+                        } else {
+                            self.remove_unmasked_branches(child_mask.not(), false);
                         }
                     },
                 }
             },
             None => {
+                debug_assert_eq!(src.child_count(), 0);
                 if remove_unset {
                     self.remove_branches(false);
-                }
-                for child_byte in child_mask.iter() {
-                    self.descend_to_byte(child_byte);
-                    self.graft_src_at(src, &[child_byte]);
-                    self.ascend_byte();
+                } else {
+                    self.remove_unmasked_branches(child_mask.not(), false);
                 }
             }
         }

--- a/src/write_zipper.rs
+++ b/src/write_zipper.rs
@@ -1481,15 +1481,40 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
     }
     /// See [ZipperWriting::graft_masked_branches]
     pub fn graft_masked_branches<Z: ZipperInfallibleSubtries<V, A>>(&mut self, src: &Z, child_mask: ByteMask, remove_unset: bool) {
-//GOAT, replace with optimized version.
-        if remove_unset {
-            self.remove_branches(false);
-        }
 
-        for child_byte in child_mask.iter() {
-            self.descend_to_byte(child_byte);
-            self.graft_src_at(src, &[child_byte]);
-            self.ascend_byte();
+        match src.get_focus().try_as_tagged().and_then(|node| node.as_dense()) {
+            Some(src_node) => {
+                // Split the focus if we're in the middle of another node
+                let self_focus_node = match self.try_borrow_focus_mut() {
+                    Some(node) => node,
+                    None => {
+                        self.split_at_focus();
+                        self.try_borrow_focus_mut().unwrap()
+                    }
+                };
+
+                match self_focus_node.make_mut() {
+                    TaggedNodeRefMut::DenseByteNode(node) => crate::dense_byte_node::merge_branches_into_byte_node(node, src_node, child_mask, remove_unset),
+                    TaggedNodeRefMut::CellByteNode(node) => crate::dense_byte_node::merge_branches_into_byte_node(node, src_node, child_mask, remove_unset),
+                    TaggedNodeRefMut::LineListNode(node) => {
+                        // Upgrade the focus to a dense node, if it's currently a list node
+                        let replacement = node.convert_to_dense::<crate::dense_byte_node::OrdinaryCoFree<V, A>>(child_mask.count_bits() + 2);
+                        *self_focus_node = replacement;
+                        let node = self_focus_node.make_mut().into_dense().unwrap();
+                        crate::dense_byte_node::merge_branches_into_byte_node(node, src_node, child_mask, remove_unset)
+                    },
+                }
+            },
+            None => {
+                if remove_unset {
+                    self.remove_branches(false);
+                }
+                for child_byte in child_mask.iter() {
+                    self.descend_to_byte(child_byte);
+                    self.graft_src_at(src, &[child_byte]);
+                    self.ascend_byte();
+                }
+            }
         }
     }
 
@@ -5426,6 +5451,83 @@ mod tests {
         assert_eq!(dst.get_val_at(b"root:d:old_d"), None);
         assert_eq!(dst.get_val_at(b"root:d:new_d"), Some(&40));
         assert_eq!(dst.get_val_at(b"root:z:old_z"), Some(&26));
+    }
+
+    #[test]
+    fn write_zipper_graft_masked_branches_test4() {
+        // Upper bound 0: remove_unset=true with an empty mask.
+        let src: PathMap<i32> = PathMap::new();
+
+        let mut dst: PathMap<i32> = PathMap::new();
+        dst.set_val_at(b"root:a:old_a", 1);
+        dst.set_val_at(b"root:b:old_b", 2);
+
+        let mut wz = dst.write_zipper_at_path(b"root:");
+        let rz = src.read_zipper_at_path(b"root:");
+        wz.graft_masked_branches(&rz, ByteMask::EMPTY, true);
+        drop(wz);
+
+        assert_eq!(dst.get_val_at(b"root:a:old_a"), None);
+        assert_eq!(dst.get_val_at(b"root:b:old_b"), None);
+        let rz = dst.read_zipper_at_path(b"root:");
+        assert_eq!(rz.child_count(), 0);
+    }
+
+    #[test]
+    fn write_zipper_graft_masked_branches_test5() {
+        // Upper bound 2: remove_unset=false with one preserved child and one masked child.
+        let mut src: PathMap<i32> = PathMap::new();
+        src.set_val_at(b"root:a:new_a", 10);
+
+        let mut dst: PathMap<i32> = PathMap::new();
+        dst.set_val_at(b"root:a:old_a", 1);
+        dst.set_val_at(b"root:z:old_z", 26);
+
+        let mut wz = dst.write_zipper_at_path(b"root:");
+        let rz = src.read_zipper_at_path(b"root:");
+        wz.graft_masked_branches(&rz, ByteMask::from(b'a'), false);
+        drop(wz);
+
+        assert_eq!(dst.get_val_at(b"root:a:old_a"), None);
+        assert_eq!(dst.get_val_at(b"root:a:new_a"), Some(&10));
+        assert_eq!(dst.get_val_at(b"root:z:old_z"), Some(&26));
+    }
+
+    /// Focussed on child values associated with the branches
+    #[test]
+    fn write_zipper_graft_masked_branches_test6() {
+        let mut src: PathMap<i32> = PathMap::new();
+        src.set_val_at(b"abcdefg", 0);
+        src.set_val_at(b"hijklmnop", 1);
+        src.set_val_at(b"qrstuwvxyz", 2);
+        src.set_val_at(b"0", 3);
+        src.set_val_at(b"1", 4);
+        src.set_val_at(b"2", 5);
+        src.set_val_at(b"3", 6);
+        src.set_val_at(b"4", 7);
+        src.set_val_at(b"5", 8);
+        src.set_val_at(b"6789", 9);
+
+        let child_mask = ByteMask::from_iter([
+            b'a', b'h', b'q', b'0', b'1', b'2', b'3', b'4', b'5', b'6'
+        ]);
+
+        let mut dst: PathMap<i32> = PathMap::new();
+        let mut wz = dst.write_zipper();
+        let rz = src.read_zipper();
+        wz.graft_masked_branches(&rz, child_mask, false);
+        drop(wz);
+
+        assert_eq!(dst.get_val_at(b"abcdefg"), Some(&0));
+        assert_eq!(dst.get_val_at(b"hijklmnop"), Some(&1));
+        assert_eq!(dst.get_val_at(b"qrstuwvxyz"), Some(&2));
+        assert_eq!(dst.get_val_at(b"0"), Some(&3));
+        assert_eq!(dst.get_val_at(b"1"), Some(&4));
+        assert_eq!(dst.get_val_at(b"2"), Some(&5));
+        assert_eq!(dst.get_val_at(b"3"), Some(&6));
+        assert_eq!(dst.get_val_at(b"4"), Some(&7));
+        assert_eq!(dst.get_val_at(b"5"), Some(&8));
+        assert_eq!(dst.get_val_at(b"6789"), Some(&9));
     }
 
     crate::zipper::zipper_moving_tests::zipper_moving_tests!(write_zipper,

--- a/src/write_zipper.rs
+++ b/src/write_zipper.rs
@@ -1264,8 +1264,13 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
         }
     }
     pub(crate) fn get_focus_at<K: AsRef<[u8]>>(&self, path: K) -> OpaqueAbstractNodeRef<'_, V, A> {
-//GOAT
-        panic!()
+        OpaqueAbstractNodeRef(TrieRefBorrowed::new_with_key_and_path_in(
+            self.focus_parent(),
+            || self.val(),
+            self.key.node_key(),
+            path.as_ref(),
+            self.alloc.clone(),
+        ).into_focus())
     }
     pub(crate) fn try_borrow_focus(&self) -> Option<OpaqueTrieNodeRef<'_, V, A>> {
         let node_key = self.key.node_key();
@@ -5335,15 +5340,16 @@ mod tests {
 
     #[test]
     fn write_zipper_graft_masked_branches_test2() {
-        // Case 4: Root the source zipper at `root` rather than `root:` so `get_focus_at(&[child_byte])`  must
-        // combine a non-empty `node_key` with the supplied child byte and traverse past the current node key.
+        // Case 4: Root the source zipper at `root` rather than `root:` so `get_focus_at(&[child_byte])`
+        // must resolve the `:` child from a focus with a non-empty remaining key, then graft the
+        // entire downstream subtree below that branch.
         let mut src: PathMap<i32> = PathMap::new();
         src.set_val_at(b"root:a:new_a", 10);
         src.set_val_at(b"root:a:nested:deep", 11);
         src.set_val_at(b"root:c:new_c", 30);
         src.set_val_at(b"root:e:unmasked", 50);
 
-        let child_mask = ByteMask::from_iter([b'a', b'b', b'c']);
+        let child_mask = ByteMask::from(b':');
 
         let mut dst: PathMap<i32> = PathMap::new();
         dst.set_val_at(b"root:a:old_a", 1);
@@ -5358,15 +5364,18 @@ mod tests {
         drop(wz);
         drop(rz);
 
+        let rz = dst.read_zipper_at_path(b"root:");
+        assert_eq!(rz.path_exists(), true);
+        drop(rz);
         assert_eq!(dst.get_val_at(b"root:a:old_a"), None);
         assert_eq!(dst.get_val_at(b"root:a:new_a"), Some(&10));
         assert_eq!(dst.get_val_at(b"root:a:nested:deep"), Some(&11));
         assert_eq!(dst.get_val_at(b"root:b:old_b"), None);
         assert_eq!(dst.get_val_at(b"root:c:old_c"), None);
         assert_eq!(dst.get_val_at(b"root:c:new_c"), Some(&30));
-        assert_eq!(dst.get_val_at(b"root:d:old_d"), Some(&4));
-        assert_eq!(dst.get_val_at(b"root:z:old_z"), Some(&26));
-        assert_eq!(dst.get_val_at(b"root:e:unmasked"), None);
+        assert_eq!(dst.get_val_at(b"root:d:old_d"), None);
+        assert_eq!(dst.get_val_at(b"root:z:old_z"), None);
+        assert_eq!(dst.get_val_at(b"root:e:unmasked"), Some(&50));
     }
 
     crate::zipper::zipper_moving_tests::zipper_moving_tests!(write_zipper,

--- a/src/write_zipper.rs
+++ b/src/write_zipper.rs
@@ -1487,20 +1487,23 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
     ) {
         use crate::dense_byte_node::{merge_branches_into_byte_node, OrdinaryCoFree};
 
-        match focus_node.make_mut() {
-            TaggedNodeRefMut::DenseByteNode(node) => {
+        let replacement = match focus_node.as_tagged() {
+            TaggedNodeRef::DenseByteNode(node) => {
                 merge_branches_into_byte_node::<_, _, _, _, REMOVE_UNSET>(node, src_node, child_mask)
             },
-            TaggedNodeRefMut::CellByteNode(node) => {
+            TaggedNodeRef::CellByteNode(node) => {
                 merge_branches_into_byte_node::<_, _, _, _, REMOVE_UNSET>(node, src_node, child_mask)
             },
-            TaggedNodeRefMut::LineListNode(node) => {
-                let replacement = node.convert_to_dense::<OrdinaryCoFree<V, A>>(child_mask.count_bits() + 2);
-                *focus_node = replacement;
-                let node = focus_node.make_mut().into_dense().unwrap();
+            TaggedNodeRef::LineListNode(node) => {
+                let mut line_node = node.clone();
+                let replacement = line_node.convert_to_dense::<OrdinaryCoFree<V, A>>(child_mask.count_bits() + 2);
+                let node = replacement.as_tagged().as_dense().unwrap();
                 merge_branches_into_byte_node::<_, _, _, _, REMOVE_UNSET>(node, src_node, child_mask)
             },
+            _ => unreachable!(),
         }
+        ;
+        *focus_node = replacement;
     }
     /// See [ZipperWriting::graft_masked_branches]
     pub fn graft_masked_branches<Z: ZipperInfallibleSubtries<V, A>>(&mut self, src: &Z, child_mask: ByteMask, remove_unset: bool) {

--- a/src/write_zipper.rs
+++ b/src/write_zipper.rs
@@ -139,12 +139,6 @@ pub trait ZipperWriting<V: Clone + Send + Sync, A: Allocator = GlobalAlloc>: Wri
         }
     }
 
-    /// Deprecated alias for [graft_masked_branches](ZipperWriting::graft_masked_branches)
-    #[deprecated]
-    fn graft_children<Z: ZipperInfallibleSubtries<V, A>>(&mut self, src: &Z, child_mask: ByteMask) {
-        self.graft_masked_branches(src, child_mask, false)
-    }
-
     /// Joins (union of) the subtrie below the focus of `read_zipper` into the subtrie downstream from the
     /// focus of `self`
     ///

--- a/src/write_zipper.rs
+++ b/src/write_zipper.rs
@@ -1336,8 +1336,13 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
     }
     /// See [ZipperValues::val_at]
     pub fn val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&V> {
-//GOAT
-        panic!()
+        TrieRefBorrowed::new_with_key_and_path_in(
+            self.focus_parent(),
+            || self.val(),
+            self.key.node_key(),
+            path.as_ref(),
+            self.alloc.clone(),
+        ).get_val()
     }
     /// See [ZipperWriting::get_val_mut]
     pub fn get_val_mut(&mut self) -> Option<&mut V> {

--- a/src/write_zipper.rs
+++ b/src/write_zipper.rs
@@ -1481,6 +1481,7 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
     }
     /// See [ZipperWriting::graft_masked_branches]
     pub fn graft_masked_branches<Z: ZipperInfallibleSubtries<V, A>>(&mut self, src: &Z, child_mask: ByteMask, remove_unset: bool) {
+        use crate::dense_byte_node::merge_branches_into_byte_node;
 
         match src.get_focus().try_as_tagged().and_then(|node| node.as_dense()) {
             Some(src_node) => {
@@ -1494,14 +1495,30 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
                 };
 
                 match self_focus_node.make_mut() {
-                    TaggedNodeRefMut::DenseByteNode(node) => crate::dense_byte_node::merge_branches_into_byte_node(node, src_node, child_mask, remove_unset),
-                    TaggedNodeRefMut::CellByteNode(node) => crate::dense_byte_node::merge_branches_into_byte_node(node, src_node, child_mask, remove_unset),
+                    TaggedNodeRefMut::DenseByteNode(node) => {
+                        if remove_unset {
+                            merge_branches_into_byte_node::<_, _, _, true>(node, src_node, child_mask)
+                        } else {
+                            merge_branches_into_byte_node::<_, _, _, false>(node, src_node, child_mask)
+                        }
+                    },
+                    TaggedNodeRefMut::CellByteNode(node) => {
+                        if remove_unset {
+                            merge_branches_into_byte_node::<_, _, _, true>(node, src_node, child_mask)
+                        } else {
+                            merge_branches_into_byte_node::<_, _, _, false>(node, src_node, child_mask)
+                        }
+                    },
                     TaggedNodeRefMut::LineListNode(node) => {
                         // Upgrade the focus to a dense node, if it's currently a list node
                         let replacement = node.convert_to_dense::<crate::dense_byte_node::OrdinaryCoFree<V, A>>(child_mask.count_bits() + 2);
                         *self_focus_node = replacement;
                         let node = self_focus_node.make_mut().into_dense().unwrap();
-                        crate::dense_byte_node::merge_branches_into_byte_node(node, src_node, child_mask, remove_unset)
+                        if remove_unset {
+                            merge_branches_into_byte_node::<_, _, _, true>(node, src_node, child_mask)
+                        } else {
+                            merge_branches_into_byte_node::<_, _, _, false>(node, src_node, child_mask)
+                        }
                     },
                 }
             },

--- a/src/write_zipper.rs
+++ b/src/write_zipper.rs
@@ -75,12 +75,20 @@ pub trait ZipperWriting<V: Clone + Send + Sync, A: Allocator = GlobalAlloc>: Wri
 
     /// Replaces the trie below the zipper's focus with the subtrie downstream from the focus of `read_zipper`
     ///
-    /// If there is a value at the zipper's focus, it will not be affected.
     /// GOAT: This method's behavior is affected by the `graft_root_vals` feature
+    /// Without `graft_root_vals`, If there is a value at the zipper's focus, it will not be affected.
     ///
     /// NOTE: If the `read_zipper` is not on an existing path (according to [Zipper::path_exists]) then the
-    /// effect will be the same as [remove_branches](ZipperWriting::remove_branches)
+    /// effect will be the same as calling both [remove_branches](ZipperWriting::remove_branches) and
+    /// [remove_val](ZipperWriting::remove_val)
     fn graft<Z: ZipperInfallibleSubtries<V, A>>(&mut self, read_zipper: &Z);
+
+    /// Replaces the subtrie at the zipper's focus with the subtrie located at `path`, relative to the focus of
+    /// the `src` zipper
+    ///
+    /// If `path` does not specify an existing path then the effect will be the same as calling both
+    /// [remove_branches](ZipperWriting::remove_branches) and [remove_val](ZipperWriting::remove_val)
+    fn graft_src_at<Z: ZipperInfallibleSubtries<V, A>, K: AsRef<[u8]>>(&mut self, src: &Z, path: K);
 
     /// Replaces the trie below the zipper's focus with the contents of a [PathMap], consuming the map
     ///
@@ -112,19 +120,29 @@ pub trait ZipperWriting<V: Clone + Send + Sync, A: Allocator = GlobalAlloc>: Wri
         }
     }
 
-    /// Grafts each child of `read_zipper` masked by `child_mask`
-    fn graft_children<Z: ZipperInfallibleSubtries<V, A> + ZipperMoving>(&mut self, read_zipper: &mut Z, child_mask: ByteMask) {
-        let rz_mask = read_zipper.child_mask();
-        let actual_mask = child_mask & rz_mask;
-        for child_byte in actual_mask.iter() {
+    /// Grafts each branch at the corresponding child byte indicated by a set bit in `child_mask`
+    ///
+    /// If `remove_unset` is `true` then the branches corresponding to unset bits will not exist after this
+    /// function completes.  If it is `false` then the branches corresponding to unset bits will be left alone.
+    ///
+    /// Set bits that correspond to non-existent branches in `src` will be non-existent in `self` after this
+    /// function completes.
+    fn graft_masked_branches<Z: ZipperInfallibleSubtries<V, A>>(&mut self, src: &Z, child_mask: ByteMask, remove_unset: bool) {
+        if remove_unset {
+            self.remove_branches(false);
+        }
+
+        for child_byte in child_mask.iter() {
             self.descend_to_byte(child_byte);
-            read_zipper.descend_to_byte(child_byte);
-
-            self.graft(read_zipper);
-
-            read_zipper.ascend_byte();
+            self.graft_src_at(src, &[child_byte]);
             self.ascend_byte();
         }
+    }
+
+    /// Deprecated alias for [graft_masked_branches](ZipperWriting::graft_masked_branches)
+    #[deprecated]
+    fn graft_children<Z: ZipperInfallibleSubtries<V, A>>(&mut self, src: &Z, child_mask: ByteMask) {
+        self.graft_masked_branches(src, child_mask, false)
     }
 
     /// Joins (union of) the subtrie below the focus of `read_zipper` into the subtrie downstream from the
@@ -324,6 +342,7 @@ impl<V: Clone + Send + Sync, Z, A: Allocator> ZipperWriting<V, A> for &mut Z whe
     fn remove_val(&mut self, prune: bool) -> Option<V> { (**self).remove_val(prune) }
     fn zipper_head<'z>(&'z mut self) -> Self::ZipperHead<'z> { (**self).zipper_head() }
     fn graft<RZ: ZipperInfallibleSubtries<V, A>>(&mut self, read_zipper: &RZ) { (**self).graft(read_zipper) }
+    fn graft_src_at<RZ: ZipperInfallibleSubtries<V, A>, K: AsRef<[u8]>>(&mut self, src: &RZ, path: K) { (**self).graft_src_at(src, path) }
     fn graft_map(&mut self, map: PathMap<V, A>) { (**self).graft_map(map) }
     fn graft_child_maps<I: IntoIterator<Item=PathMap<V, A>>>(&mut self, child_mask: ByteMask, maps: I, remove_unset: bool) { (**self).graft_child_maps(child_mask, maps, remove_unset) }
     fn join_into<RZ: ZipperInfallibleSubtries<V, A>>(&mut self, read_zipper: &RZ) -> AlgebraicStatus where V: Lattice { (**self).join_into(read_zipper) }
@@ -376,6 +395,7 @@ impl<'a, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> Zipper for WriteZipp
 
 impl<'a, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> ZipperValues<V> for WriteZipperTracked<'a, '_, V, A>{
     fn val(&self) -> Option<&V> { self.z.val() }
+    fn val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&V> { self.z.val_at(path) }
 }
 
 impl<'trie, V: Clone + Send + Sync + Unpin, A: Allocator + 'trie> ZipperForking<V> for WriteZipperTracked<'trie, '_, V, A>{
@@ -397,6 +417,7 @@ impl<'a, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> ZipperInfallibleSubt
     fn make_map(&self) -> PathMap<V, A> { self.z.make_map() }
     fn get_trie_ref(&self) -> TrieRef<'_, V, A> { self.z.get_trie_ref() }
     fn get_focus(&self) -> OpaqueAbstractNodeRef<'_, V, A> { self.z.get_focus() }
+    fn get_focus_at<K: AsRef<[u8]>>(&self, path: K) -> OpaqueAbstractNodeRef<'_, V, A> { self.z.get_focus_at(path) }
     fn try_borrow_focus(&self) -> Option<OpaqueTrieNodeRef<'_, V, A>> { self.z.try_borrow_focus() }
 }
 
@@ -481,6 +502,7 @@ impl<'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> ZipperWriting
     fn remove_val(&mut self, prune: bool) -> Option<V> { self.z.remove_val(prune) }
     fn zipper_head<'z>(&'z mut self) -> Self::ZipperHead<'z> { self.z.zipper_head() }
     fn graft<Z: ZipperInfallibleSubtries<V, A>>(&mut self, read_zipper: &Z) { self.z.graft(read_zipper) }
+    fn graft_src_at<Z: ZipperInfallibleSubtries<V, A>, K: AsRef<[u8]>>(&mut self, src: &Z, path: K) { self.z.graft_src_at(src, path) }
     fn graft_map(&mut self, map: PathMap<V, A>) { self.z.graft_map(map) }
     fn graft_child_maps<I: IntoIterator<Item=PathMap<V, A>>>(&mut self, child_mask: ByteMask, maps: I, remove_unset: bool) { self.z.graft_child_maps(child_mask, maps, remove_unset) }
     fn join_into<Z: ZipperInfallibleSubtries<V, A>>(&mut self, read_zipper: &Z) -> AlgebraicStatus where V: Lattice { self.z.join_into(read_zipper) }
@@ -532,6 +554,7 @@ impl<'a, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> Zipper for WriteZipp
 
 impl<'a, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> ZipperValues<V> for WriteZipperUntracked<'a, '_, V, A> {
     fn val(&self) -> Option<&V> { self.z.val() }
+    fn val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&V> { self.z.val_at(path) }
 }
 
 impl<'trie, V: Clone + Send + Sync + Unpin, A: Allocator + 'trie> ZipperForking<V> for WriteZipperUntracked<'trie, '_, V, A> {
@@ -553,6 +576,7 @@ impl<'a, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> ZipperInfallibleSubt
     fn make_map(&self) -> PathMap<V, A> { self.z.make_map() }
     fn get_trie_ref(&self) -> TrieRef<'_, V, A> { self.z.get_trie_ref() }
     fn get_focus(&self) -> OpaqueAbstractNodeRef<'_, V, A> { self.z.get_focus() }
+    fn get_focus_at<K: AsRef<[u8]>>(&self, path: K) -> OpaqueAbstractNodeRef<'_, V, A> { self.z.get_focus_at(path) }
     fn try_borrow_focus(&self) -> Option<OpaqueTrieNodeRef<'_, V, A>> { self.z.try_borrow_focus() }
 }
 
@@ -639,6 +663,7 @@ impl<'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> ZipperWriting
     fn remove_val(&mut self, prune: bool) -> Option<V> { self.z.remove_val(prune) }
     fn zipper_head<'z>(&'z mut self) -> Self::ZipperHead<'z> { self.z.zipper_head() }
     fn graft<Z: ZipperInfallibleSubtries<V, A>>(&mut self, read_zipper: &Z) { self.z.graft(read_zipper) }
+    fn graft_src_at<Z: ZipperInfallibleSubtries<V, A>, K: AsRef<[u8]>>(&mut self, src: &Z, path: K) { self.z.graft_src_at(src, path) }
     fn graft_map(&mut self, map: PathMap<V, A>) { self.z.graft_map(map) }
     fn graft_child_maps<I: IntoIterator<Item=PathMap<V, A>>>(&mut self, child_mask: ByteMask, maps: I, remove_unset: bool) { self.z.graft_child_maps(child_mask, maps, remove_unset) }
     fn join_into<Z: ZipperInfallibleSubtries<V, A>>(&mut self, read_zipper: &Z) -> AlgebraicStatus where V: Lattice { self.z.join_into(read_zipper) }
@@ -775,6 +800,7 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperWriting<V, A> for Write
     fn remove_val(&mut self, prune: bool) -> Option<V> { self.z.remove_val(prune) }
     fn zipper_head<'z>(&'z mut self) -> Self::ZipperHead<'z> { self.z.zipper_head() }
     fn graft<Z: ZipperInfallibleSubtries<V, A>>(&mut self, read_zipper: &Z) { self.z.graft(read_zipper) }
+    fn graft_src_at<Z: ZipperInfallibleSubtries<V, A>, K: AsRef<[u8]>>(&mut self, src: &Z, path: K) { self.z.graft_src_at(src, path) }
     fn graft_map(&mut self, map: PathMap<V, A>) { self.z.graft_map(map) }
     fn graft_child_maps<I: IntoIterator<Item=PathMap<V, A>>>(&mut self, child_mask: ByteMask, maps: I, remove_unset: bool) { self.z.graft_child_maps(child_mask, maps, remove_unset) }
     fn join_into<Z: ZipperInfallibleSubtries<V, A>>(&mut self, read_zipper: &Z) -> AlgebraicStatus where V: Lattice { self.z.join_into(read_zipper) }
@@ -1237,6 +1263,10 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
             OpaqueAbstractNodeRef( unsafe{ AbstractNodeRef::BorrowedRc(self.focus_stack.root_unchecked()) } )
         }
     }
+    pub(crate) fn get_focus_at<K: AsRef<[u8]>>(&self, path: K) -> OpaqueAbstractNodeRef<'_, V, A> {
+//GOAT
+        panic!()
+    }
     pub(crate) fn try_borrow_focus(&self) -> Option<OpaqueTrieNodeRef<'_, V, A>> {
         let node_key = self.key.node_key();
         if node_key.len() == 0 {
@@ -1303,6 +1333,11 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
             debug_assert!(self.at_root());
             self.root_val.as_ref().and_then(|val| unsafe{&**val}.as_ref())
         }
+    }
+    /// See [ZipperValues::val_at]
+    pub fn val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&V> {
+//GOAT
+        panic!()
     }
     /// See [ZipperWriting::get_val_mut]
     pub fn get_val_mut(&mut self) -> Option<&mut V> {
@@ -1403,6 +1438,16 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
 
         #[cfg(feature = "graft_root_vals")]
         let _ = match read_zipper.val() {
+            Some(src_val) => self.set_val(src_val.clone()),
+            None => self.remove_val(false)
+        };
+    }
+    /// See [ZipperWriting::graft_src_at]
+    fn graft_src_at<Z: ZipperInfallibleSubtries<V, A>, K: AsRef<[u8]>>(&mut self, src: &Z, path: K) {
+        self.graft_internal(src.get_focus_at(&path).into_option());
+
+        #[cfg(feature = "graft_root_vals")]
+        let _ = match src.val_at(&path) {
             Some(src_val) => self.set_val(src_val.clone()),
             None => self.remove_val(false)
         };
@@ -5189,6 +5234,99 @@ mod tests {
         assert_eq!(map4.get_val_at(b"root:s:new_s"), Some(&403));
         assert_eq!(map4.get_val_at(b"root:t:old_t"), Some(&44));  // 't' preserved
     }
+
+    // #[test]
+    // fn write_zipper_graft_masked_branches_test() {
+    //     // Source has masked branches `a` and `c`, but no `b`, plus an unrelated `e` branch.
+    //     let mut src: PathMap<i32> = PathMap::new();
+    //     src.set_val_at(b"root:", 700);
+    //     src.set_val_at(b"root:a:new_a", 10);
+    //     src.set_val_at(b"root:a:nested:deep", 11);
+    //     src.set_val_at(b"root:c:new_c", 30);
+    //     src.set_val_at(b"root:e:unmasked", 50);
+
+    //     let child_mask = ByteMask::from_iter([b'a', b'b', b'c']);
+
+    //     // Case 1: `remove_unset=false` replaces masked branches and removes masked-missing `b`, while preserving unmasked siblings.
+    //     let mut dst1: PathMap<i32> = PathMap::new();
+    //     dst1.set_val_at(b"root:", 900);
+    //     dst1.set_val_at(b"root:a:old_a", 1);
+    //     dst1.set_val_at(b"root:b:old_b", 2);
+    //     dst1.set_val_at(b"root:c:old_c", 3);
+    //     dst1.set_val_at(b"root:d:old_d", 4);
+    //     dst1.set_val_at(b"root:z:old_z", 26);
+
+    //     let mut wz1 = dst1.write_zipper_at_path(b"root:");
+    //     let mut rz1 = src.read_zipper_at_path(b"root:");
+    //     wz1.graft_masked_branches(&mut rz1, child_mask, false);
+    //     assert_eq!(wz1.val(), Some(&900));
+    //     assert_eq!(rz1.path(), b"");
+    //     assert_eq!(rz1.child_mask(), ByteMask::from_iter([b'a', b'c', b'e']));
+    //     drop(wz1);
+    //     drop(rz1);
+
+    //     assert_eq!(dst1.get_val_at(b"root:"), Some(&900));
+    //     assert_eq!(dst1.get_val_at(b"root:a:old_a"), None);
+    //     assert_eq!(dst1.get_val_at(b"root:a:new_a"), Some(&10));
+    //     assert_eq!(dst1.get_val_at(b"root:a:nested:deep"), Some(&11));
+    //     assert_eq!(dst1.get_val_at(b"root:b:old_b"), None);
+    //     assert_eq!(dst1.get_val_at(b"root:c:old_c"), None);
+    //     assert_eq!(dst1.get_val_at(b"root:c:new_c"), Some(&30));
+    //     assert_eq!(dst1.get_val_at(b"root:d:old_d"), Some(&4));
+    //     assert_eq!(dst1.get_val_at(b"root:z:old_z"), Some(&26));
+    //     assert_eq!(dst1.get_val_at(b"root:e:unmasked"), None);
+
+    //     // Case 2: `remove_unset=true` removes unmasked siblings in addition to grafting masked branches.
+    //     let mut dst2: PathMap<i32> = PathMap::new();
+    //     dst2.set_val_at(b"root:", 901);
+    //     dst2.set_val_at(b"root:a:old_a", 101);
+    //     dst2.set_val_at(b"root:b:old_b", 102);
+    //     dst2.set_val_at(b"root:c:old_c", 103);
+    //     dst2.set_val_at(b"root:d:old_d", 104);
+    //     dst2.set_val_at(b"root:z:old_z", 126);
+
+    //     let mut wz2 = dst2.write_zipper_at_path(b"root:");
+    //     let mut rz2 = src.read_zipper_at_path(b"root:");
+    //     wz2.graft_masked_branches(&mut rz2, child_mask, true);
+    //     assert_eq!(wz2.val(), Some(&901));
+    //     assert_eq!(rz2.path(), b"");
+    //     drop(wz2);
+    //     drop(rz2);
+
+    //     assert_eq!(dst2.get_val_at(b"root:"), Some(&901));
+    //     assert_eq!(dst2.get_val_at(b"root:a:old_a"), None);
+    //     assert_eq!(dst2.get_val_at(b"root:a:new_a"), Some(&10));
+    //     assert_eq!(dst2.get_val_at(b"root:a:nested:deep"), Some(&11));
+    //     assert_eq!(dst2.get_val_at(b"root:b:old_b"), None);
+    //     assert_eq!(dst2.get_val_at(b"root:c:old_c"), None);
+    //     assert_eq!(dst2.get_val_at(b"root:c:new_c"), Some(&30));
+    //     assert_eq!(dst2.get_val_at(b"root:d:old_d"), None);
+    //     assert_eq!(dst2.get_val_at(b"root:z:old_z"), None);
+    //     assert_eq!(dst2.val_count(), 4);
+
+    //     // Case 3: a masked child missing in `src` must not create a new dangling branch when `self` also lacks that child.
+    //     let mut dst3: PathMap<i32> = PathMap::new();
+    //     dst3.set_val_at(b"root:", 902);
+
+    //     let mut wz3 = dst3.write_zipper_at_path(b"root:");
+    //     let mut rz3 = src.read_zipper_at_path(b"root:");
+    //     wz3.graft_masked_branches(&mut rz3, child_mask, false);
+    //     assert_eq!(wz3.val(), Some(&902));
+    //     assert_eq!(wz3.child_mask(), ByteMask::from_iter([b'a', b'c']));
+    //     assert_eq!(rz3.path(), b"");
+    //     drop(wz3);
+    //     drop(rz3);
+
+    //     let rz3 = dst3.read_zipper_at_path(b"root:b");
+    //     assert_eq!(rz3.path_exists(), false);
+    //     drop(rz3);
+    //     assert_eq!(dst3.get_val_at(b"root:"), Some(&902));
+    //     assert_eq!(dst3.get_val_at(b"root:a:new_a"), Some(&10));
+    //     assert_eq!(dst3.get_val_at(b"root:a:nested:deep"), Some(&11));
+    //     assert_eq!(dst3.get_val_at(b"root:b"), None);
+    //     assert_eq!(dst3.get_val_at(b"root:c:new_c"), Some(&30));
+    //     assert_eq!(dst3.val_count(), 4);
+    // }
 
     crate::zipper::zipper_moving_tests::zipper_moving_tests!(write_zipper,
         |keys: &[&[u8]]| {

--- a/src/write_zipper.rs
+++ b/src/write_zipper.rs
@@ -5240,98 +5240,134 @@ mod tests {
         assert_eq!(map4.get_val_at(b"root:t:old_t"), Some(&44));  // 't' preserved
     }
 
-    // #[test]
-    // fn write_zipper_graft_masked_branches_test() {
-    //     // Source has masked branches `a` and `c`, but no `b`, plus an unrelated `e` branch.
-    //     let mut src: PathMap<i32> = PathMap::new();
-    //     src.set_val_at(b"root:", 700);
-    //     src.set_val_at(b"root:a:new_a", 10);
-    //     src.set_val_at(b"root:a:nested:deep", 11);
-    //     src.set_val_at(b"root:c:new_c", 30);
-    //     src.set_val_at(b"root:e:unmasked", 50);
+    #[test]
+    fn write_zipper_graft_masked_branches_test1() {
+        // Source has masked branches `a` and `c`, but no `b`, plus an unrelated `e` branch.
+        let mut src: PathMap<i32> = PathMap::new();
+        src.set_val_at(b"root:", 700);
+        src.set_val_at(b"root:a:new_a", 10);
+        src.set_val_at(b"root:a:nested:deep", 11);
+        src.set_val_at(b"root:c:new_c", 30);
+        src.set_val_at(b"root:e:unmasked", 50);
 
-    //     let child_mask = ByteMask::from_iter([b'a', b'b', b'c']);
+        let child_mask = ByteMask::from_iter([b'a', b'b', b'c']);
 
-    //     // Case 1: `remove_unset=false` replaces masked branches and removes masked-missing `b`, while preserving unmasked siblings.
-    //     let mut dst1: PathMap<i32> = PathMap::new();
-    //     dst1.set_val_at(b"root:", 900);
-    //     dst1.set_val_at(b"root:a:old_a", 1);
-    //     dst1.set_val_at(b"root:b:old_b", 2);
-    //     dst1.set_val_at(b"root:c:old_c", 3);
-    //     dst1.set_val_at(b"root:d:old_d", 4);
-    //     dst1.set_val_at(b"root:z:old_z", 26);
+        // Case 1: `remove_unset=false` replaces masked branches and removes masked-missing `b`, while preserving unmasked siblings.
+        let mut dst1: PathMap<i32> = PathMap::new();
+        dst1.set_val_at(b"root:", 900);
+        dst1.set_val_at(b"root:a:old_a", 1);
+        dst1.set_val_at(b"root:b:old_b", 2);
+        dst1.set_val_at(b"root:c:old_c", 3);
+        dst1.set_val_at(b"root:d:old_d", 4);
+        dst1.set_val_at(b"root:z:old_z", 26);
 
-    //     let mut wz1 = dst1.write_zipper_at_path(b"root:");
-    //     let mut rz1 = src.read_zipper_at_path(b"root:");
-    //     wz1.graft_masked_branches(&mut rz1, child_mask, false);
-    //     assert_eq!(wz1.val(), Some(&900));
-    //     assert_eq!(rz1.path(), b"");
-    //     assert_eq!(rz1.child_mask(), ByteMask::from_iter([b'a', b'c', b'e']));
-    //     drop(wz1);
-    //     drop(rz1);
+        let mut wz1 = dst1.write_zipper_at_path(b"root:");
+        let mut rz1 = src.read_zipper_at_path(b"root:");
+        wz1.graft_masked_branches(&mut rz1, child_mask, false);
+        assert_eq!(wz1.val(), Some(&900));
+        assert_eq!(rz1.path(), b"");
+        assert_eq!(rz1.child_mask(), ByteMask::from_iter([b'a', b'c', b'e']));
+        drop(wz1);
+        drop(rz1);
 
-    //     assert_eq!(dst1.get_val_at(b"root:"), Some(&900));
-    //     assert_eq!(dst1.get_val_at(b"root:a:old_a"), None);
-    //     assert_eq!(dst1.get_val_at(b"root:a:new_a"), Some(&10));
-    //     assert_eq!(dst1.get_val_at(b"root:a:nested:deep"), Some(&11));
-    //     assert_eq!(dst1.get_val_at(b"root:b:old_b"), None);
-    //     assert_eq!(dst1.get_val_at(b"root:c:old_c"), None);
-    //     assert_eq!(dst1.get_val_at(b"root:c:new_c"), Some(&30));
-    //     assert_eq!(dst1.get_val_at(b"root:d:old_d"), Some(&4));
-    //     assert_eq!(dst1.get_val_at(b"root:z:old_z"), Some(&26));
-    //     assert_eq!(dst1.get_val_at(b"root:e:unmasked"), None);
+        assert_eq!(dst1.get_val_at(b"root:"), Some(&900));
+        assert_eq!(dst1.get_val_at(b"root:a:old_a"), None);
+        assert_eq!(dst1.get_val_at(b"root:a:new_a"), Some(&10));
+        assert_eq!(dst1.get_val_at(b"root:a:nested:deep"), Some(&11));
+        assert_eq!(dst1.get_val_at(b"root:b:old_b"), None);
+        assert_eq!(dst1.get_val_at(b"root:c:old_c"), None);
+        assert_eq!(dst1.get_val_at(b"root:c:new_c"), Some(&30));
+        assert_eq!(dst1.get_val_at(b"root:d:old_d"), Some(&4));
+        assert_eq!(dst1.get_val_at(b"root:z:old_z"), Some(&26));
+        assert_eq!(dst1.get_val_at(b"root:e:unmasked"), None);
 
-    //     // Case 2: `remove_unset=true` removes unmasked siblings in addition to grafting masked branches.
-    //     let mut dst2: PathMap<i32> = PathMap::new();
-    //     dst2.set_val_at(b"root:", 901);
-    //     dst2.set_val_at(b"root:a:old_a", 101);
-    //     dst2.set_val_at(b"root:b:old_b", 102);
-    //     dst2.set_val_at(b"root:c:old_c", 103);
-    //     dst2.set_val_at(b"root:d:old_d", 104);
-    //     dst2.set_val_at(b"root:z:old_z", 126);
+        // Case 2: `remove_unset=true` removes unmasked siblings in addition to grafting masked branches.
+        let mut dst2: PathMap<i32> = PathMap::new();
+        dst2.set_val_at(b"root:", 901);
+        dst2.set_val_at(b"root:a:old_a", 101);
+        dst2.set_val_at(b"root:b:old_b", 102);
+        dst2.set_val_at(b"root:c:old_c", 103);
+        dst2.set_val_at(b"root:d:old_d", 104);
+        dst2.set_val_at(b"root:z:old_z", 126);
 
-    //     let mut wz2 = dst2.write_zipper_at_path(b"root:");
-    //     let mut rz2 = src.read_zipper_at_path(b"root:");
-    //     wz2.graft_masked_branches(&mut rz2, child_mask, true);
-    //     assert_eq!(wz2.val(), Some(&901));
-    //     assert_eq!(rz2.path(), b"");
-    //     drop(wz2);
-    //     drop(rz2);
+        let mut wz2 = dst2.write_zipper_at_path(b"root:");
+        let mut rz2 = src.read_zipper_at_path(b"root:");
+        wz2.graft_masked_branches(&mut rz2, child_mask, true);
+        assert_eq!(wz2.val(), Some(&901));
+        assert_eq!(rz2.path(), b"");
+        drop(wz2);
+        drop(rz2);
 
-    //     assert_eq!(dst2.get_val_at(b"root:"), Some(&901));
-    //     assert_eq!(dst2.get_val_at(b"root:a:old_a"), None);
-    //     assert_eq!(dst2.get_val_at(b"root:a:new_a"), Some(&10));
-    //     assert_eq!(dst2.get_val_at(b"root:a:nested:deep"), Some(&11));
-    //     assert_eq!(dst2.get_val_at(b"root:b:old_b"), None);
-    //     assert_eq!(dst2.get_val_at(b"root:c:old_c"), None);
-    //     assert_eq!(dst2.get_val_at(b"root:c:new_c"), Some(&30));
-    //     assert_eq!(dst2.get_val_at(b"root:d:old_d"), None);
-    //     assert_eq!(dst2.get_val_at(b"root:z:old_z"), None);
-    //     assert_eq!(dst2.val_count(), 4);
+        assert_eq!(dst2.get_val_at(b"root:"), Some(&901));
+        assert_eq!(dst2.get_val_at(b"root:a:old_a"), None);
+        assert_eq!(dst2.get_val_at(b"root:a:new_a"), Some(&10));
+        assert_eq!(dst2.get_val_at(b"root:a:nested:deep"), Some(&11));
+        assert_eq!(dst2.get_val_at(b"root:b:old_b"), None);
+        assert_eq!(dst2.get_val_at(b"root:c:old_c"), None);
+        assert_eq!(dst2.get_val_at(b"root:c:new_c"), Some(&30));
+        assert_eq!(dst2.get_val_at(b"root:d:old_d"), None);
+        assert_eq!(dst2.get_val_at(b"root:z:old_z"), None);
+        assert_eq!(dst2.val_count(), 4);
 
-    //     // Case 3: a masked child missing in `src` must not create a new dangling branch when `self` also lacks that child.
-    //     let mut dst3: PathMap<i32> = PathMap::new();
-    //     dst3.set_val_at(b"root:", 902);
+        // Case 3: a masked child missing in `src` must not create a new dangling branch when `self` also lacks that child.
+        let mut dst3: PathMap<i32> = PathMap::new();
+        dst3.set_val_at(b"root:", 902);
 
-    //     let mut wz3 = dst3.write_zipper_at_path(b"root:");
-    //     let mut rz3 = src.read_zipper_at_path(b"root:");
-    //     wz3.graft_masked_branches(&mut rz3, child_mask, false);
-    //     assert_eq!(wz3.val(), Some(&902));
-    //     assert_eq!(wz3.child_mask(), ByteMask::from_iter([b'a', b'c']));
-    //     assert_eq!(rz3.path(), b"");
-    //     drop(wz3);
-    //     drop(rz3);
+        let mut wz3 = dst3.write_zipper_at_path(b"root:");
+        let mut rz3 = src.read_zipper_at_path(b"root:");
+        wz3.graft_masked_branches(&mut rz3, child_mask, false);
+        assert_eq!(wz3.val(), Some(&902));
+        assert_eq!(wz3.child_mask(), ByteMask::from_iter([b'a', b'c']));
+        assert_eq!(rz3.path(), b"");
+        drop(wz3);
+        drop(rz3);
 
-    //     let rz3 = dst3.read_zipper_at_path(b"root:b");
-    //     assert_eq!(rz3.path_exists(), false);
-    //     drop(rz3);
-    //     assert_eq!(dst3.get_val_at(b"root:"), Some(&902));
-    //     assert_eq!(dst3.get_val_at(b"root:a:new_a"), Some(&10));
-    //     assert_eq!(dst3.get_val_at(b"root:a:nested:deep"), Some(&11));
-    //     assert_eq!(dst3.get_val_at(b"root:b"), None);
-    //     assert_eq!(dst3.get_val_at(b"root:c:new_c"), Some(&30));
-    //     assert_eq!(dst3.val_count(), 4);
-    // }
+        let rz3 = dst3.read_zipper_at_path(b"root:b");
+        assert_eq!(rz3.path_exists(), false);
+        drop(rz3);
+        assert_eq!(dst3.get_val_at(b"root:"), Some(&902));
+        assert_eq!(dst3.get_val_at(b"root:a:new_a"), Some(&10));
+        assert_eq!(dst3.get_val_at(b"root:a:nested:deep"), Some(&11));
+        assert_eq!(dst3.get_val_at(b"root:b"), None);
+        assert_eq!(dst3.get_val_at(b"root:c:new_c"), Some(&30));
+        assert_eq!(dst3.val_count(), 4);
+    }
+
+    #[test]
+    fn write_zipper_graft_masked_branches_test2() {
+        // Case 4: Root the source zipper at `root` rather than `root:` so `get_focus_at(&[child_byte])`  must
+        // combine a non-empty `node_key` with the supplied child byte and traverse past the current node key.
+        let mut src: PathMap<i32> = PathMap::new();
+        src.set_val_at(b"root:a:new_a", 10);
+        src.set_val_at(b"root:a:nested:deep", 11);
+        src.set_val_at(b"root:c:new_c", 30);
+        src.set_val_at(b"root:e:unmasked", 50);
+
+        let child_mask = ByteMask::from_iter([b'a', b'b', b'c']);
+
+        let mut dst: PathMap<i32> = PathMap::new();
+        dst.set_val_at(b"root:a:old_a", 1);
+        dst.set_val_at(b"root:b:old_b", 2);
+        dst.set_val_at(b"root:c:old_c", 3);
+        dst.set_val_at(b"root:d:old_d", 4);
+        dst.set_val_at(b"root:z:old_z", 26);
+
+        let mut wz = dst.write_zipper_at_path(b"root");
+        let mut rz = src.read_zipper_at_path(b"root");
+        wz.graft_masked_branches(&mut rz, child_mask, false);
+        drop(wz);
+        drop(rz);
+
+        assert_eq!(dst.get_val_at(b"root:a:old_a"), None);
+        assert_eq!(dst.get_val_at(b"root:a:new_a"), Some(&10));
+        assert_eq!(dst.get_val_at(b"root:a:nested:deep"), Some(&11));
+        assert_eq!(dst.get_val_at(b"root:b:old_b"), None);
+        assert_eq!(dst.get_val_at(b"root:c:old_c"), None);
+        assert_eq!(dst.get_val_at(b"root:c:new_c"), Some(&30));
+        assert_eq!(dst.get_val_at(b"root:d:old_d"), Some(&4));
+        assert_eq!(dst.get_val_at(b"root:z:old_z"), Some(&26));
+        assert_eq!(dst.get_val_at(b"root:e:unmasked"), None);
+    }
 
     crate::zipper::zipper_moving_tests::zipper_moving_tests!(write_zipper,
         |keys: &[&[u8]]| {

--- a/src/write_zipper.rs
+++ b/src/write_zipper.rs
@@ -344,6 +344,7 @@ impl<V: Clone + Send + Sync, Z, A: Allocator> ZipperWriting<V, A> for &mut Z whe
     fn graft<RZ: ZipperInfallibleSubtries<V, A>>(&mut self, read_zipper: &RZ) { (**self).graft(read_zipper) }
     fn graft_src_at<RZ: ZipperInfallibleSubtries<V, A>, K: AsRef<[u8]>>(&mut self, src: &RZ, path: K) { (**self).graft_src_at(src, path) }
     fn graft_map(&mut self, map: PathMap<V, A>) { (**self).graft_map(map) }
+    fn graft_masked_branches<RZ: ZipperInfallibleSubtries<V, A>>(&mut self, src: &RZ, child_mask: ByteMask, remove_unset: bool) { (**self).graft_masked_branches(src, child_mask, remove_unset) }
     fn graft_child_maps<I: IntoIterator<Item=PathMap<V, A>>>(&mut self, child_mask: ByteMask, maps: I, remove_unset: bool) { (**self).graft_child_maps(child_mask, maps, remove_unset) }
     fn join_into<RZ: ZipperInfallibleSubtries<V, A>>(&mut self, read_zipper: &RZ) -> AlgebraicStatus where V: Lattice { (**self).join_into(read_zipper) }
     fn join_map_into(&mut self, map: PathMap<V, A>) -> AlgebraicStatus where V: Lattice { (**self).join_map_into(map) }
@@ -504,6 +505,7 @@ impl<'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> ZipperWriting
     fn graft<Z: ZipperInfallibleSubtries<V, A>>(&mut self, read_zipper: &Z) { self.z.graft(read_zipper) }
     fn graft_src_at<Z: ZipperInfallibleSubtries<V, A>, K: AsRef<[u8]>>(&mut self, src: &Z, path: K) { self.z.graft_src_at(src, path) }
     fn graft_map(&mut self, map: PathMap<V, A>) { self.z.graft_map(map) }
+    fn graft_masked_branches<Z: ZipperInfallibleSubtries<V, A>>(&mut self, src: &Z, child_mask: ByteMask, remove_unset: bool) { self.z.graft_masked_branches(src, child_mask, remove_unset) }
     fn graft_child_maps<I: IntoIterator<Item=PathMap<V, A>>>(&mut self, child_mask: ByteMask, maps: I, remove_unset: bool) { self.z.graft_child_maps(child_mask, maps, remove_unset) }
     fn join_into<Z: ZipperInfallibleSubtries<V, A>>(&mut self, read_zipper: &Z) -> AlgebraicStatus where V: Lattice { self.z.join_into(read_zipper) }
     fn join_map_into(&mut self, map: PathMap<V, A>) -> AlgebraicStatus where V: Lattice { self.z.join_map_into(map) }
@@ -665,6 +667,7 @@ impl<'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> ZipperWriting
     fn graft<Z: ZipperInfallibleSubtries<V, A>>(&mut self, read_zipper: &Z) { self.z.graft(read_zipper) }
     fn graft_src_at<Z: ZipperInfallibleSubtries<V, A>, K: AsRef<[u8]>>(&mut self, src: &Z, path: K) { self.z.graft_src_at(src, path) }
     fn graft_map(&mut self, map: PathMap<V, A>) { self.z.graft_map(map) }
+    fn graft_masked_branches<Z: ZipperInfallibleSubtries<V, A>>(&mut self, src: &Z, child_mask: ByteMask, remove_unset: bool) { self.z.graft_masked_branches(src, child_mask, remove_unset) }
     fn graft_child_maps<I: IntoIterator<Item=PathMap<V, A>>>(&mut self, child_mask: ByteMask, maps: I, remove_unset: bool) { self.z.graft_child_maps(child_mask, maps, remove_unset) }
     fn join_into<Z: ZipperInfallibleSubtries<V, A>>(&mut self, read_zipper: &Z) -> AlgebraicStatus where V: Lattice { self.z.join_into(read_zipper) }
     fn join_map_into(&mut self, map: PathMap<V, A>) -> AlgebraicStatus where V: Lattice { self.z.join_map_into(map) }
@@ -802,6 +805,7 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperWriting<V, A> for Write
     fn graft<Z: ZipperInfallibleSubtries<V, A>>(&mut self, read_zipper: &Z) { self.z.graft(read_zipper) }
     fn graft_src_at<Z: ZipperInfallibleSubtries<V, A>, K: AsRef<[u8]>>(&mut self, src: &Z, path: K) { self.z.graft_src_at(src, path) }
     fn graft_map(&mut self, map: PathMap<V, A>) { self.z.graft_map(map) }
+    fn graft_masked_branches<Z: ZipperInfallibleSubtries<V, A>>(&mut self, src: &Z, child_mask: ByteMask, remove_unset: bool) { self.z.graft_masked_branches(src, child_mask, remove_unset) }
     fn graft_child_maps<I: IntoIterator<Item=PathMap<V, A>>>(&mut self, child_mask: ByteMask, maps: I, remove_unset: bool) { self.z.graft_child_maps(child_mask, maps, remove_unset) }
     fn join_into<Z: ZipperInfallibleSubtries<V, A>>(&mut self, read_zipper: &Z) -> AlgebraicStatus where V: Lattice { self.z.join_into(read_zipper) }
     fn join_map_into(&mut self, map: PathMap<V, A>) -> AlgebraicStatus where V: Lattice { self.z.join_map_into(map) }
@@ -1474,6 +1478,19 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
             Some(src_val) => self.set_val(src_val),
             None => self.remove_val(false)
         };
+    }
+    /// See [ZipperWriting::graft_masked_branches]
+    pub fn graft_masked_branches<Z: ZipperInfallibleSubtries<V, A>>(&mut self, src: &Z, child_mask: ByteMask, remove_unset: bool) {
+//GOAT, replace with optimized version.
+        if remove_unset {
+            self.remove_branches(false);
+        }
+
+        for child_byte in child_mask.iter() {
+            self.descend_to_byte(child_byte);
+            self.graft_src_at(src, &[child_byte]);
+            self.ascend_byte();
+        }
     }
 
     /// Optimized implementation of [ZipperWriting::graft_child_maps] for WriteZipperCore
@@ -5376,6 +5393,39 @@ mod tests {
         assert_eq!(dst.get_val_at(b"root:d:old_d"), None);
         assert_eq!(dst.get_val_at(b"root:z:old_z"), None);
         assert_eq!(dst.get_val_at(b"root:e:unmasked"), Some(&50));
+    }
+
+    #[test]
+    fn write_zipper_graft_masked_branches_test3() {
+        // Force the specialized `resulting_child_count > 2` path, while still including a masked child
+        // that is missing from the source so we preserve the semantics of removing old destination data.
+        let mut src: PathMap<i32> = PathMap::new();
+        src.set_val_at(b"root:a:new_a", 10);
+        src.set_val_at(b"root:c:new_c", 30);
+        src.set_val_at(b"root:d:new_d", 40);
+
+        let child_mask = ByteMask::from_iter([b'a', b'b', b'c', b'd']);
+
+        let mut dst: PathMap<i32> = PathMap::new();
+        dst.set_val_at(b"root:a:old_a", 1);
+        dst.set_val_at(b"root:b:old_b", 2);
+        dst.set_val_at(b"root:c:old_c", 3);
+        dst.set_val_at(b"root:d:old_d", 4);
+        dst.set_val_at(b"root:z:old_z", 26);
+
+        let mut wz = dst.write_zipper_at_path(b"root:");
+        let rz = src.read_zipper_at_path(b"root:");
+        wz.graft_masked_branches(&rz, child_mask, false);
+        drop(wz);
+
+        assert_eq!(dst.get_val_at(b"root:a:old_a"), None);
+        assert_eq!(dst.get_val_at(b"root:a:new_a"), Some(&10));
+        assert_eq!(dst.get_val_at(b"root:b:old_b"), None);
+        assert_eq!(dst.get_val_at(b"root:c:old_c"), None);
+        assert_eq!(dst.get_val_at(b"root:c:new_c"), Some(&30));
+        assert_eq!(dst.get_val_at(b"root:d:old_d"), None);
+        assert_eq!(dst.get_val_at(b"root:d:new_d"), Some(&40));
+        assert_eq!(dst.get_val_at(b"root:z:old_z"), Some(&26));
     }
 
     crate::zipper::zipper_moving_tests::zipper_moving_tests!(write_zipper,

--- a/src/zipper.rs
+++ b/src/zipper.rs
@@ -1090,7 +1090,7 @@ impl<'a, V: Clone + Send + Sync + Unpin + 'a, A: Allocator + 'a> ZipperReadOnlyS
     type TrieRefT = TrieRefBorrowed<'a, V, A>;
     fn trie_ref_at_path<K: AsRef<[u8]>>(&self, path: K) -> TrieRefBorrowed<'a, V, A> {
         let path = path.as_ref();
-        TrieRefBorrowed::new_with_key_and_path_in(self.z.focus_parent_borrowed(), self.get_val(), self.z.node_key(), path, self.z.alloc.clone())
+        TrieRefBorrowed::new_with_key_and_path_in(self.z.focus_parent_borrowed(), || self.get_val(), self.z.node_key(), path, self.z.alloc.clone())
     }
 }
 
@@ -1506,7 +1506,7 @@ pub(crate) mod read_zipper_core {
             PathMap::new_with_root_in(root_node, root_val, self.alloc.clone())
         }
         fn get_trie_ref(&self) -> TrieRef<'_, V, A> {
-            TrieRefBorrowed::new_with_key_and_path_in(self.focus_parent_borrowed(), self.val(), self.node_key(), b"", self.alloc.clone()).into()
+            TrieRefBorrowed::new_with_key_and_path_in(self.focus_parent_borrowed(), || self.val(), self.node_key(), b"", self.alloc.clone()).into()
         }
         fn get_focus(&self) -> OpaqueAbstractNodeRef<'_, V, A> {
             self.get_focus_at([])
@@ -2349,8 +2349,25 @@ pub(crate) mod read_zipper_core {
         /// the returned value might outlive the zipper.  We need to only expose this through methods
         /// that have tighter lifetime bounds, or on types that guarantee the root won't be owned
         pub(crate) unsafe fn get_val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&'a V> {
-//GOAT
-            panic!()
+            let val = TrieRefBorrowed::new_with_key_and_path_in(
+                self.focus_parent(),
+                || {
+                    // SAFETY: `get_val_at` has the same lifetime contract as `get_val`. This closure is
+                    // only invoked when the target path resolves to the current focus itself, so using
+                    // `self.get_val()` here is equivalent to asking for the current focus value.
+                    unsafe { self.get_val() }
+                },
+                self.node_key(),
+                path.as_ref(),
+                self.alloc.clone(),
+            ).get_val();
+
+            // SAFETY: `val` points into the trie reachable from `self`. The only reason its inferred
+            // lifetime is shorter is that `focus_parent()` returns a reference tied to `&self`, even when
+            // the underlying trie root is owned by the zipper and is therefore guaranteed to stay alive
+            // for `'a`. This method is already `unsafe` for exactly that reason, and callers must uphold
+            // the documented requirement that the returned reference not outlive the backing trie storage.
+            unsafe { core::mem::transmute::<Option<&V>, Option<&'a V>>(val) }
         }
 
         /// See [ReadZipperCore::get_val] for explanation as to why this is unsafe

--- a/src/zipper.rs
+++ b/src/zipper.rs
@@ -548,7 +548,7 @@ impl<'a, V: Clone + Send + Sync, A: Allocator> OpaqueAbstractNodeRef<'a, V, A> {
 pub struct OpaqueTrieNodeRef<'trie, V: Clone + Send + Sync, A: Allocator>(pub(crate) &'trie TrieNodeODRc<V, A>);
 
 /// Similar to [ZipperSubtries], but with the stronger guarantee that subtrie access will be constant-time and won't fail
-pub trait ZipperInfallibleSubtries<V: Clone + Send + Sync, A: Allocator = GlobalAlloc>: ZipperValues<V> {
+pub trait ZipperInfallibleSubtries<V: Clone + Send + Sync, A: Allocator = GlobalAlloc>: ZipperValues<V> + Zipper {
     /// Returns a new [PathMap] containing everything below the zipper's focus
     fn make_map(&self) -> PathMap<V, A>;
 

--- a/src/zipper.rs
+++ b/src/zipper.rs
@@ -59,6 +59,12 @@ pub trait ZipperValues<V> {
     /// will provide a longer-lived reference to the value.
     fn val(&self) -> Option<&V>;
 
+    /// Returns a refernce to the value at `path`, relative to the zipper's focus, or `None` if there is no value
+    ///
+    /// If you have a zipper type that implements [ZipperReadOnlyValues] then [ZipperReadOnlyValues::get_val_at]
+    /// will provide a longer-lived reference to the value.
+    fn val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&V>;
+
     /// Deprecated alias for [ZipperValues::val]
     #[deprecated] //GOAT-old-names
     fn value(&self) -> Option<&V> {
@@ -81,7 +87,7 @@ pub trait ZipperForking<V> {
 }
 
 /// Methods for zippers that can access concrete subtries
-pub trait ZipperSubtries<V: Clone + Send + Sync, A: Allocator = GlobalAlloc>: ZipperValues<V> {
+pub trait ZipperSubtries<V: Clone + Send + Sync, A: Allocator = GlobalAlloc>: ZipperValues<V> + Zipper {
     /// Returns `true` if the zipper can access a subtrie in constant time
     ///
     /// Sometimes this trait will be implemented on abstract zipper types, in which case this method will return
@@ -445,6 +451,12 @@ pub trait ZipperReadOnlyValues<'a, V>: ZipperValues<V> {
     /// instead of the temporary lifetime of the method.
     fn get_val(&self) -> Option<&'a V>;
 
+    /// Returns a refernce to the value at `path`, relative to the zipper's focus, or `None` if there is no value
+    ///
+    /// NOTE: Unlike [ZipperValues::val_at], this method returns a reference with the lifetime of `'a`
+    /// instead of the temporary lifetime of the method.
+    fn get_val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&'a V>;
+
     /// Deprecated alias for [ZipperReadOnlyValues::get_val]
     #[deprecated] //GOAT-old-names
     fn get_value(&self) -> Option<&'a V> {
@@ -546,6 +558,10 @@ pub trait ZipperInfallibleSubtries<V: Clone + Send + Sync, A: Allocator = Global
     /// **INTERNAL USE ONLY**  Returns a reference to trie internals
     #[doc(hidden)]
     fn get_focus(&self) -> OpaqueAbstractNodeRef<'_, V, A>;
+
+    /// **INTERNAL USE ONLY**  Returns a reference to trie internals
+    #[doc(hidden)]
+    fn get_focus_at<K: AsRef<[u8]>>(&self, path: K) -> OpaqueAbstractNodeRef<'_, V, A>;
 
     /// **INTERNAL USE ONLY**  Attemps to return a node at the zipper's focus.  Returns
     /// `None` if the focus is not on a node.
@@ -805,6 +821,7 @@ macro_rules! zipper_impl_lens {
     };
     (ZipperValues $s: ident => $e:expr) => {
         fn val(&$s) -> Option<&V> { $e.val() }
+        fn val_at<K: AsRef<[u8]>>(&$s, path: K) -> Option<&V> { $e.val_at(path) }
     };
     (ZipperForking $s: ident => $e:expr) => {
         fn fork_read_zipper<'a>(&'a $s) -> Self::ReadZipperT<'a> { $e.fork_read_zipper() }
@@ -842,10 +859,12 @@ macro_rules! zipper_impl_lens {
         fn make_map(&$s) -> crate::PathMap<V, A> { $e.make_map() }
         fn get_trie_ref(&$s) -> TrieRef<'_, V, A> { $e.get_trie_ref() }
         fn get_focus(&$s) -> OpaqueAbstractNodeRef<'_, V, A> { $e.get_focus() }
+        fn get_focus_at<K: AsRef<[u8]>>(&$s, k: K) -> OpaqueAbstractNodeRef<'_, V, A> { $e.get_focus_at(k) }
         fn try_borrow_focus(&$s) -> Option<OpaqueTrieNodeRef<'_, V, A>> { $e.try_borrow_focus() }
     };
     (ZipperReadOnlyValues $s: ident => $e:expr) => {
         fn get_val(&$s) -> Option<&'a V> { $e.get_val() }
+        fn get_val_at<K: AsRef<[u8]>>(&$s, path: K) -> Option<&'a V> { $e.get_val_at(path) }
     };
     (ZipperReadOnlyConditionalValues $s: ident => $e:expr) => {
         fn witness<'w>(&$s) -> Self::WitnessT { $e.witness() }
@@ -1058,6 +1077,7 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperForking<V> for ReadZipp
 
 impl<'trie, V: Clone + Send + Sync + Unpin + 'trie, A: Allocator + 'trie> ZipperReadOnlyValues<'trie, V> for ReadZipperUntracked<'trie, '_, V, A> {
     fn get_val(&self) -> Option<&'trie V> { unsafe{ self.z.get_val() } }
+    fn get_val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&'trie V> { unsafe{ self.z.get_val_at(path) } }
 }
 
 impl<'trie, V: Clone + Send + Sync + Unpin + 'trie, A: Allocator + 'trie> ZipperReadOnlyConditionalValues<'trie, V> for ReadZipperUntracked<'trie, '_, V, A> {
@@ -1212,6 +1232,7 @@ impl<'trie, V: Clone + Send + Sync + Unpin + 'trie, A: Allocator + 'trie> Zipper
 
 impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperValues<V> for ReadZipperOwned<V, A> {
     fn val(&self) -> Option<&V> { unsafe{ self.z.get_val() } }
+    fn val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&V> { unsafe{ self.z.get_val_at(path) } }
 }
 
 impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperForking<V> for ReadZipperOwned<V, A> {
@@ -1450,6 +1471,7 @@ pub(crate) mod read_zipper_core {
 
     impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperValues<V> for ReadZipperCore<'_, '_, V, A> {
         fn val(&self) -> Option<&V> { unsafe{ self.get_val() } }
+        fn val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&V> { unsafe{ self.get_val_at(path) } }
     }
 
     impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperForking<V> for ReadZipperCore<'_, '_, V, A> {
@@ -1487,20 +1509,38 @@ pub(crate) mod read_zipper_core {
             TrieRefBorrowed::new_with_key_and_path_in(self.focus_parent_borrowed(), self.val(), self.node_key(), b"", self.alloc.clone()).into()
         }
         fn get_focus(&self) -> OpaqueAbstractNodeRef<'_, V, A> {
+            self.get_focus_at([])
+        }
+        #[inline]
+        fn get_focus_at<K: AsRef<[u8]>>(&self, path: K) -> OpaqueAbstractNodeRef<'_, V, A> {
+            let path = path.as_ref();
             let node_key = self.node_key();
 
-            //See if we need to deregularize the zipper here to get at the ODRc that holds the focus
-            let (focus_node, node_key) = if node_key.len() == 0 {
-                match self.ancestors.last() {
-                    Some((focus_node, _iter_tok, _prefix_offset)) => (focus_node, self.parent_key()),
-                    None => {
-                        return OpaqueAbstractNodeRef(AbstractNodeRef::BorrowedRc(self.root_node.as_ref()))
+            match (node_key.len() == 0, path.len() == 0) {
+                //No onward key means we want to reference the focus node, but we want to get the ODRC, so we can clone it by reference
+                (true, true) => {
+                    match self.ancestors.last() {
+                        Some((focus_node, _iter_tok, _prefix_offset)) => OpaqueAbstractNodeRef(focus_node.get_node_at_key(self.parent_key())),
+                        None => OpaqueAbstractNodeRef(AbstractNodeRef::BorrowedRc(self.root_node.as_ref()))
                     }
-                }
-            } else {
-                (&*self.focus_node, node_key)
-            };
-            OpaqueAbstractNodeRef(focus_node.get_node_at_key(node_key))
+                },
+                //Based off the `node_key` only
+                (false, true) => {
+                    OpaqueAbstractNodeRef(self.focus_node.get_node_at_key(node_key))
+                },
+                //Based off of the supplied `path` only
+                (true, false) => {
+                    OpaqueAbstractNodeRef(self.focus_node.get_node_at_key(path))
+                },
+                //Combine both
+                (false, false) => {
+//GOAT, no alloc allowed!!!  This is temporary Cheese
+                    let mut full_key = Vec::with_capacity(node_key.len() + path.len());
+                    full_key.extend_from_slice(node_key);
+                    full_key.extend_from_slice(path);
+                    OpaqueAbstractNodeRef(self.focus_node.get_node_at_key(&full_key))
+                },
+            }
         }
         fn try_borrow_focus(&self) -> Option<OpaqueTrieNodeRef<'_, V, A>> {
             let node_key = self.node_key();
@@ -2303,6 +2343,14 @@ pub(crate) mod read_zipper_core {
                     self.root_val
                 }
             }
+        }
+
+        /// Internal impl is marked `unsafe` because ReadZipperCore::root_node might be `Owned`, meaning
+        /// the returned value might outlive the zipper.  We need to only expose this through methods
+        /// that have tighter lifetime bounds, or on types that guarantee the root won't be owned
+        pub(crate) unsafe fn get_val_at<K: AsRef<[u8]>>(&self, path: K) -> Option<&'a V> {
+//GOAT
+            panic!()
         }
 
         /// See [ReadZipperCore::get_val] for explanation as to why this is unsafe
@@ -3135,6 +3183,12 @@ pub(crate) mod zipper_moving_tests {
                     let mut temp_store = $read_keys(crate::zipper::zipper_moving_tests::ZIPPER_BYTES_ITER_TEST5_KEYS);
                     crate::zipper::zipper_moving_tests::run_test(&mut temp_store, $make_z, &[], crate::zipper::zipper_moving_tests::zipper_byte_iter_test5)
                 }
+
+                #[test]
+                fn [<$z_name _zipper_val_at_test>]() {
+                    let mut temp_store = $read_keys(crate::zipper::zipper_moving_tests::ZIPPER_VAL_AT_TEST_KEYS);
+                    crate::zipper::zipper_moving_tests::run_test(&mut temp_store, $make_z, &[], crate::zipper::zipper_moving_tests::zipper_val_at_test)
+                }
             }
         }
     }
@@ -3801,6 +3855,48 @@ pub(crate) mod zipper_moving_tests {
         zipper.reset();
         zipper.descend_to([2, 197, 97, 120, 105]);
         assert_eq!(zipper.to_next_sibling_byte(), true);
+    }
+
+    pub const ZIPPER_VAL_AT_TEST_KEYS: &[&[u8]] = &[
+        b"arrow", b"bow", b"cannon", b"roman", b"romane", b"romanus",
+        b"romulus", b"rubens", b"ruber", b"rubicon", b"rubicundus", b"rom'i",
+    ];
+
+    pub fn zipper_val_at_test<Z: ZipperMoving + ZipperValues<()>>(mut zipper: Z) {
+        assert_eq!(zipper.val_at(b""), None);
+        assert_eq!(zipper.val_at(b"roman"), Some(&()));
+        assert_eq!(zipper.val_at(b"romane"), Some(&()));
+        assert_eq!(zipper.val_at(b"roma"), None);
+        assert_eq!(zipper.val_at(b"romanu"), None);
+        assert_eq!(zipper.val_at(b"ruber"), Some(&()));
+        assert_eq!(zipper.val_at(b"rub"), None);
+        assert_eq!(zipper.val_at(b"zzz"), None);
+
+        zipper.descend_to(b"ro");
+        assert!(zipper.path_exists());
+        assert_eq!(zipper.val_at(b""), None);
+        assert_eq!(zipper.val_at(b"m"), None);
+        assert_eq!(zipper.val_at(b"man"), Some(&()));
+        assert_eq!(zipper.val_at(b"mane"), Some(&()));
+        assert_eq!(zipper.val_at(b"manus"), Some(&()));
+        assert_eq!(zipper.val_at(b"manu"), None);
+        assert_eq!(zipper.val_at(b"mulus"), Some(&()));
+        assert_eq!(zipper.val_at(b"mulu"), None);
+        assert_eq!(zipper.val_at(b"zz"), None);
+
+        zipper.descend_to(b"man");
+        assert!(zipper.path_exists());
+        assert_eq!(zipper.val_at(b""), Some(&()));
+        assert_eq!(zipper.val_at(b"e"), Some(&()));
+        assert_eq!(zipper.val_at(b"us"), Some(&()));
+        assert_eq!(zipper.val_at(b"u"), None);
+        assert_eq!(zipper.val_at(b"zz"), None);
+
+        zipper.reset();
+        zipper.descend_to(b"romanx");
+        assert!(!zipper.path_exists());
+        assert_eq!(zipper.val_at(b""), None);
+        assert_eq!(zipper.val_at(b"e"), None);
     }
 
 }

--- a/src/zipper.rs
+++ b/src/zipper.rs
@@ -3049,6 +3049,7 @@ impl<'a> SliceOrLen<'a> {
 #[cfg(test)]
 pub(crate) mod zipper_moving_tests {
     use crate::trie_map::*;
+    use crate::trie_node::MAX_NODE_KEY_BYTES;
     use super::*;
 
     /// `$ident` is a unique identifier for the zipper, so the generated tests don't collide
@@ -3205,6 +3206,14 @@ pub(crate) mod zipper_moving_tests {
                 fn [<$z_name _zipper_val_at_test>]() {
                     let mut temp_store = $read_keys(crate::zipper::zipper_moving_tests::ZIPPER_VAL_AT_TEST_KEYS);
                     crate::zipper::zipper_moving_tests::run_test(&mut temp_store, $make_z, &[], crate::zipper::zipper_moving_tests::zipper_val_at_test)
+                }
+
+                #[test]
+                fn [<$z_name _zipper_val_at_long_path_test>]() {
+                    let long_key = crate::zipper::zipper_moving_tests::zipper_val_at_long_path_test_key();
+                    let keys = [&long_key[..], b"zzz" as &[u8]];
+                    let mut temp_store = $read_keys(&keys);
+                    crate::zipper::zipper_moving_tests::run_test(&mut temp_store, $make_z, &[], crate::zipper::zipper_moving_tests::zipper_val_at_long_path_test)
                 }
             }
         }
@@ -3914,6 +3923,27 @@ pub(crate) mod zipper_moving_tests {
         assert!(!zipper.path_exists());
         assert_eq!(zipper.val_at(b""), None);
         assert_eq!(zipper.val_at(b"e"), None);
+    }
+
+    pub fn zipper_val_at_long_path_test_key() -> Vec<u8> {
+        let mut key = b"rom".to_vec();
+        key.extend((0..(MAX_NODE_KEY_BYTES * 2 + 17)).map(|i| b'a' + (i % 26) as u8));
+        key
+    }
+
+    pub fn zipper_val_at_long_path_test<Z: ZipperMoving + ZipperValues<()>>(mut zipper: Z) {
+        let long_key = zipper_val_at_long_path_test_key();
+        let relative_long_suffix = &long_key[3..];
+        let almost_full_suffix = &relative_long_suffix[..relative_long_suffix.len()-1];
+
+        assert_eq!(relative_long_suffix.len() > MAX_NODE_KEY_BYTES, true);
+        assert_eq!(zipper.val_at(&long_key), Some(&()));
+
+        zipper.descend_to(b"rom");
+        assert!(zipper.path_exists());
+        assert_eq!(zipper.val_at(relative_long_suffix), Some(&()));
+        assert_eq!(zipper.val_at(almost_full_suffix), None);
+        assert_eq!(zipper.val_at(b"zzz"), None);
     }
 
 }

--- a/src/zipper.rs
+++ b/src/zipper.rs
@@ -1513,34 +1513,13 @@ pub(crate) mod read_zipper_core {
         }
         #[inline]
         fn get_focus_at<K: AsRef<[u8]>>(&self, path: K) -> OpaqueAbstractNodeRef<'_, V, A> {
-            let path = path.as_ref();
-            let node_key = self.node_key();
-
-            match (node_key.len() == 0, path.len() == 0) {
-                //No onward key means we want to reference the focus node, but we want to get the ODRC, so we can clone it by reference
-                (true, true) => {
-                    match self.ancestors.last() {
-                        Some((focus_node, _iter_tok, _prefix_offset)) => OpaqueAbstractNodeRef(focus_node.get_node_at_key(self.parent_key())),
-                        None => OpaqueAbstractNodeRef(AbstractNodeRef::BorrowedRc(self.root_node.as_ref()))
-                    }
-                },
-                //Based off the `node_key` only
-                (false, true) => {
-                    OpaqueAbstractNodeRef(self.focus_node.get_node_at_key(node_key))
-                },
-                //Based off of the supplied `path` only
-                (true, false) => {
-                    OpaqueAbstractNodeRef(self.focus_node.get_node_at_key(path))
-                },
-                //Combine both
-                (false, false) => {
-//GOAT, no alloc allowed!!!  This is temporary Cheese
-                    let mut full_key = Vec::with_capacity(node_key.len() + path.len());
-                    full_key.extend_from_slice(node_key);
-                    full_key.extend_from_slice(path);
-                    OpaqueAbstractNodeRef(self.focus_node.get_node_at_key(&full_key))
-                },
-            }
+            OpaqueAbstractNodeRef(TrieRefBorrowed::new_with_key_and_path_in(
+                self.focus_parent(),
+                || self.val(),
+                self.node_key(),
+                path.as_ref(),
+                self.alloc.clone(),
+            ).into_focus())
         }
         fn try_borrow_focus(&self) -> Option<OpaqueTrieNodeRef<'_, V, A>> {
             let node_key = self.node_key();


### PR DESCRIPTION
A small PR that just extends `ZipperAlgebraExt` ( `z.join()` syntax ) and `SomeMutRefZ` ( `zipper_join_n!(...)` and `(z1, z2,...).join` ) support to more zippers. Concretely, `ZipperAlgebraExt` is 'implemented' for `ReadZipperOwned` and `PrefixZipper`. `SomeMutRefZ` now covers `PrefixZipper` for `ReadZipperUntracked` and `ReadZipperTracked`.

Note: There are some limitations: `SomeMutRefZ` cannot support `ReadZipperOwned` because it forces `V: 'static` which we don't want; it also cannot support arbitrary `PrefixZipper` because it can't be expressed without GADTs (or, at least I don't know how)