### PR TITLE
DNF zipper merge

### DIFF
--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -3790,6 +3790,16 @@ mod tests {
         (&[0b000001, 0b11, 0b1111], 12),
     ];
 
+    fn prefixed<V: Clone + Send + Sync + Unpin, Z: ZipperInfallibleSubtries<V>>(
+        rz: &Z,
+        path: &[u8],
+    ) -> PathMap<V> {
+        let mut res = PathMap::new();
+        let mut out = res.write_zipper_at_path(path);
+        out.graft(rz);
+        res
+    }
+
     #[test]
     fn test_merkleization() {
         use crate::experimental::zipper_algebra::*;
@@ -3824,16 +3834,6 @@ mod tests {
             (&[0b11, 0b1111], 12),
         ];
         assert_trie(expected0.iter().copied(), result0);
-
-        fn prefixed<V: Clone + Send + Sync + Unpin, Z: ZipperInfallibleSubtries<V>>(
-            rz: &Z,
-            path: &[u8],
-        ) -> PathMap<V> {
-            let mut res = PathMap::new();
-            let mut out = res.write_zipper_at_path(path);
-            out.graft(rz);
-            res
-        }
 
         let mut map1 = prefixed(&mut r3, &[0]);
         let mut map2 = prefixed(&mut r4, &[0]);
@@ -3987,6 +3987,73 @@ mod tests {
                 &mut out,
             );
             let expected = trie2.meet(&trie1.join(&trie3));
+            assert_trie(expected, result);
+        }
+
+        #[test]
+        fn test_partial_overlap_3() {
+            let mut trie1 = PathMap::from_iter(SMALL_TRIE_1);
+            let mut trie2 = PathMap::from_iter(SMALL_TRIE_2);
+            let mut trie3 = PathMap::from_iter(SMALL_TRIE_3);
+
+            let mut z3 = trie3.read_zipper();
+
+            let mut result = PathMap::new();
+            let mut out = result.write_zipper();
+            zipper_merge_dnf(
+                &mut [
+                    &mut [&mut trie1.read_zipper(), &mut trie2.read_zipper(), &mut z3],
+                    &mut [&mut trie1.read_zipper(), &mut trie2.read_zipper()],
+                ],
+                &mut out,
+            );
+            let expected = trie2.meet(&trie1);
+            assert_trie(expected, result);
+        }
+
+        #[test]
+        fn test_mixed_depth() {
+            let deep_chain: Vec<u8> = (0..100).map(|i| i & 1).collect();
+            let shallow_chain: Vec<u8> = (0..10).map(|i| (i + 1) & 1).collect();
+            let branches: Paths = &[
+                (&[0b0], 0),
+                (&[0b0, 0b01], 1),
+                (&[0b0, 0b10], 2),
+                (&[0b0, 0b11], 3),
+                (&[0b0, 0b01, 0b01], 4),
+                (&[0b0, 0b01, 0b11], 5),
+                (&[0b0, 0b10, 0b10], 6),
+                (&[0b0, 0b10, 0b10, 0b0], 7),
+                (&[0b0, 0b11, 0b00], 8),
+                (&[0b0, 0b11, 0b10], 9),
+                (&[0b0, 0b11, 0b10], 9),
+                (&[0b0, 0b11, 0b00, 0b00], 11),
+                (&[0b0, 0b11, 0b10, 0b00], 12),
+                (&[0b0, 0b11, 0b10, 0b00], 13),
+            ];
+
+            let mut trie1 = PathMap::from_iter(&[(deep_chain, 0)]);
+            let mut trie2 = PathMap::from_iter(&[(shallow_chain, 1)]);
+            let mut trie3 = PathMap::from_iter(branches);
+
+            let a = &[0, 0, 0, 0];
+            let a_deep_chain = prefixed(&trie1.read_zipper(), a);
+            let a_shallow_chain = prefixed(&trie2.read_zipper(), a);
+            let a_branching = prefixed(&trie3.read_zipper(), a);
+
+            let mut z3 = trie3.read_zipper();
+
+            let mut result = PathMap::new();
+            let mut out = result.write_zipper();
+            zipper_merge_dnf(
+                &mut [
+                    &mut [&mut a_deep_chain.read_zipper()],
+                    &mut [&mut a_shallow_chain.read_zipper()],
+                    &mut [&mut a_branching.read_zipper()],
+                ],
+                &mut out,
+            );
+            let expected = a_deep_chain.join(&a_shallow_chain.join(&a_branching));
             assert_trie(expected, result);
         }
     }

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -1610,6 +1610,9 @@ where
             let single_clause = first_active_mut(clauses, active);
             match single_clause {
                 [z0] => {
+                    if let Some(v) = z0.val() {
+                        out.set_val(v.clone());
+                    }
                     Meet::on_id(z0, out);
                     return;
                 }

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -1,7 +1,9 @@
+use std::borrow::Cow;
+
 use crate::{
     alloc::{Allocator, GlobalAlloc},
     ring::{AlgebraicResult, COUNTER_IDENT, DistributiveLattice, Lattice, SELF_IDENT},
-    utils::ByteMask,
+    utils::{BitMask, ByteMask},
     zipper::*,
 };
 
@@ -360,26 +362,43 @@ trait MergePolicy<V: Clone + Send + Sync> {
         Out: ZipperWriting<V, A>;
 }
 
-trait ValuePolicy<V> {
-    fn combine(l: Option<&V>, r: Option<&V>) -> Option<V>;
+#[inline(always)]
+fn lift<'a, V: Clone>(v: Option<&'a V>) -> Option<Cow<'a, V>> {
+    v.map(Cow::Borrowed)
+}
+
+#[inline(always)]
+fn unlift<V: Clone>(v: Option<Cow<V>>) -> Option<V> {
+    v.map(Cow::into_owned)
+}
+trait ValuePolicy<V: Clone> {
+    fn combine_impl<'a>(l: Option<Cow<'a, V>>, r: Option<Cow<'a, V>>) -> Option<Cow<'a, V>>;
     #[inline]
-    fn combine_acc(l: Option<V>, r: Option<&V>) -> Option<V> {
-        Self::combine(l.as_ref(), r)
+    fn combine(l: Option<&V>, r: Option<&V>) -> Option<V> {
+        unlift(Self::combine_impl(lift(l), lift(r)))
     }
+    #[inline]
     fn combine3(l: Option<&V>, m: Option<&V>, r: Option<&V>) -> Option<V> {
         // (l op m) op r
-        Self::combine_acc(Self::combine(l, m), r)
+        unlift(Self::combine_impl(
+            Self::combine_impl(lift(l), lift(m)),
+            lift(r),
+        ))
     }
+    #[inline]
     fn combine4(a: Option<&V>, b: Option<&V>, c: Option<&V>, d: Option<&V>) -> Option<V> {
         // ((a op b) op c) op d
-        Self::combine_acc(Self::combine_acc(Self::combine(a, b), c), d)
+        unlift(Self::combine_impl(
+            Self::combine_impl(Self::combine_impl(lift(a), lift(b)), lift(c)),
+            lift(d),
+        ))
     }
     fn combine_n<'a, I>(vals: I) -> Option<V>
     where
-        I: Iterator<Item = Option<&'a V>>,
+        I: Iterator<Item = Option<Cow<'a, V>>>,
         V: 'a,
     {
-        vals.fold(None, |acc, v| Self::combine_acc(acc, v))
+        unlift(vals.fold(None, |acc, v| Self::combine_impl(acc, v)))
     }
 }
 
@@ -1194,12 +1213,12 @@ where
     fn values<'a, V, Z, const N: usize>(
         zs: &'a [Z; N],
         active: u64,
-    ) -> impl Iterator<Item = Option<&'a V>>
+    ) -> impl Iterator<Item = Option<Cow<'a, V>>>
     where
-        V: 'a,
+        V: Clone + 'a,
         Z: ZipperValues<V>,
     {
-        only_active(zs, active).map(|(_, z)| z.val())
+        only_active(zs, active).map(|(_, z)| lift(z.val()))
     }
 
     fn all_active_share<Z, const N: usize>(zs: &[Z; N], active: u64) -> bool
@@ -1505,47 +1524,25 @@ impl<V: Clone + Send + Sync> MergePolicy<V> for Join {
 }
 
 impl<V: Lattice + Clone> ValuePolicy<V> for Join {
-    fn combine(l: Option<&V>, r: Option<&V>) -> Option<V> {
-        if let Some(lv) = l {
-            if let Some(rv) = r {
+    fn combine_impl<'a>(l: Option<Cow<'a, V>>, r: Option<Cow<'a, V>>) -> Option<Cow<'a, V>> {
+        if let Some(ref lv) = l {
+            if let Some(ref rv) = r {
                 match lv.pjoin(rv) {
                     AlgebraicResult::None => None,
                     AlgebraicResult::Identity(mask) => {
                         if mask & SELF_IDENT != 0 {
-                            l.cloned()
+                            l
                         } else {
-                            r.cloned()
+                            r
                         }
                     }
-                    AlgebraicResult::Element(v) => Some(v),
+                    AlgebraicResult::Element(v) => Some(Cow::Owned(v)),
                 }
             } else {
-                l.cloned()
+                l
             }
         } else {
-            r.cloned()
-        }
-    }
-
-    fn combine_acc(l: Option<V>, r: Option<&V>) -> Option<V> {
-        if let Some(lv) = l {
-            if let Some(rv) = r {
-                match lv.pjoin(rv) {
-                    AlgebraicResult::None => None,
-                    AlgebraicResult::Identity(mask) => {
-                        if mask & SELF_IDENT != 0 {
-                            Some(lv)
-                        } else {
-                            r.cloned()
-                        }
-                    }
-                    AlgebraicResult::Element(v) => Some(v),
-                }
-            } else {
-                Some(lv)
-            }
-        } else {
-            r.cloned()
+            r
         }
     }
 }
@@ -1580,62 +1577,68 @@ impl<V: Clone + Send + Sync> MergePolicy<V> for Meet {
 }
 
 impl<V: Lattice + Clone> ValuePolicy<V> for Meet {
-    fn combine(l: Option<&V>, r: Option<&V>) -> Option<V> {
-        l.and_then(|lv| r.and_then(|rv| meet_refs(lv, rv)))
+    #[inline]
+    fn combine_impl<'a>(l: Option<Cow<'a, V>>, r: Option<Cow<'a, V>>) -> Option<Cow<'a, V>> {
+        l.and_then(|lv| r.and_then(|rv| meet_impl(lv, rv)))
     }
 
     fn combine3(l: Option<&V>, m: Option<&V>, r: Option<&V>) -> Option<V> {
-        l.and_then(|x| m.and_then(|y| r.and_then(|z| meet_acc(meet_refs(x, y)?, z))))
+        l.and_then(|x| {
+            m.and_then(|y| {
+                r.and_then(|z| {
+                    unlift(meet_impl(
+                        meet_impl(Cow::Borrowed(x), Cow::Borrowed(y))?,
+                        Cow::Borrowed(z),
+                    ))
+                })
+            })
+        })
     }
 
     fn combine4(a: Option<&V>, b: Option<&V>, c: Option<&V>, d: Option<&V>) -> Option<V> {
         a.and_then(|w| {
             b.and_then(|x| {
-                c.and_then(|y| d.and_then(|z| meet_acc(meet_acc(meet_refs(w, x)?, y)?, z)))
+                c.and_then(|y| {
+                    d.and_then(|z| {
+                        unlift(meet_impl(
+                            meet_impl(
+                                meet_impl(Cow::Borrowed(w), Cow::Borrowed(x))?,
+                                Cow::Borrowed(y),
+                            )?,
+                            Cow::Borrowed(z),
+                        ))
+                    })
+                })
             })
         })
     }
 
     fn combine_n<'a, I>(vals: I) -> Option<V>
     where
-        I: Iterator<Item = Option<&'a V>>,
+        I: Iterator<Item = Option<Cow<'a, V>>>,
         V: 'a,
     {
         let mut it = vals;
-        let z = it.next()?.cloned()?;
-        it.try_fold(z, |acc, v| {
+        let z = it.next()??;
+        unlift(it.try_fold(z, |acc, v| {
             let rv = v?;
-            meet_acc(acc, rv)
-        })
+            meet_impl(acc, rv)
+        }))
     }
 }
 
 #[inline]
-fn meet_refs<V: Lattice + Clone>(a: &V, b: &V) -> Option<V> {
-    match a.pmeet(b) {
-        AlgebraicResult::None => None,
-        AlgebraicResult::Identity(mask) => {
-            if mask & SELF_IDENT != 0 {
-                Some(a.clone())
-            } else {
-                Some(b.clone())
-            }
-        }
-        AlgebraicResult::Element(v) => Some(v),
-    }
-}
-#[inline]
-fn meet_acc<V: Lattice + Clone>(a: V, b: &V) -> Option<V> {
-    match a.pmeet(b) {
+fn meet_impl<'a, V: Lattice + Clone>(a: Cow<'a, V>, b: Cow<'a, V>) -> Option<Cow<'a, V>> {
+    match a.pmeet(&b) {
         AlgebraicResult::None => None,
         AlgebraicResult::Identity(mask) => {
             if mask & SELF_IDENT != 0 {
                 Some(a)
             } else {
-                Some(b.clone())
+                Some(b)
             }
         }
-        AlgebraicResult::Element(v) => Some(v),
+        AlgebraicResult::Element(v) => Some(Cow::Owned(v)),
     }
 }
 
@@ -1690,59 +1693,37 @@ impl<V: Clone + Send + Sync> MergePolicy<V> for Subtract {
 }
 
 impl<V: DistributiveLattice + Clone> ValuePolicy<V> for Subtract {
-    fn combine(l: Option<&V>, r: Option<&V>) -> Option<V> {
+    fn combine_impl<'a>(l: Option<Cow<'a, V>>, r: Option<Cow<'a, V>>) -> Option<Cow<'a, V>> {
         l.and_then(|lv| {
             if let Some(rv) = r {
-                subtract_refs(lv, rv)
-            } else {
-                // lhs-only → keep
-                Some(lv.clone())
-            }
-        })
-    }
-
-    fn combine_n<'a, I>(vals: I) -> Option<V>
-    where
-        I: Iterator<Item = Option<&'a V>>,
-        V: 'a,
-    {
-        let mut it = vals;
-        let z = it.next()?.cloned()?;
-        it.try_fold(z, |acc, v| match v {
-            Some(rv) => subtract_acc(acc, rv),
-            None => Some(acc),
-        })
-    }
-
-    fn combine_acc(l: Option<V>, r: Option<&V>) -> Option<V> {
-        l.and_then(|lv| {
-            if let Some(rv) = r {
-                subtract_acc(lv, rv)
+                subtract_impl(lv, rv)
             } else {
                 // lhs-only → keep
                 Some(lv)
             }
         })
     }
+
+    fn combine_n<'a, I>(vals: I) -> Option<V>
+    where
+        I: Iterator<Item = Option<Cow<'a, V>>>,
+        V: 'a,
+    {
+        let mut it = vals;
+        let z = it.next()??;
+        unlift(it.try_fold(z, |acc, v| match v {
+            Some(rv) => subtract_impl(acc, rv),
+            None => Some(acc),
+        }))
+    }
 }
 
 #[inline]
-fn subtract_refs<V: DistributiveLattice + Clone>(a: &V, b: &V) -> Option<V> {
-    match a.psubtract(b) {
-        AlgebraicResult::None => None,
-        AlgebraicResult::Identity(mask) => {
-            if mask & SELF_IDENT != 0 {
-                Some(a.clone())
-            } else {
-                None
-            }
-        }
-        AlgebraicResult::Element(v) => Some(v),
-    }
-}
-#[inline]
-fn subtract_acc<V: DistributiveLattice>(a: V, b: &V) -> Option<V> {
-    match a.psubtract(b) {
+fn subtract_impl<'a, V: DistributiveLattice + Clone>(
+    a: Cow<'a, V>,
+    b: Cow<'a, V>,
+) -> Option<Cow<'a, V>> {
+    match a.psubtract(&b) {
         AlgebraicResult::None => None,
         AlgebraicResult::Identity(mask) => {
             if mask & SELF_IDENT != 0 {
@@ -1751,7 +1732,7 @@ fn subtract_acc<V: DistributiveLattice>(a: V, b: &V) -> Option<V> {
                 None
             }
         }
-        AlgebraicResult::Element(v) => Some(v),
+        AlgebraicResult::Element(v) => Some(Cow::Owned(v)),
     }
 }
 

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -1180,6 +1180,35 @@ where
     zipper_merge_n_mono::<Subtract, _, _, _, _, _>(zs, (1 << N) - 1, out);
 }
 
+// small micro-helpers
+#[inline(always)]
+fn for_each_bit(mut bits: u64, mut f: impl FnMut(usize)) {
+    while bits != 0 {
+        let i = bits.trailing_zeros() as usize;
+        bits &= bits - 1;
+        f(i);
+    }
+}
+
+#[inline]
+fn active_bits<const N: usize>(active: u64) -> impl Iterator<Item = usize> {
+    (0..N).filter(move |i| (active >> i) & 1 != 0)
+}
+
+fn only_active<'a, T, const N: usize>(
+    ts: &'a [T; N],
+    active: u64,
+) -> impl Iterator<Item = (usize, &'a T)> {
+    active_bits::<N>(active).map(|i| (i, &ts[i]))
+}
+
+#[inline(always)]
+fn first_active_mut<T, const N: usize>(ts: &mut [T; N], active: u64) -> &mut T {
+    debug_assert_ne!(active, 0);
+    let i0 = active.trailing_zeros() as usize;
+    &mut ts[i0]
+}
+
 // - The function is fully monomorphized over `Z` and `N` and uses a bitmask (`active`)
 //   to track participating zippers.
 // - Small frontiers (`k ≤ 4`) are dispatched to specialized implementations
@@ -1197,18 +1226,6 @@ where
     // LLVM needs to prove: `0 ≤ i < N` But i comes from: `i = bits.trailing_zeros() as usize;`` So the
     // compiler must connect: “this bitmask only contains bits < N”
     assert!(active >> N == 0);
-
-    #[inline]
-    fn active_bits<const N: usize>(active: u64) -> impl Iterator<Item = usize> {
-        (0..N).filter(move |i| (active >> i) & 1 != 0)
-    }
-
-    fn only_active<'a, T, const N: usize>(
-        ts: &'a [T; N],
-        active: u64,
-    ) -> impl Iterator<Item = (usize, &'a T)> {
-        active_bits::<N>(active).map(|i| (i, &ts[i]))
-    }
 
     fn values<'a, V, Z, const N: usize>(
         zs: &'a [Z; N],
@@ -1229,23 +1246,6 @@ where
         match iter.next() {
             Some(Some(first)) => iter.all(|next| next.is_some_and(|snid| snid == first)),
             _ => false,
-        }
-    }
-
-    // small micro-helpers
-    #[inline(always)]
-    fn first_active<T, const N: usize>(ts: &mut [T; N], active: u64) -> &mut T {
-        debug_assert_ne!(active, 0);
-        let i0 = active.trailing_zeros() as usize;
-        &mut ts[i0]
-    }
-
-    #[inline(always)]
-    fn for_each_bit(mut bits: u64, mut f: impl FnMut(usize)) {
-        while bits != 0 {
-            let i = bits.trailing_zeros() as usize;
-            bits &= bits - 1;
-            f(i);
         }
     }
 
@@ -1280,7 +1280,7 @@ where
 
     // check for node-sharing first
     if all_active_share(zs, active) {
-        P::on_id(first_active(zs, active), out);
+        P::on_id(first_active_mut(zs, active), out);
         return;
     }
 
@@ -1370,7 +1370,7 @@ where
 
                         // check structural sharing first
                         if all_active_share(zs, active) {
-                            P::on_id(first_active(zs, active), out);
+                            P::on_id(first_active_mut(zs, active), out);
 
                             for_each_bit(active, |i| {
                                 zs[i].ascend_byte();
@@ -1475,7 +1475,7 @@ where
         if (k == 0) {
             break 'ascend;
         }
-        let byte_from = *first_active(zs, active)
+        let byte_from = *first_active_mut(zs, active)
             .path()
             .last()
             .expect("non-empty path when k > 0");
@@ -1491,6 +1491,212 @@ where
         out.ascend_byte();
         k -= 1;
     }
+}
+
+fn zipper_merge_dnf<V, Z, Out, A, const M: usize>(clauses: &mut [&mut [Z]; M], out: &mut Out)
+where
+    V: Lattice + Clone + Send + Sync + Unpin,
+    A: Allocator,
+    Z: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
+    Out: ZipperWriting<V, A>,
+{
+    #[inline(always)]
+    fn clause_mask<Z>(zs: &[Z]) -> ByteMask
+    where
+        Z: Zipper,
+    {
+        if zs.is_empty() {
+            return ByteMask::EMPTY;
+        };
+        zs.iter()
+            .try_fold(ByteMask::FULL, |mut mask, z| {
+                mask &= z.child_mask();
+                if mask.is_empty_mask() {
+                    None
+                } else {
+                    Some(mask)
+                }
+            })
+            .unwrap_or(ByteMask::EMPTY)
+    }
+
+    #[inline(always)]
+    fn clause_value<V, Z>(zs: &[Z]) -> Option<V>
+    where
+        V: Lattice + Clone,
+        Z: ZipperValues<V>,
+    {
+        Meet::combine_n(zs.iter().map(|z| lift(z.val())))
+    }
+
+    fn active_clauses_value<V, Z, const M: usize>(clauses: &[&mut [Z]; M], active: u64) -> Option<V>
+    where
+        V: Lattice + Clone,
+        Z: ZipperValues<V>,
+    {
+        Join::combine_n(
+            only_active(clauses, active).map(|(_, zs)| clause_value(zs).map(Cow::Owned)),
+        )
+    }
+
+    #[inline(always)]
+    fn compute_masks<Z, const M: usize>(
+        clauses: &[&mut [Z]; M],
+        active: u64,
+        clause_masks: &mut [ByteMask; M],
+    ) -> ByteMask
+    where
+        Z: Zipper,
+    {
+        let mut global = ByteMask::EMPTY;
+
+        for (i, zs) in only_active(clauses, active) {
+            let m = clause_mask(zs);
+
+            clause_masks[i] = m;
+            global |= m;
+        }
+
+        global
+    }
+
+    fn zipper_merge_dnf_branch<V, Z, Out, A, const M: usize>(
+        clauses: &mut [&mut [Z]; M],
+        active: u64,
+        out: &mut Out,
+    ) where
+        V: Lattice + Clone + Send + Sync + Unpin,
+        A: Allocator,
+        Z: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
+        Out: ZipperWriting<V, A>,
+    {
+        assert!(active >> M == 0);
+
+        // check for singleton
+        if active.count_ones() == 1 {
+            let single_clause = first_active_mut(clauses, active);
+            match single_clause {
+                [z0] => {
+                    Meet::on_id(z0, out);
+                    return;
+                }
+                [z0, z1] => {
+                    zipper_meet(z0, z1, out);
+                    return;
+                }
+                [z0, z1, z2] => {
+                    zipper_meet3(z0, z1, z2, out);
+                    return;
+                }
+                [z0, z1, z2, z3] => {
+                    zipper_merge4::<Meet, V, Z, Z, Z, Z, Out, A>(z0, z1, z2, z3, out);
+                    return;
+                }
+                _ => {} // do nothing special
+            }
+        }
+
+        let mut clause_masks = [ByteMask::EMPTY; M];
+        let mut depth = 0;
+
+        // -------------------------------------------------
+        // Emit values
+        // -------------------------------------------------
+
+        if let Some(v) = active_clauses_value(clauses, active) {
+            out.set_val(v);
+        }
+        // -------------------------------------------------
+        // Compute clause masks
+        // -------------------------------------------------
+
+        let mut global = compute_masks(clauses, active, &mut clause_masks);
+        let mut next = global.indexed_bit::<true>(0);
+        'descend: loop {
+            // -------------------------------------------------
+            // Iterate global frontier
+            // -------------------------------------------------
+            while let Some(byte) = next {
+                out.descend_to_byte(byte);
+
+                let mut sub_active = 0u64;
+
+                // descend participating clauses
+                for_each_bit(active, |i| {
+                    if clause_masks[i].test_bit(byte) {
+                        sub_active |= 1 << i;
+
+                        for z in clauses[i].iter_mut() {
+                            z.descend_to_byte(byte);
+                        }
+                    }
+                });
+
+                // -------------------------------------------------
+                // Tail-descent fast path
+                // -------------------------------------------------
+
+                if sub_active == active {
+                    depth += 1;
+
+                    if let Some(v) = active_clauses_value(clauses, active) {
+                        out.set_val(v);
+                    }
+
+                    global = compute_masks(clauses, active, &mut clause_masks);
+                    next = global.indexed_bit::<true>(0);
+                    continue 'descend;
+                }
+
+                // -------------------------------------------------
+                // Branching recursion
+                // -------------------------------------------------
+
+                zipper_merge_dnf_branch(clauses, sub_active, out);
+
+                // ascend
+                for_each_bit(sub_active, |i| {
+                    for z in clauses[i].iter_mut() {
+                        z.ascend_byte();
+                    }
+                });
+
+                out.ascend_byte();
+
+                next = global.next_bit(byte);
+            }
+
+            // -------------------------------------------------
+            // Ascend iterative spine
+            // -------------------------------------------------
+            if depth == 0 {
+                break;
+            }
+
+            let byte_from = first_active_mut(clauses, active)
+                .first()
+                .and_then(|z| z.path().last().copied())
+                .expect("non-empty path at depth > 0");
+
+            for_each_bit(active, |i| {
+                for z in clauses[i].iter_mut() {
+                    z.ascend_byte();
+                }
+            });
+
+            out.ascend_byte();
+
+            depth -= 1;
+
+            // recompute masks after ascent
+            global = compute_masks(clauses, active, &mut clause_masks);
+            // resume sibling traversal
+            next = global.next_bit(byte_from);
+        }
+    }
+
+    debug_assert!(M > 0 && M <= 64);
+    zipper_merge_dnf_branch(clauses, ((1 << M) - 1), out);
 }
 
 // ==================== JOIN ====================
@@ -2084,6 +2290,7 @@ mod tests {
             ZipperWriting,
         },
     };
+    use std::borrow::Borrow;
 
     type Paths = &'static [(&'static [u8], u64)];
     type BinaryTest = (Paths, Paths);
@@ -2130,7 +2337,7 @@ mod tests {
 
         op(&mut lhs, &mut rhs, &mut out);
 
-        assert_trie(expected, result);
+        assert_trie(expected.into_iter().copied(), result);
     }
 
     fn check3<
@@ -2158,7 +2365,7 @@ mod tests {
 
         op(&mut lhs, &mut mid, &mut rhs, &mut out);
 
-        assert_trie(expected, result);
+        assert_trie(expected.into_iter().copied(), result);
     }
 
     fn checkn<
@@ -2179,10 +2386,10 @@ mod tests {
             result.write_zipper(),
         );
 
-        assert_trie(expected, result);
+        assert_trie(expected.into_iter().copied(), result);
     }
 
-    fn assert_trie<'a, T: IntoIterator<Item = &'a (&'a [u8], u64)>>(
+    fn assert_trie<T: IntoIterator<Item = (P, u64)>, P: Borrow<[u8]>>(
         expected: T,
         result: PathMap<u64>,
     ) {
@@ -2190,17 +2397,19 @@ mod tests {
 
         for (expected_path, expected_val) in expected {
             assert!(
-                result.path_exists_at(expected_path),
-                "Path {expected_path:#?} does NOT exist in {result:#?}"
+                result.path_exists_at(expected_path.borrow()),
+                "Path {:#?} does NOT exist in {result:#?}",
+                expected_path.borrow()
             );
-            let actual_val = result.get_val_at(expected_path);
+            let actual_val = result.get_val_at(expected_path.borrow()).copied();
             assert_eq!(
                 actual_val,
                 Some(expected_val),
-                "Value at {expected_path:#?}"
+                "Value at {:#?}",
+                expected_path.borrow()
             );
 
-            result_copy.remove_val_at(expected_path, true);
+            result_copy.remove_val_at(expected_path.borrow(), true);
         }
 
         assert!(
@@ -3606,7 +3815,7 @@ mod tests {
             (&[0b11, 0b0111], 11),
             (&[0b11, 0b1111], 12),
         ];
-        assert_trie(expected0, result0);
+        assert_trie(expected0.iter().copied(), result0);
 
         fn prefixed<V: Clone + Send + Sync + Unpin, Z: ZipperInfallibleSubtries<V>>(
             rz: &Z,
@@ -3637,7 +3846,7 @@ mod tests {
             (&[0b0, 0b01, 0b0111], 7),
             (&[0b0, 0b01, 0b1111], 8),
         ];
-        assert_trie(expected1, result1);
+        assert_trie(expected1.iter().copied(), result1);
 
         let mut map3 = prefixed(&mut r5, &[0]);
         let mut map4 = prefixed(&mut r6, &[1]);
@@ -3663,6 +3872,114 @@ mod tests {
             (&[0b1, 0b00, 0b0111], 3),
             (&[0b1, 0b00, 0b1111], 4),
         ];
-        assert_trie(expected2, result2);
+        assert_trie(expected2.iter().copied(), result2);
+    }
+
+    mod dnf {
+        use crate::experimental::zipper_algebra::{zipper_join3, zipper_meet3, zipper_merge_dnf};
+
+        use super::*;
+
+        const SMALL_TRIE_1: Paths = &[(&[0, 1, 2], 1), (&[0, 1, 3], 2)];
+        const SMALL_TRIE_2: Paths = &[(&[0, 1], 1), (&[0, 2], 2), (&[3], 3), (&[2, 3], 4)];
+        const SMALL_TRIE_3: Paths = &[(&[0, 1, 2], 1), (&[0, 1, 3], 2), (&[0, 1, 4], 3)];
+
+        #[test]
+        fn test_single_clause_multiple_zippers() {
+            let mut trie1 = PathMap::from_iter(SMALL_TRIE_1);
+            let mut trie2 = PathMap::from_iter(SMALL_TRIE_2);
+            let mut trie3 = PathMap::from_iter(SMALL_TRIE_3);
+
+            let mut z1 = trie1.read_zipper();
+            let mut z2 = trie2.read_zipper();
+            let mut z3 = trie3.read_zipper();
+
+            let mut result = PathMap::new();
+            let mut out = result.write_zipper();
+            zipper_merge_dnf(&mut [&mut [&mut z1, &mut z2, &mut z3]], &mut out);
+
+            let mut expected = PathMap::new();
+            {
+                z1.reset();
+                z2.reset();
+                z3.reset();
+                zipper_meet3(&mut z1, &mut z2, &mut z3, &mut expected.write_zipper());
+            }
+
+            assert_trie(expected, result);
+        }
+
+        #[test]
+        fn test_multiple_singleton_clauses() {
+            let mut trie1 = PathMap::from_iter(SMALL_TRIE_1);
+            let mut trie2 = PathMap::from_iter(SMALL_TRIE_2);
+            let mut trie3 = PathMap::from_iter(SMALL_TRIE_3);
+
+            let mut z1 = trie1.read_zipper();
+            let mut z2 = trie2.read_zipper();
+            let mut z3 = trie3.read_zipper();
+
+            let mut result = PathMap::new();
+            let mut out = result.write_zipper();
+            zipper_merge_dnf(
+                &mut [&mut [&mut z1], &mut [&mut z2], &mut [&mut z3]],
+                &mut out,
+            );
+
+            let mut expected = PathMap::new();
+            {
+                z1.reset();
+                z2.reset();
+                z3.reset();
+                zipper_join3(&mut z1, &mut z2, &mut z3, &mut expected.write_zipper());
+            }
+
+            assert_trie(expected, result);
+        }
+
+        #[test]
+        fn test_partial_overlap_1() {
+            let mut trie1 = PathMap::from_iter(SMALL_TRIE_1);
+            let mut trie2 = PathMap::from_iter(SMALL_TRIE_2);
+            let mut trie3 = PathMap::from_iter(SMALL_TRIE_3);
+
+            let mut z2 = trie2.read_zipper();
+            let mut z3 = trie3.read_zipper();
+
+            let mut result = PathMap::new();
+            let mut out = result.write_zipper();
+            zipper_merge_dnf(
+                &mut [
+                    &mut [&mut trie1.read_zipper(), &mut z2],
+                    &mut [&mut trie1.read_zipper(), &mut z3],
+                ],
+                &mut out,
+            );
+            let expected = trie1.meet(&trie2.join(&trie3));
+            assert_trie(expected, result);
+        }
+
+        #[test]
+        fn test_partial_overlap_2() {
+            let mut trie1 = PathMap::from_iter(SMALL_TRIE_1);
+            let mut trie2 = PathMap::from_iter(SMALL_TRIE_2);
+            let mut trie3 = PathMap::from_iter(SMALL_TRIE_3);
+
+            let mut z1 = trie1.read_zipper();
+            let mut z2 = trie2.read_zipper();
+            let mut z3 = trie3.read_zipper();
+
+            let mut result = PathMap::new();
+            let mut out = result.write_zipper();
+            zipper_merge_dnf(
+                &mut [
+                    &mut [&mut z1, &mut trie2.read_zipper()],
+                    &mut [&mut trie2.read_zipper(), &mut z3],
+                ],
+                &mut out,
+            );
+            let expected = trie2.meet(&trie1.join(&trie3));
+            assert_trie(expected, result);
+        }
     }
 }

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -1493,7 +1493,7 @@ where
     }
 }
 
-fn zipper_merge_dnf<V, Z, Out, A, const M: usize>(clauses: &mut [&mut [Z]; M], out: &mut Out)
+pub fn zipper_merge_dnf<V, Z, Out, A, const M: usize>(clauses: &mut [&mut [Z]; M], out: &mut Out)
 where
     V: Lattice + Clone + Send + Sync + Unpin,
     A: Allocator,

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -1485,7 +1485,7 @@ impl<V: Clone + Send + Sync> MergePolicy<V> for Join {
         Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
         Out: ZipperWriting<V, A>,
     {
-        out.graft_children(z, range);
+        out.graft_masked_branches(z, range, false)
     }
 
     #[inline]
@@ -1500,7 +1500,7 @@ impl<V: Clone + Send + Sync> MergePolicy<V> for Join {
         Z: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
         Out: ZipperWriting<V, A>,
     {
-        out.graft_children(z, ByteMask::FULL);
+        out.graft_masked_branches(z, ByteMask::FULL, false)
     }
 }
 
@@ -1575,7 +1575,7 @@ impl<V: Clone + Send + Sync> MergePolicy<V> for Meet {
         Z: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
         Out: ZipperWriting<V, A>,
     {
-        out.graft_children(z, ByteMask::FULL);
+        out.graft_masked_branches(z, ByteMask::FULL, false);
     }
 }
 
@@ -1650,7 +1650,7 @@ impl<V: Clone + Send + Sync> MergePolicy<V> for Subtract {
         Z: ZipperInfallibleSubtries<V, A> + ZipperMoving,
         Out: ZipperWriting<V, A>,
     {
-        out.graft_children(z, range);
+        out.graft_masked_branches(z, range, false);
     }
 
     #[inline]
@@ -1670,7 +1670,7 @@ impl<V: Clone + Send + Sync> MergePolicy<V> for Subtract {
         Out: ZipperWriting<V, A>,
     {
         if mask == 1 {
-            out.graft_children(z, range);
+            out.graft_masked_branches(z, range, false)
         }
     }
 

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -98,6 +98,16 @@ impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperAlgebraExt<V, A>
 {
 }
 
+impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperAlgebraExt<V, A>
+    for ReadZipperOwned<V, A>
+{
+}
+
+impl<Z, V: Clone + Send + Sync + Unpin, A: Allocator> ZipperAlgebraExt<V, A> for PrefixZipper<'_, Z> where
+    Z: ZipperInfallibleSubtries<V, A> + ZipperSubtries<V, A> + ZipperConcrete + ZipperMoving
+{
+}
+
 /// Performs an ordered join (least upper bound) of two radix-256 tries using zipper traversal.
 ///
 /// This function merges two tries by simultaneously traversing them in lexicographic order,
@@ -1760,6 +1770,8 @@ mod zipper_algebra_poly {
     pub(super) enum SomeMutRefZ<'a, 'trie, 'path, V: Clone + Send + Sync + Unpin, A: Allocator> {
         RZ(&'a mut ReadZipperUntracked<'trie, 'path, V, A>),
         RZT(&'a mut ReadZipperTracked<'trie, 'path, V, A>),
+        PZRZ(&'a mut PrefixZipper<'a, ReadZipperUntracked<'trie, 'path, V, A>>),
+        PZRZT(&'a mut PrefixZipper<'a, ReadZipperTracked<'trie, 'path, V, A>>),
     }
 
     impl<V: Clone + Send + Sync + Unpin, A: Allocator> ZipperInfallibleSubtries<V, A>
@@ -1769,6 +1781,8 @@ mod zipper_algebra_poly {
             match self {
                 SomeMutRefZ::RZ(inner) => inner.make_map(),
                 SomeMutRefZ::RZT(inner) => inner.make_map(),
+                SomeMutRefZ::PZRZ(inner) => inner.make_map(),
+                SomeMutRefZ::PZRZT(inner) => inner.make_map(),
             }
         }
 
@@ -1776,6 +1790,8 @@ mod zipper_algebra_poly {
             match self {
                 SomeMutRefZ::RZ(inner) => inner.get_trie_ref(),
                 SomeMutRefZ::RZT(inner) => inner.get_trie_ref(),
+                SomeMutRefZ::PZRZ(inner) => inner.get_trie_ref(),
+                SomeMutRefZ::PZRZT(inner) => inner.get_trie_ref(),
             }
         }
 
@@ -1783,6 +1799,8 @@ mod zipper_algebra_poly {
             match self {
                 SomeMutRefZ::RZ(inner) => inner.get_focus(),
                 SomeMutRefZ::RZT(inner) => inner.get_focus(),
+                SomeMutRefZ::PZRZ(inner) => inner.get_focus(),
+                SomeMutRefZ::PZRZT(inner) => inner.get_focus(),
             }
         }
 
@@ -1790,6 +1808,8 @@ mod zipper_algebra_poly {
             match self {
                 SomeMutRefZ::RZ(inner) => inner.get_focus_at(path),
                 SomeMutRefZ::RZT(inner) => inner.get_focus_at(path),
+                SomeMutRefZ::PZRZ(inner) => inner.get_focus_at(path),
+                SomeMutRefZ::PZRZT(inner) => inner.get_focus_at(path),
             }
         }
 
@@ -1797,6 +1817,8 @@ mod zipper_algebra_poly {
             match self {
                 SomeMutRefZ::RZ(inner) => inner.try_borrow_focus(),
                 SomeMutRefZ::RZT(inner) => inner.try_borrow_focus(),
+                SomeMutRefZ::PZRZ(inner) => inner.try_borrow_focus(),
+                SomeMutRefZ::PZRZT(inner) => inner.try_borrow_focus(),
             }
         }
     }

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -1572,7 +1572,9 @@ where
     {
         assert!(active >> M == 0);
 
-        // check for singleton
+        // -------------------------------------------------
+        // Single clause fast path
+        // -------------------------------------------------
         if active.count_ones() == 1 {
             let single_clause = first_active_mut(clauses, active);
             match single_clause {
@@ -1725,7 +1727,10 @@ impl<V: Clone + Send + Sync> MergePolicy<V> for Join {
         Z: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
         Out: ZipperWriting<V, A>,
     {
-        out.graft_masked_branches(z, ByteMask::FULL, false)
+        if let Some(v) = z.val() {
+            out.set_val(v.clone());
+        }
+        out.graft(z);
     }
 }
 
@@ -1778,7 +1783,10 @@ impl<V: Clone + Send + Sync> MergePolicy<V> for Meet {
         Z: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
         Out: ZipperWriting<V, A>,
     {
-        out.graft_masked_branches(z, ByteMask::FULL, false);
+        if let Some(v) = z.val() {
+            out.set_val(v.clone());
+        }
+        out.graft(z);
     }
 }
 

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -400,6 +400,9 @@ trait ValuePolicy<V: Clone> {
     {
         unlift(vals.fold(None, |acc, v| Self::combine_impl(acc, v)))
     }
+    fn combine_n_times(val: Option<Cow<V>>, n: usize) -> Option<V> {
+        Self::combine_n(std::iter::repeat_n(val, n))
+    }
 }
 
 fn zipper_merge<P, V, ZL, ZR, Out, A>(lhs: &mut ZL, rhs: &mut ZR, out: &mut Out)
@@ -421,6 +424,9 @@ where
     }
     // check for node-sharing first
     if check_sharing(lhs, rhs) {
+        if let Some(v) = P::combine_n_times(lift(lhs.val()), 2) {
+            out.set_val(v);
+        }
         P::on_id(lhs, out);
         return;
     }
@@ -467,6 +473,9 @@ where
                         // optimization - if both zippers share the node after descend, we can skip
                         // further descend and continue merging
                         if check_sharing(lhs, rhs) {
+                            if let Some(v) = P::combine_n_times(lift(lhs.val()), 2) {
+                                out.set_val(v);
+                            }
                             P::on_id(lhs, out);
 
                             rhs.ascend_byte();
@@ -592,6 +601,9 @@ where
 
     // check for node-sharing first
     if all_share(lhs, mid, rhs) {
+        if let Some(v) = P::combine_n_times(lift(lhs.val()), 3) {
+            out.set_val(v);
+        }
         P::on_id(lhs, out);
         return;
     }
@@ -694,6 +706,9 @@ where
 
                         //structural sharing check
                         if all_share(lhs, mid, rhs) {
+                            if let Some(v) = P::combine_n_times(lift(lhs.val()), 3) {
+                                out.set_val(v);
+                            }
                             P::on_id(lhs, out);
 
                             rhs.ascend_byte();
@@ -793,6 +808,9 @@ fn zipper_merge4<P, V, Z0, Z1, Z2, Z3, Out, A>(
 
     // check for node-sharing first
     if all_share(z0, z1, z2, z3) {
+        if let Some(v) = P::combine_n_times(lift(z0.val()), 4) {
+            out.set_val(v);
+        }
         P::on_id(z0, out);
         return;
     }
@@ -852,6 +870,9 @@ fn zipper_merge4<P, V, Z0, Z1, Z2, Z3, Out, A>(
 
                     // check structural sharing
                     if all_share(z0, z1, z2, z3) {
+                        if let Some(v) = P::combine_n_times(lift(z0.val()), 4) {
+                            out.set_val(v);
+                        }
                         P::on_id(z0, out);
 
                         z3.ascend_byte();
@@ -1280,7 +1301,11 @@ where
 
     // check for node-sharing first
     if all_active_share(zs, active) {
-        P::on_id(first_active_mut(zs, active), out);
+        let z0 = first_active_mut(zs, active);
+        if let Some(v) = P::combine_n_times(lift(z0.val()), active.count_ones() as usize) {
+            out.set_val(v);
+        }
+        P::on_id(z0, out);
         return;
     }
 
@@ -1370,7 +1395,13 @@ where
 
                         // check structural sharing first
                         if all_active_share(zs, active) {
-                            P::on_id(first_active_mut(zs, active), out);
+                            let z0 = first_active_mut(zs, active);
+                            if let Some(v) =
+                                P::combine_n_times(lift(z0.val()), active.count_ones() as usize)
+                            {
+                                out.set_val(v);
+                            }
+                            P::on_id(z0, out);
 
                             for_each_bit(active, |i| {
                                 zs[i].ascend_byte();
@@ -1727,9 +1758,6 @@ impl<V: Clone + Send + Sync> MergePolicy<V> for Join {
         Z: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
         Out: ZipperWriting<V, A>,
     {
-        if let Some(v) = z.val() {
-            out.set_val(v.clone());
-        }
         out.graft(z);
     }
 }
@@ -1755,6 +1783,10 @@ impl<V: Lattice + Clone> ValuePolicy<V> for Join {
         } else {
             r
         }
+    }
+    fn combine_n_times(val: Option<Cow<V>>, n: usize) -> Option<V> {
+        // join is idempotent
+        unlift(val)
     }
 }
 
@@ -1783,9 +1815,6 @@ impl<V: Clone + Send + Sync> MergePolicy<V> for Meet {
         Z: ZipperInfallibleSubtries<V, A> + ZipperConcrete + ZipperMoving,
         Out: ZipperWriting<V, A>,
     {
-        if let Some(v) = z.val() {
-            out.set_val(v.clone());
-        }
         out.graft(z);
     }
 }
@@ -1838,6 +1867,11 @@ impl<V: Lattice + Clone> ValuePolicy<V> for Meet {
             let rv = v?;
             meet_impl(acc, rv)
         }))
+    }
+
+    fn combine_n_times(val: Option<Cow<V>>, n: usize) -> Option<V> {
+        // meet is idempotent
+        unlift(val)
     }
 }
 
@@ -1929,6 +1963,10 @@ impl<V: DistributiveLattice + Clone> ValuePolicy<V> for Subtract {
             Some(rv) => subtract_impl(acc, rv),
             None => Some(acc),
         }))
+    }
+
+    fn combine_n_times(_val: Option<Cow<V>>, _n: usize) -> Option<V> {
+        None
     }
 }
 

--- a/src/write_zipper.rs
+++ b/src/write_zipper.rs
@@ -139,12 +139,6 @@ pub trait ZipperWriting<V: Clone + Send + Sync, A: Allocator = GlobalAlloc>: Wri
         }
     }
 
-    /// Deprecated alias for [graft_masked_branches](ZipperWriting::graft_masked_branches)
-    #[deprecated]
-    fn graft_children<Z: ZipperInfallibleSubtries<V, A>>(&mut self, src: &Z, child_mask: ByteMask) {
-        self.graft_masked_branches(src, child_mask, false)
-    }
-
     /// Joins (union of) the subtrie below the focus of `read_zipper` into the subtrie downstream from the
     /// focus of `self`
     ///


### PR DESCRIPTION
This PR introduces a DNF-based zipper merge engine capable of evaluating expressions of the form:

```text
(z11 ∧ z12 ∧ ...)
∨ ...
∨
(zn1 ∧ zn2 ∧ ...)
```

where each conjunctive clause is evaluated as an intersection (`Meet`) of zipper frontiers, and the resulting clauses are combined using union (`Join`).

The implementation extends the existing zipper merge framework while preserving:

* iterative traversal on unanimous descent paths,
* bounded recursion on branching points only,
* structural locality of zipper state,
* and zero-allocation traversal state.

---

## Representation

The new interface operates on clauses:

```rust
fn zipper_merge_dnf<
    V,
    Z,
    Out,
    A,
    const M: usize,
>(
    clauses: &mut [&mut [Z]; M],
    out: &mut Out,
)
```

Each clause represents a conjunction of zippers:

```text
[
    [A, B],
    [A, C],
]
=
(A ∧ B) ∨ (A ∧ C)
```

Clause lengths are dynamic while the number of clauses (`M`) remains const-generic for efficient mask-based dispatch.

---

## Traversal strategy

At each node:

1. Clause masks are computed as intersections of child masks:

```text
clause_mask = ∧ child_masks
```

2. A global frontier is formed as the union of clause masks:

```text
global = ⋃ clause_masks
```

3. For each byte in the global frontier:

   * participating clauses are identified,
   * relevant zippers descend,
   * and evaluation continues recursively or iteratively.

---

## Iterative unanimous descent

A key optimization is the detection of unanimous clause continuation:

```rust
if sub_active == active
```

In this case:

* all currently active clauses descend together,
* recursion is avoided,
* and traversal continues iteratively.

This eliminates stack growth on long shared paths and restores the same “tail-descent spine” optimization used by the original mono merge engine.

---

## Recursion behavior

Recursion now occurs only on true branching points:

```text
sub_active ⊂ active
```

which bounds recursive depth by branching structure rather than trie depth.

---

## State model

Unlike the original zipper merge, DNF traversal introduces aggregate evaluator state:

```text
clause masks
global frontier
active clause sets
```

Rather than storing this state explicitly across descent, the implementation recomputes it after ascent from zipper positions.

This keeps traversal state lightweight while relying on inexpensive bitmask recomputation.

---

## Performance notes

The implementation preserves several optimizer-friendly properties:

* `M` is const-generic,
* active clause sets are represented as bitmasks,
* stack allocations are compile-time sized,
* unanimous descent avoids recursive overhead,
* and traversal state remains primarily encoded in zipper positions.

The hot path is dominated by compact bitmask operations and zipper movement rather than evaluator bookkeeping.
