### PR TITLE
Add ACTOutputStream: build an ACT on disk from a stream of ordered paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,9 @@ harness = false
 
 [[bench]]
 name = "byte_mask"
+harness = false
+
+[[bench]]
 name = "zipper_head_owned"
 harness = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,11 @@ harness = false
 name = "zipper_head_owned"
 harness = false
 
+[[bench]]
+name = "act_paths"
+harness = false
+required-features = ["arena_compact", "serialization"]
+
 [workspace]
 members = ["pathmap-derive", "examples/sampling", "examples/arena_compact_tests"]
 resolver = "2"

--- a/benches/act_paths.rs
+++ b/benches/act_paths.rs
@@ -1,0 +1,281 @@
+//! `PathMap` -> `.paths` -> `.act`.
+//!
+//! The pipeline of the `test_act_paths_round_trip` unit test, sized up:
+//! serialize a `PathMap` to `.paths`, then replay the paths into an
+//! [ACTOutputStream] to build an `.act` file without ever holding the trie in
+//! memory. `*_map_to_act_cata` builds the same file through the catamorphism
+//! instead, as a baseline for the streaming path; both write a `0` value per
+//! path so the two measure the same output.
+//!
+//! Three axes:
+//! - `size_*` holds the shape fixed and varies the number of paths, to see
+//!   whether any stage is worse than linear.
+//! - `shape_*` holds the number of paths fixed and varies the structure, from
+//!   a complete 4-ary trie to uniform random 16-byte paths. `inflate_only`
+//!   replays `.paths` without building anything, so the ACT build cost can be
+//!   separated from the cost of decompressing its input.
+//! - `round_trip` and `big_logic_paths_to_act` run the whole pipeline, the
+//!   latter on real data.
+//!
+//! Correctness is checked once per benchmark, outside the timed closure:
+//! `val_count` walks the whole trie, so it would swamp what is measured.
+//! Setting `ACT_BENCH_TABLE=1` prints path/`.paths`/`.act` sizes per shape
+//! before the run.
+
+use divan::{Bencher, Divan, counter::ItemsCount};
+use pathmap::PathMap;
+use pathmap::arena_compact::{ACTOutputStream, ArenaCompactTree};
+use pathmap::paths_serialization::{for_each_deserialized_path, serialize_paths};
+use pathmap::zipper::ZipperMoving;
+use rand::{Rng, SeedableRng, rngs::StdRng};
+use std::path::Path;
+
+const SIZES: &[usize] = &[25_000, 50_000, 100_000, 200_000, 400_000, 800_000];
+const SHAPES: &[Shape] = &[
+  Shape::DenseNarrow, Shape::DenseWide, Shape::Clustered,
+  Shape::SmallAlphabet, Shape::RandomLong,
+];
+const SHAPE_SIZE: usize = 200_000;
+/// The shape the `size_*` sweep uses, unless the bench name says otherwise
+const SIZE_SHAPE: Shape = Shape::RandomLong;
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+enum Shape {
+  /// Complete 4-ary trie: every branch node is full and the trie is as deep
+  /// as it can be for this path count
+  DenseNarrow,
+  /// 3-byte counters in lex order, i.e. fanout 256 at the top two levels
+  DenseWide,
+  /// Piecewise dense: random 8-byte prefixes, each carrying a dense block of
+  /// 2-byte suffixes
+  Clustered,
+  /// Random over 5 letters, length 1..12 (the round-trip test's shape) —
+  /// heavy prefix sharing, short paths. Only ~half the draws are distinct.
+  SmallAlphabet,
+  /// Uniform random 16-byte paths — almost no sharing below the first couple
+  /// of bytes, so nearly every path ends in a line node
+  RandomLong,
+}
+
+impl std::fmt::Display for Shape {
+  fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    f.pad(match self { // `pad`, not `write_str`: the size table aligns columns
+      Shape::DenseNarrow => "dense_narrow",
+      Shape::DenseWide => "dense_wide",
+      Shape::Clustered => "clustered",
+      Shape::SmallAlphabet => "small_alphabet",
+      Shape::RandomLong => "random_long",
+    })
+  }
+}
+
+/// Generates `n` paths of the requested shape, lazily: at the top sizes
+/// materializing them would cost more memory than the trie they build
+fn paths(shape: Shape, n: usize) -> Box<dyn Iterator<Item = Vec<u8>>> {
+  let mut rng = StdRng::seed_from_u64(0xAC7_0003);
+  match shape {
+    Shape::DenseNarrow => {
+      let depth = (n as f64).log(4.0).ceil() as u32;
+      Box::new((0..n).map(move |i| (0..depth).rev().map(|d| b"abcd"[(i >> (2 * d)) & 3]).collect()))
+    }
+    Shape::DenseWide =>
+      Box::new((0..n).map(|i| vec![(i >> 16) as u8, (i >> 8) as u8, i as u8])),
+    Shape::Clustered => {
+      let cluster = 100;
+      Box::new((0..n.div_ceil(cluster)).flat_map(move |_| {
+        let prefix: [u8; 8] = rng.random();
+        (0..cluster).map(move |j| {
+          let mut p = prefix.to_vec();
+          p.extend_from_slice(&[(j >> 8) as u8, j as u8]);
+          p
+        })
+      }).take(n))
+    }
+    Shape::SmallAlphabet => Box::new((0..n).map(move |_| {
+      let len = rng.random_range(1..12);
+      (0..len).map(|_| b"abcde"[rng.random_range(0..5)]).collect()
+    })),
+    Shape::RandomLong => Box::new((0..n).map(move |_| rng.random::<[u8; 16]>().to_vec())),
+  }
+}
+
+fn make_map(shape: Shape, n: usize) -> PathMap<u64> {
+  let mut map = PathMap::new();
+  for (idx, path) in paths(shape, n).enumerate() {
+    map.set_val_at(&path[..], idx as u64);
+  }
+  map
+}
+
+fn to_paths(map: &PathMap<u64>) -> Vec<u8> {
+  let mut data = Vec::new();
+  serialize_paths(map.read_zipper(), &mut data).expect("serialization error");
+  data
+}
+
+/// Replays `.paths` data into the `.act` file at `dst`, returning the number
+/// of paths written. The tree is dropped and the file rewritten on the next
+/// call, so only the write side is measured.
+fn paths_to_act(data: &[u8], dst: &Path) -> usize {
+  let mut out = ACTOutputStream::new(dst).expect("open error");
+  let stats = for_each_deserialized_path(data, |_idx, p| out.push(p))
+    .expect("deserialization error");
+  out.finish().expect("act write error");
+  stats.path_count
+}
+
+fn act_val_count(dst: &Path) -> usize {
+  ArenaCompactTree::open_mmap(dst).unwrap().read_zipper_u64().val_count()
+}
+
+fn big_logic_paths() -> Vec<u8> {
+  let data_dir = match std::env::var("BENCH_DATA_DIR") {
+    Ok(val) => std::path::PathBuf::from(val),
+    Err(_) => std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches"),
+  };
+  std::fs::read(data_dir.join("big_logic.metta.paths")).unwrap()
+}
+
+// ---- shared bench bodies --------------------------------------------------
+
+fn bench_map_to_paths(bencher: Bencher, map: PathMap<u64>) {
+  let expected = map.val_count();
+  let mut buf = Vec::with_capacity(1 << 22);
+  bencher.counter(ItemsCount::new(expected)).bench_local(|| {
+    buf.clear();
+    serialize_paths(map.read_zipper(), &mut buf).expect("serialization error").path_count
+  });
+}
+
+fn bench_paths_to_act(bencher: Bencher, map: PathMap<u64>) {
+  let expected = map.val_count();
+  let data = to_paths(&map);
+  let dir = tempfile::tempdir().unwrap();
+  let file = dir.path().join("bench.act");
+
+  assert_eq!(paths_to_act(&data, &file), expected);
+  assert_eq!(act_val_count(&file), expected);
+
+  bencher.counter(ItemsCount::new(expected)).bench_local(|| paths_to_act(&data, &file));
+}
+
+fn bench_map_to_act_cata(bencher: Bencher, map: PathMap<u64>) {
+  let expected = map.val_count();
+  let dir = tempfile::tempdir().unwrap();
+  let file = dir.path().join("bench_cata.act");
+
+  ArenaCompactTree::dump_from_zipper(map.read_zipper(), |_| 0, &file).expect("act write error");
+  assert_eq!(act_val_count(&file), expected);
+
+  bencher.counter(ItemsCount::new(expected)).bench_local(|| {
+    ArenaCompactTree::dump_from_zipper(map.read_zipper(), |_| 0, &file).expect("act write error")
+  });
+}
+
+// ---- number of paths, shape held fixed ------------------------------------
+
+#[divan::bench(args = SIZES)]
+fn size_map_to_paths(bencher: Bencher, n: usize) {
+  bench_map_to_paths(bencher, make_map(SIZE_SHAPE, n))
+}
+
+#[divan::bench(args = SIZES)]
+fn size_paths_to_act(bencher: Bencher, n: usize) {
+  bench_paths_to_act(bencher, make_map(SIZE_SHAPE, n))
+}
+
+#[divan::bench(args = SIZES)]
+fn size_map_to_act_cata(bencher: Bencher, n: usize) {
+  bench_map_to_act_cata(bencher, make_map(SIZE_SHAPE, n))
+}
+
+/// The dense counterpart of `size_paths_to_act`: whether the sweep stays
+/// linear should not depend on the shape
+#[divan::bench(args = SIZES)]
+fn size_dense_paths_to_act(bencher: Bencher, n: usize) {
+  bench_paths_to_act(bencher, make_map(Shape::DenseWide, n))
+}
+
+// ---- shape, number of paths held fixed ------------------------------------
+
+#[divan::bench(args = SHAPES)]
+fn shape_map_to_paths(bencher: Bencher, shape: Shape) {
+  bench_map_to_paths(bencher, make_map(shape, SHAPE_SIZE))
+}
+
+#[divan::bench(args = SHAPES)]
+fn shape_paths_to_act(bencher: Bencher, shape: Shape) {
+  bench_paths_to_act(bencher, make_map(shape, SHAPE_SIZE))
+}
+
+#[divan::bench(args = SHAPES)]
+fn shape_map_to_act_cata(bencher: Bencher, shape: Shape) {
+  bench_map_to_act_cata(bencher, make_map(shape, SHAPE_SIZE))
+}
+
+#[divan::bench(args = SHAPES)]
+fn shape_inflate_only(bencher: Bencher, shape: Shape) {
+  let map = make_map(shape, SHAPE_SIZE);
+  let data = to_paths(&map);
+  bencher.counter(ItemsCount::new(map.val_count())).bench_local(|| {
+    for_each_deserialized_path(&data[..], |_idx, p| { divan::black_box(p); Ok(()) })
+      .expect("deserialization error").path_count
+  });
+}
+
+// ---- the whole pipeline ---------------------------------------------------
+
+#[divan::bench]
+fn round_trip(bencher: Bencher) {
+  let map = make_map(Shape::SmallAlphabet, SHAPE_SIZE);
+  let expected = map.val_count();
+  let dir = tempfile::tempdir().unwrap();
+  let file = dir.path().join("round_trip.act");
+  bencher.counter(ItemsCount::new(expected)).bench_local(|| {
+    paths_to_act(&to_paths(&map), &file)
+  });
+  assert_eq!(act_val_count(&file), expected);
+}
+
+#[divan::bench]
+fn big_logic_paths_to_act(bencher: Bencher) {
+  let data = big_logic_paths();
+  let dir = tempfile::tempdir().unwrap();
+  let file = dir.path().join("big_logic.act");
+
+  let expected = paths_to_act(&data, &file);
+  assert_eq!(act_val_count(&file), expected);
+
+  bencher.counter(ItemsCount::new(expected)).bench_local(|| paths_to_act(&data, &file));
+}
+
+/// Path bytes in, `.paths` bytes and `.act` bytes out, per shape — context for
+/// the `shape_*` numbers. Skipped unless asked for: it costs a second of setup
+/// that a filtered run should not pay.
+fn print_size_table() {
+  println!("{:<15} {:>8} {:>12} {:>12} {:>12} {:>10}",
+    "shape", "paths", "path bytes", ".paths", ".act", "act/path");
+  let dir = tempfile::tempdir().unwrap();
+  for &shape in SHAPES {
+    let mut map = PathMap::new();
+    let mut path_bytes = 0;
+    for (idx, path) in paths(shape, SHAPE_SIZE).enumerate() {
+      path_bytes += path.len();
+      map.set_val_at(&path[..], idx as u64);
+    }
+    let data = to_paths(&map);
+    let file = dir.path().join(format!("{shape}.act"));
+    let count = paths_to_act(&data, &file);
+    let act_bytes = std::fs::metadata(&file).unwrap().len() as usize;
+    println!("{:<15} {:>8} {:>12} {:>12} {:>12} {:>10.2}",
+      shape, count, path_bytes, data.len(), act_bytes, act_bytes as f64 / count as f64);
+  }
+  println!();
+}
+
+fn main() {
+  if std::env::var_os("ACT_BENCH_TABLE").is_some() {
+    print_size_table();
+  }
+  Divan::from_args().sample_count(5).main();
+}

--- a/src/arena_compact.rs
+++ b/src/arena_compact.rs
@@ -1358,6 +1358,193 @@ impl ArenaCompactTree<Mmap> {
     }
 }
 
+/// A single in-construction trie node used by [ACTOutputStream]
+///
+/// One frame exists per byte of the most recently pushed path. A frame
+/// accumulates completed child subtrees (in ascending byte order, which the
+/// sorted input guarantees) until the input stream moves past it, at which
+/// point it is sealed and written to the arena.
+struct StreamFrame {
+    /// Bytes of the children attached so far
+    mask: ByteMask,
+    /// Completed child nodes, parallel to the set bits of `mask` (ascending)
+    children: Vec<Node>,
+    /// Value at this node, if the exact path was pushed
+    value: Option<u64>,
+}
+
+impl StreamFrame {
+    fn empty() -> Self {
+        StreamFrame {
+            mask: ByteMask::EMPTY,
+            children: Vec::new(),
+            value: None,
+        }
+    }
+
+    /// A frame with no children and no value is a pure pass-through and can
+    /// be folded into a line node instead of becoming a branch node
+    fn is_passthrough(&self) -> bool {
+        self.mask.is_empty_mask() && self.value.is_none()
+    }
+}
+
+/// Builds an [ArenaCompactTree] on disk from a stream of ordered paths.
+///
+/// Paths must be pushed in strictly increasing lexicographic (byte) order.
+/// Memory usage is bounded by the longest path pushed (plus the line-reuse
+/// cache), so this can build tries far larger than available RAM.
+///
+/// # Examples
+/// ```
+/// use pathmap::arena_compact::ACTOutputStream;
+/// # fn main() -> std::io::Result<()> {
+/// let dir = tempfile::tempdir()?;
+/// let file = dir.path().join("file.act");
+/// let mut b = ACTOutputStream::new(&file)?;
+/// b.push("123")?;
+/// b.push("124")?;
+/// let tree = b.finish()?;
+/// assert_eq!(tree.get_val_at("123"), Some(0));
+/// assert_eq!(tree.get_val_at("124"), Some(0));
+/// assert_eq!(tree.get_val_at("125"), None);
+/// # Ok(())
+/// # }
+/// ```
+pub struct ACTOutputStream {
+    act: ArenaCompactTree<FileDumper>,
+    /// `stack[d]` is the in-construction node at depth `d` along `prev_path`;
+    /// `stack[0]` is the root
+    stack: Vec<StreamFrame>,
+    /// The most recently pushed path
+    prev_path: Vec<u8>,
+    /// Number of paths pushed so far
+    count: u64,
+}
+
+impl ACTOutputStream {
+    /// Create (or truncate) the file at `path` and start streaming a trie into it
+    pub fn new(path: impl AsRef<Path>) -> Result<Self, std::io::Error> {
+        Ok(ACTOutputStream {
+            act: ArenaCompactTree::<FileDumper>::open(path)?,
+            stack: Vec::from([StreamFrame::empty()]),
+            prev_path: Vec::new(),
+            count: 0,
+        })
+    }
+
+    /// Add `path` to the trie with a value of `0`
+    ///
+    /// Paths must arrive in strictly increasing lexicographic order,
+    /// otherwise an [InvalidInput](std::io::ErrorKind::InvalidInput) error
+    /// is returned. A path that extends the previous one (e.g. `"ab"` after
+    /// `"a"`) is fine; both keep their values.
+    pub fn push(&mut self, path: impl AsRef<[u8]>) -> Result<(), std::io::Error> {
+        self.push_val(path, 0)
+    }
+
+    /// Add `path` to the trie with the given `value`
+    ///
+    /// See [push](Self::push) for the ordering requirements.
+    pub fn push_val(
+        &mut self, path: impl AsRef<[u8]>, value: u64,
+    ) -> Result<(), std::io::Error> {
+        let path = path.as_ref();
+        if self.count > 0 && path <= &self.prev_path[..] {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "paths must be pushed in strictly increasing order",
+            ));
+        }
+        let common = find_prefix_overlap(path, &self.prev_path);
+        self.collapse_to(common)?;
+        for _ in common..path.len() {
+            self.stack.push(StreamFrame::empty());
+        }
+        self.stack.last_mut().unwrap().value = Some(value);
+        self.prev_path.truncate(common);
+        self.prev_path.extend_from_slice(&path[common..]);
+        self.count += 1;
+        Ok(())
+    }
+
+    /// Seal every frame deeper than `target`, writing completed subtrees to
+    /// the arena and attaching them as children of the frame at `target`
+    fn collapse_to(&mut self, target: usize) -> Result<(), std::io::Error> {
+        while self.stack.len() - 1 > target {
+            let top = self.stack.len() - 1;
+            let frame = self.stack.pop().unwrap();
+            let node = self.seal(frame)?;
+            // Fold pure pass-through ancestors into a line segment
+            while self.stack.len() - 1 > target
+                && self.stack.last().unwrap().is_passthrough()
+            {
+                self.stack.pop();
+            }
+            let start = self.stack.len() - 1;
+            // `prev_path[start]` goes into the parent's mask; if the chain is
+            // longer, the remaining bytes become line data
+            let node = if top - start >= 2 {
+                let mut line = NodeLine::empty();
+                line.path = self.act.add_path(&self.prev_path[start + 1..top])?;
+                match node {
+                    Node::Branch(branch) if branch.bytemask.is_empty_mask() => {
+                        line.value = branch.value;
+                    }
+                    node => {
+                        line.child = Some(self.act.push(&node)?);
+                    }
+                }
+                Node::Line(line)
+            } else {
+                node
+            };
+            let parent = self.stack.last_mut().unwrap();
+            parent.mask.set_bit(self.prev_path[start]);
+            parent.children.push(node);
+        }
+        Ok(())
+    }
+
+    /// Write `frame`'s children to the arena (contiguously, so that
+    /// `first_child` suffices to address them) and return the branch node
+    fn seal(&mut self, frame: StreamFrame) -> Result<Node, std::io::Error> {
+        let mut first_child: Option<NodeId> = None;
+        for child in frame.children.iter() {
+            let id = self.act.push(child)?;
+            first_child = first_child.or(Some(id));
+        }
+        Ok(Node::Branch(NodeBranch {
+            bytemask: frame.mask,
+            first_child,
+            value: frame.value,
+        }))
+    }
+
+    /// Seal the remaining frames, write the root, and flush to disk
+    ///
+    /// Returns the finished tree, memory-mapped from the written file.
+    pub fn finish(mut self) -> Result<ArenaCompactTree<Mmap>, std::io::Error> {
+        self.collapse_to(0)?;
+        let root_frame = self.stack.pop().unwrap();
+        let root = self.seal(root_frame)?;
+        self.act.set_root(&root)?;
+        self.act.finalize()?;
+        let ArenaCompactTree { storage, counters, .. } = self.act;
+        let file = storage.buf_writer.into_inner()?;
+        let memmap = unsafe { Mmap::map(&file) }?;
+        Ok(ArenaCompactTree {
+            position: memmap.as_ref().len() as u64,
+            storage: memmap,
+            line_map: Default::default(),
+            lines: Default::default(),
+            hasher: Default::default(),
+            value: Cell::new(0),
+            counters,
+        })
+    }
+}
+
 /// A merged subtree: either an existing node reused as-is, or a freshly
 /// built node (whose descendants have already been appended).
 enum Merged {
@@ -2956,6 +3143,102 @@ mod tests {
                 assert!(pair[0].0 > pair[1].0, "roots must be newest-first: {history:?}");
             }
         }
+    }
+
+    #[test]
+    fn test_act_output_stream() -> Result<(), std::io::Error> {
+        use super::ACTOutputStream;
+        use crate::zipper::ZipperReadOnlyValues;
+        let mut paths = PATHS.to_vec();
+        paths.sort();
+
+        let dir = tempfile::tempdir()?;
+        let file = dir.path().join("stream.act");
+        let mut out = ACTOutputStream::new(&file)?;
+        for (idx, path) in paths.iter().enumerate() {
+            out.push_val(path, idx as u64)?;
+        }
+        let tree = out.finish()?;
+        for (idx, path) in paths.iter().enumerate() {
+            assert_eq!(tree.get_val_at(path), Some(idx as u64));
+        }
+        assert_eq!(tree.get_val_at("arr"), None);
+        assert_eq!(tree.get_val_at("arrows"), None);
+
+        // The streamed tree must enumerate the same paths/values as one
+        // built through the catamorphism
+        let btm = PathMap::from_iter(
+            paths.iter().enumerate().map(|(idx, path)| (path, idx as u64)));
+        let act = ArenaCompactTree::from_zipper(btm.read_zipper(), |&v| v);
+        let mut cata_zipper = act.read_zipper_u64();
+        let mut stream_zipper = tree.read_zipper_u64();
+        loop {
+            let cata_next = cata_zipper.to_next_val();
+            let stream_next = stream_zipper.to_next_val();
+            assert_eq!(cata_next, stream_next);
+            assert_eq!(cata_zipper.path(), stream_zipper.path());
+            assert_eq!(cata_zipper.get_val(), stream_zipper.get_val());
+            if !cata_next {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_act_output_stream_prefixes() -> Result<(), std::io::Error> {
+        use super::ACTOutputStream;
+        let dir = tempfile::tempdir()?;
+        let file = dir.path().join("prefixes.act");
+        let mut out = ACTOutputStream::new(&file)?;
+        // Empty path, paths extending previous ones, and a long chain
+        let paths: &[&str] = &["", "a", "ab", "abc", "abcdefgh", "b"];
+        for (idx, path) in paths.iter().enumerate() {
+            out.push_val(path, idx as u64)?;
+        }
+        let tree = out.finish()?;
+        for (idx, path) in paths.iter().enumerate() {
+            assert_eq!(tree.get_val_at(path), Some(idx as u64), "path={path:?}");
+        }
+        assert_eq!(tree.get_val_at("abcd"), None);
+        assert_eq!(tree.get_val_at("ba"), None);
+        Ok(())
+    }
+
+    #[test]
+    fn test_act_output_stream_wide_branch() -> Result<(), std::io::Error> {
+        use super::ACTOutputStream;
+        let dir = tempfile::tempdir()?;
+        let file = dir.path().join("wide.act");
+        let mut out = ACTOutputStream::new(&file)?;
+        // 256 children at the root exercises the child-mask encoding
+        for byte in 0..=255_u8 {
+            out.push_val([byte], byte as u64)?;
+        }
+        let tree = out.finish()?;
+        for byte in 0..=255_u8 {
+            assert_eq!(tree.get_val_at([byte]), Some(byte as u64));
+        }
+        assert_eq!(tree.get_val_at([0, 0]), None);
+        Ok(())
+    }
+
+    #[test]
+    fn test_act_output_stream_rejects_unordered() -> Result<(), std::io::Error> {
+        use super::ACTOutputStream;
+        let dir = tempfile::tempdir()?;
+        let file = dir.path().join("unordered.act");
+        let mut out = ACTOutputStream::new(&file)?;
+        out.push("bcd")?;
+        assert!(out.push("bcd").is_err(), "duplicates must be rejected");
+        assert!(out.push("abc").is_err(), "out-of-order must be rejected");
+        assert!(out.push("b").is_err(), "prefix of previous is out-of-order");
+        out.push("bce")?;
+        let tree = out.finish()?;
+        assert_eq!(tree.get_val_at("bcd"), Some(0));
+        assert_eq!(tree.get_val_at("bce"), Some(0));
+        assert_eq!(tree.get_val_at("abc"), None);
+        Ok(())
     }
 
     #[test]

--- a/src/arena_compact.rs
+++ b/src/arena_compact.rs
@@ -1545,6 +1545,12 @@ impl ACTOutputStream {
     }
 }
 
+#[cfg(feature="nightly")]
+#[path="arena_compact_nightly.rs"]
+mod arena_compact_nightly;
+#[cfg(feature="nightly")]
+pub use arena_compact_nightly::*;
+
 /// A merged subtree: either an existing node reused as-is, or a freshly
 /// built node (whose descendants have already been appended).
 enum Merged {
@@ -3265,6 +3271,111 @@ mod tests {
             format!("('{path}' {val:?} {bm:?}\n{children})")
         });
         assert_eq!(btm_value, act_value);
+        Ok(())
+    }
+
+    /// A deterministic pseudo-random `PathMap`
+    ///
+    /// The small alphabet and short paths make prefixes collide heavily, so
+    /// the trie mixes branch nodes, line nodes, and values on interior paths.
+    /// Paths are never empty: `.paths` carries no root value, so an empty path
+    /// would show up as a round-trip difference that says nothing about ACT.
+    #[cfg(any(feature = "serialization", feature = "nightly"))]
+    fn random_pathmap(seed: u64, count: usize) -> PathMap<u64> {
+        use rand::{Rng, SeedableRng, rngs::StdRng};
+        const ALPHABET: &[u8] = b"abcde";
+        let mut rng = StdRng::seed_from_u64(seed);
+        let mut map = PathMap::new();
+        for idx in 0..count {
+            let len = rng.random_range(1..12);
+            let path: Vec<u8> = (0..len)
+                .map(|_| ALPHABET[rng.random_range(0..ALPHABET.len())]).collect();
+            map.set_val_at(&path[..], idx as u64);
+        }
+        map
+    }
+
+    /// Asserts that `tree` holds exactly the paths and values of `map`
+    #[cfg(any(feature = "serialization", feature = "nightly"))]
+    fn assert_act_matches_map(map: &PathMap<u64>, tree: &ArenaCompactTree<super::Mmap>) {
+        let mut map_zipper = map.read_zipper();
+        let mut act_zipper = tree.read_zipper_u64();
+        loop {
+            let map_next = map_zipper.to_next_val();
+            assert_eq!(map_next, act_zipper.to_next_val());
+            assert_eq!(map_zipper.path(), act_zipper.path());
+            assert_eq!(map_zipper.val().copied(), act_zipper.val().copied());
+            if !map_next { break }
+        }
+    }
+
+    /// `PathMap` -> `.paths` -> `.act`, checking the tree that comes out the
+    /// far end against the map that went in
+    #[cfg(all(feature = "serialization", not(miri)))] // miri really hates the zlib-ng-sys C API
+    #[test]
+    fn test_act_paths_round_trip() -> Result<(), std::io::Error> {
+        use super::ACTOutputStream;
+        use crate::paths_serialization::{for_each_deserialized_path, serialize_paths_with_auxdata};
+
+        let map = random_pathmap(0xAC7_0001, 5000);
+
+        // `.paths` stores no values, so the aux-data callback collects them on
+        // the side, indexed by the order the paths were written in
+        let mut paths_data = Vec::new();
+        let mut values = Vec::new();
+        let ser = serialize_paths_with_auxdata(
+            map.read_zipper(), &mut paths_data,
+            |idx, _path, val: &u64| { assert_eq!(values.len(), idx); values.push(*val) })?;
+        assert_eq!(ser.path_count, map.val_count());
+
+        // The deserializer replays paths in the order the zipper produced
+        // them, i.e. strictly increasing, which is exactly what the streaming
+        // ACT builder requires
+        let dir = tempfile::tempdir()?;
+        let file = dir.path().join("round_trip.act");
+        let mut out = ACTOutputStream::new(&file)?;
+        let de = for_each_deserialized_path(
+            &paths_data[..], |idx, path| out.push_val(path, values[idx]))?;
+        let tree = out.finish()?;
+        assert_eq!(de.path_count, ser.path_count);
+
+        assert_act_matches_map(&map, &tree);
+        Ok(())
+    }
+
+    /// The same build, driven through [act_serialization_sink_with_vals]
+    ///
+    /// The producer owns its paths, which is what the sink's resume type
+    /// requires: one lifetime is fixed for every path the coroutine is fed.
+    #[cfg(feature = "nightly")]
+    #[test]
+    fn test_act_serialization_sink() -> Result<(), std::io::Error> {
+        use std::ops::{Coroutine, CoroutineState};
+        use std::pin::pin;
+        use super::{ACTOutputStream, act_serialization_sink_with_vals};
+
+        let map = random_pathmap(0xAC7_0002, 5000);
+        let mut items: Vec<(Vec<u8>, u64)> = Vec::with_capacity(map.val_count());
+        let mut zipper = map.read_zipper();
+        while zipper.to_next_val() {
+            items.push((zipper.path().to_vec(), *zipper.val().unwrap()));
+        }
+
+        let dir = tempfile::tempdir()?;
+        let file = dir.path().join("sink.act");
+        let mut sink = pin!(act_serialization_sink_with_vals(ACTOutputStream::new(&file)?));
+        for (path, val) in items.iter() {
+            match sink.as_mut().resume(Some((&path[..], *val))) {
+                CoroutineState::Yielded(()) => {}
+                CoroutineState::Complete(res) => { res?; panic!("sink ended early") }
+            }
+        }
+        let tree = match sink.as_mut().resume(None) {
+            CoroutineState::Complete(res) => res?,
+            CoroutineState::Yielded(()) => panic!("`None` must end the stream"),
+        };
+
+        assert_act_matches_map(&map, &tree);
         Ok(())
     }
 }

--- a/src/arena_compact_nightly.rs
+++ b/src/arena_compact_nightly.rs
@@ -1,0 +1,85 @@
+use super::*;
+
+/// The shared body of the sinks below: resume with an item to push it, resume
+/// with `None` to seal the trie and return it
+fn act_sink<T>(
+    mut out: ACTOutputStream,
+    mut push: impl FnMut(&mut ACTOutputStream, T) -> std::io::Result<()>,
+) -> impl std::ops::Coroutine<
+    Option<T>,
+    Yield = (),
+    Return = std::io::Result<ArenaCompactTree<Mmap>>,
+> {
+    #[coroutine] move |mut i: Option<T>| {
+        while let Some(item) = i {
+            push(&mut out, item)?;
+            i = yield ();
+        }
+        out.finish()
+    }
+}
+
+/// Returns a coroutine to incrementally build an `.act` file from pushed paths
+///
+/// This is the push-driven counterpart to [ACTOutputStream::push]: instead of
+/// the caller driving a loop, the sink is resumed with one path at a time,
+/// which suits producers that are themselves loops or coroutines.
+///
+/// Paths must arrive in strictly increasing lexicographic order (see
+/// [ACTOutputStream::push]) and every path gets a value of `0`. Passing `None`
+/// signals the end of input; the coroutine then seals the trie and returns it,
+/// memory-mapped from the written file.
+///
+/// The resume type fixes a single lifetime for every path the sink is fed, so
+/// the producer must own its paths — a borrowed scratch buffer refilled per
+/// path will not type-check.
+///
+/// # Examples
+/// ```
+/// #![feature(coroutines, coroutine_trait)]
+/// use std::ops::{Coroutine, CoroutineState};
+/// use std::pin::pin;
+/// use pathmap::arena_compact::{ACTOutputStream, act_serialization_sink};
+/// # fn main() -> std::io::Result<()> {
+/// let dir = tempfile::tempdir()?;
+/// let out = ACTOutputStream::new(dir.path().join("sink.act"))?;
+/// let mut sink = pin!(act_serialization_sink(out));
+/// for path in [b"123".as_slice(), b"124".as_slice()] {
+///     match sink.as_mut().resume(Some(path)) {
+///         CoroutineState::Yielded(()) => {}
+///         CoroutineState::Complete(r) => { r?; unreachable!("ended early") }
+///     }
+/// }
+/// let tree = match sink.as_mut().resume(None) {
+///     CoroutineState::Complete(r) => r?,
+///     CoroutineState::Yielded(()) => unreachable!("`None` ends the stream"),
+/// };
+/// assert_eq!(tree.get_val_at("123"), Some(0));
+/// assert_eq!(tree.get_val_at("125"), None);
+/// # Ok(())
+/// # }
+/// ```
+pub fn act_serialization_sink<'p>(
+    out: ACTOutputStream,
+) -> impl std::ops::Coroutine<
+    Option<&'p [u8]>,
+    Yield = (),
+    Return = std::io::Result<ArenaCompactTree<Mmap>>,
+> {
+    act_sink(out, |out: &mut ACTOutputStream, p: &'p [u8]| out.push(p))
+}
+
+/// Returns a coroutine to incrementally build an `.act` file from pushed
+/// `(path, value)` pairs
+///
+/// See [act_serialization_sink], which this mirrors; the only difference is
+/// that each path carries a value instead of defaulting to `0`.
+pub fn act_serialization_sink_with_vals<'p>(
+    out: ACTOutputStream,
+) -> impl std::ops::Coroutine<
+    Option<(&'p [u8], u64)>,
+    Yield = (),
+    Return = std::io::Result<ArenaCompactTree<Mmap>>,
+> {
+    act_sink(out, |out: &mut ACTOutputStream, (p, v): (&'p [u8], u64)| out.push_val(p, v))
+}


### PR DESCRIPTION
Streams strictly-increasing paths into an on-disk ArenaCompactTree without holding the trie in memory: a stack of in-construction frames (one per byte of the current path) is sealed bottom-up whenever the input diverges, writing each node's children contiguously as the format requires and folding non-branching runs into line nodes. Reuses the existing FileDumper writer, including line-data dedup.
```
    let mut b = ACTOutputStream::new("file.act")?;
    b.push("123")?;
    b.push_val("124", 42)?;
    let tree = b.finish()?;  // mmap-backed ArenaCompactTree
```

Also fixes a pre-existing out-of-bounds walk in get_val_at: it never checked the branch bytemask before index_of/nth_node, so looking up a byte absent from a branch with children stepped past the last sibling into unrelated arena bytes (subtract-overflow panic in debug builds).