### PR TITLE
Line list node graft fixes

### DIFF
--- a/src/line_list_node.rs
+++ b/src/line_list_node.rs
@@ -1762,47 +1762,43 @@ impl<V: Clone + Send + Sync, A: Allocator> TrieNode<V, A> for LineListNode<V, A>
         //Removing a value is one of the ways a node can be left holding two onward children
         // under one key, so check the node over on the way out
         let result = (|| {
-        if self.is_used_value_0() {
-            let node_key_0 = unsafe{ self.key_unchecked::<0>() };
-            if node_key_0 == key {
-                if prune {
-                    return Some(self.take_payload::<0>().unwrap().into_val())
-                } else {
-                    //If the other slot already keeps this path, then just remove the value
-                    let node_key_1 = unsafe{ self.key_unchecked::<1>() };
-                    let overlap = find_prefix_overlap(node_key_0, node_key_1);
-                    if node_key_0.len() == overlap {
+            if self.is_used_value_0() {
+                let node_key_0 = unsafe{ self.key_unchecked::<0>() };
+                if node_key_0 == key {
+                    if prune {
                         return Some(self.take_payload::<0>().unwrap().into_val())
                     } else {
-                        //Otherwise, turn the value into an empty node
-                        return Some(self.swap_payload::<0>(ValOrChild::Child(TrieNodeODRc::new_empty())).into_val())
+                        //If the other slot already keeps this path, then just remove the value
+                        let node_key_1 = unsafe{ self.key_unchecked::<1>() };
+                        let overlap = find_prefix_overlap(node_key_0, node_key_1);
+                        if node_key_0.len() == overlap {
+                            return Some(self.take_payload::<0>().unwrap().into_val())
+                        } else {
+                            //Otherwise, turn the value into an empty node
+                            return Some(self.swap_payload::<0>(ValOrChild::Child(TrieNodeODRc::new_empty())).into_val())
+                        }
                     }
                 }
             }
-        }
-        if self.is_used_value_1() {
-            let node_key_1 = unsafe{ self.key_unchecked::<1>() };
-            if node_key_1 == key {
-                if prune {
-                    return Some(self.take_payload::<1>().unwrap().into_val())
-                } else {
-                    //If the other slot already keeps this path, then just remove the value.
-                    // Leaving a sentinel here would give the node two onward children under
-                    // the same key, which is ambiguous: `node_get_child` would resolve the
-                    // byte to slot_0 while `next_items` resolves it to the empty sentinel in
-                    // slot_1, and iteration would walk into nothing.
-                    let node_key_0 = unsafe{ self.key_unchecked::<0>() };
-                    let overlap = find_prefix_overlap(node_key_1, node_key_0);
-                    if node_key_1.len() == overlap {
+            if self.is_used_value_1() {
+                let node_key_1 = unsafe{ self.key_unchecked::<1>() };
+                if node_key_1 == key {
+                    if prune {
                         return Some(self.take_payload::<1>().unwrap().into_val())
                     } else {
-                        //Otherwise, turn the value into an empty node
-                        return Some(self.swap_payload::<1>(ValOrChild::Child(TrieNodeODRc::new_empty())).into_val())
+                        //If the other slot already keeps this path, then remove the value
+                        let node_key_0 = unsafe{ self.key_unchecked::<0>() };
+                        let overlap = find_prefix_overlap(node_key_1, node_key_0);
+                        if node_key_1.len() == overlap {
+                            return Some(self.take_payload::<1>().unwrap().into_val())
+                        } else {
+                            //Otherwise, turn the value into an empty node
+                            return Some(self.swap_payload::<1>(ValOrChild::Child(TrieNodeODRc::new_empty())).into_val())
+                        }
                     }
                 }
             }
-        }
-        None
+            None
         })();
         debug_assert!(validate_node(self));
         result
@@ -2082,19 +2078,14 @@ impl<V: Clone + Send + Sync, A: Allocator> TrieNode<V, A> for LineListNode<V, A>
                             return (Some(key0[key.len()]), None)
                         }
                     }
-                    //Both slots hold the same key, which happens when one of them holds the value
-                    // at that key and the other holds the onward child.  The byte is the same either
-                    // way, but the child can be in either slot, so check both before giving up on it
-                    // (`node_get_child` does the same).
-                    if key.len() + 1 == key0.len() {
-                        if self.is_child_ptr::<0>() {
-                            return (Some(key0[key.len()]), unsafe{ Some(self.child_in_slot::<0>().as_tagged()) })
-                        }
-                        if self.is_child_ptr::<1>() {
-                            return (Some(key0[key.len()]), unsafe{ Some(self.child_in_slot::<1>().as_tagged()) })
-                        }
+                    //If we get here, we know both slots hold the same single-byte key, which means one of them holds
+                    // a value and the other holds the onward child.  So we have to check both
+                    if self.is_child_ptr::<0>() {
+                        return (Some(key0[key.len()]), unsafe{ Some(self.child_in_slot::<0>().as_tagged()) })
                     }
-                    return (Some(key0[key.len()]), None)
+                    if self.is_child_ptr::<1>() {
+                        return (Some(key0[key.len()]), unsafe{ Some(self.child_in_slot::<1>().as_tagged()) })
+                    }
                 }
                 if starts_with(key1, key) && key1.len() > key.len() {
                     if key.len() + 1 == key1.len() && self.is_child_ptr::<1>() {

--- a/src/line_list_node.rs
+++ b/src/line_list_node.rs
@@ -1759,6 +1759,9 @@ impl<V: Clone + Send + Sync, A: Allocator> TrieNode<V, A> for LineListNode<V, A>
         })
     }
     fn node_remove_val(&mut self, key: &[u8], prune: bool) -> Option<V> {
+        //Removing a value is one of the ways a node can be left holding two onward children
+        // under one key, so check the node over on the way out
+        let result = (|| {
         if self.is_used_value_0() {
             let node_key_0 = unsafe{ self.key_unchecked::<0>() };
             if node_key_0 == key {
@@ -1783,12 +1786,26 @@ impl<V: Clone + Send + Sync, A: Allocator> TrieNode<V, A> for LineListNode<V, A>
                 if prune {
                     return Some(self.take_payload::<1>().unwrap().into_val())
                 } else {
-                    //Turn the value into an empty node
-                    return Some(self.swap_payload::<1>(ValOrChild::Child(TrieNodeODRc::new_empty())).into_val())
+                    //If the other slot already keeps this path, then just remove the value.
+                    // Leaving a sentinel here would give the node two onward children under
+                    // the same key, which is ambiguous: `node_get_child` would resolve the
+                    // byte to slot_0 while `next_items` resolves it to the empty sentinel in
+                    // slot_1, and iteration would walk into nothing.
+                    let node_key_0 = unsafe{ self.key_unchecked::<0>() };
+                    let overlap = find_prefix_overlap(node_key_1, node_key_0);
+                    if node_key_1.len() == overlap {
+                        return Some(self.take_payload::<1>().unwrap().into_val())
+                    } else {
+                        //Otherwise, turn the value into an empty node
+                        return Some(self.swap_payload::<1>(ValOrChild::Child(TrieNodeODRc::new_empty())).into_val())
+                    }
                 }
             }
         }
         None
+        })();
+        debug_assert!(validate_node(self));
+        result
     }
 
     #[inline]
@@ -2775,6 +2792,14 @@ pub(crate) fn validate_node<V: Clone + Send + Sync, A: Allocator>(node: &LineLis
         panic!()
     }
 
+    //Two slots may share a key (that is how a value and the onward child at the same path are
+    // stored) but only one of them may be the onward child, otherwise the byte leads to two
+    // different subtries and every accessor is free to pick a different one
+    if node.is_used_child_0() && node.is_used_child_1() && key0 == key1 {
+        println!("Invalid node - two onward children under the same key. {node:?}");
+        panic!()
+    }
+
     //The keys may never have more than one prefix byte in common
     if key0.get(0) == key1.get(0) && key0.get(1) == key1.get(1) && key0.get(1).is_some() {
         println!("Invalid node - duplicated prefix too long. {node:?}");
@@ -3377,13 +3402,16 @@ mod tests {
         use crate::PathMap;
         use crate::zipper::{ZipperMoving, ZipperValues, ZipperWriting, Zipper};
 
-        // Grafting builds the shape: "a" ends up with a value and children
-        let leaf = PathMap::from_iter([("", 9u64), ("x", 1)]);
+        // Grafting puts the child in slot 0; the value added afterwards lands
+        // in slot 1 under the same key.  (Insertion alone builds the mirror
+        // image, which is the arrangement the buggy code expected.)
+        let leaf = PathMap::from_iter([("x", 1u64)]);
         let mut map = PathMap::<u64>::new();
-        for prefix in [b"a".as_slice(), b"aa"] {
-            let mut wz = map.write_zipper_at_path(prefix);
+        {
+            let mut wz = map.write_zipper_at_path(b"a");
             wz.graft(&leaf.read_zipper());
         }
+        map.set_val_at(b"a", 9);
 
         let mut by_index = map.read_zipper();
         assert!(by_index.descend_indexed_byte(0));
@@ -3392,7 +3420,7 @@ mod tests {
 
         assert_eq!(by_index.path(), by_path.path());
         assert_eq!(by_index.val(), Some(&9));
-        assert_eq!(by_path.child_count(), 2, "\"a\" has children 'a' and 'x'");
+        assert_eq!(by_path.child_count(), 1, "\"a\" has the child 'x'");
         assert_eq!(by_index.child_count(), by_path.child_count());
         assert_eq!(by_index.child_mask(), by_path.child_mask());
     }

--- a/src/line_list_node.rs
+++ b/src/line_list_node.rs
@@ -2065,6 +2065,19 @@ impl<V: Clone + Send + Sync, A: Allocator> TrieNode<V, A> for LineListNode<V, A>
                             return (Some(key0[key.len()]), None)
                         }
                     }
+                    //Both slots hold the same key, which happens when one of them holds the value
+                    // at that key and the other holds the onward child.  The byte is the same either
+                    // way, but the child can be in either slot, so check both before giving up on it
+                    // (`node_get_child` does the same).
+                    if key.len() + 1 == key0.len() {
+                        if self.is_child_ptr::<0>() {
+                            return (Some(key0[key.len()]), unsafe{ Some(self.child_in_slot::<0>().as_tagged()) })
+                        }
+                        if self.is_child_ptr::<1>() {
+                            return (Some(key0[key.len()]), unsafe{ Some(self.child_in_slot::<1>().as_tagged()) })
+                        }
+                    }
+                    return (Some(key0[key.len()]), None)
                 }
                 if starts_with(key1, key) && key1.len() > key.len() {
                     if key.len() + 1 == key1.len() && self.is_child_ptr::<1>() {
@@ -3353,6 +3366,36 @@ mod tests {
         assert_eq!(inner_node.as_tagged().node_get_val(b"anana"), Some(&1));
     }
 
+    /// Regression test: a value and the onward child at the same path are kept
+    /// in the two slots of one node, both under the same key.  In that shape
+    /// `nth_child_from_key` used to look for the child in slot 1 only, and so
+    /// reported "no child node" whenever the child sat in slot 0.  A zipper
+    /// that descended by index then left its focus in the parent node, and
+    /// reported the position as having no children at all.
+    #[test]
+    fn test_nth_child_from_key_val_and_child_share_key() {
+        use crate::PathMap;
+        use crate::zipper::{ZipperMoving, ZipperValues, ZipperWriting, Zipper};
+
+        // Grafting builds the shape: "a" ends up with a value and children
+        let leaf = PathMap::from_iter([("", 9u64), ("x", 1)]);
+        let mut map = PathMap::<u64>::new();
+        for prefix in [b"a".as_slice(), b"aa"] {
+            let mut wz = map.write_zipper_at_path(prefix);
+            wz.graft(&leaf.read_zipper());
+        }
+
+        let mut by_index = map.read_zipper();
+        assert!(by_index.descend_indexed_byte(0));
+        let mut by_path = map.read_zipper();
+        by_path.descend_to(b"a");
+
+        assert_eq!(by_index.path(), by_path.path());
+        assert_eq!(by_index.val(), Some(&9));
+        assert_eq!(by_path.child_count(), 2, "\"a\" has children 'a' and 'x'");
+        assert_eq!(by_index.child_count(), by_path.child_count());
+        assert_eq!(by_index.child_mask(), by_path.child_mask());
+    }
 }
 
 //GOAT, merge wrappers for lattice impls on primitives

--- a/src/write_zipper.rs
+++ b/src/write_zipper.rs
@@ -2826,6 +2826,92 @@ mod tests {
     use crate::trie_node::*;
     use crate::alloc::GlobalAlloc;
 
+    /// Removing a value that shares its key with the onward child must not
+    /// leave a path-preserving sentinel behind: the node would then hold two
+    /// onward children under one key, and the accessors disagree about which
+    /// one the byte leads to.  `node_get_child` picks the real subtrie (so
+    /// `get_val_at`, `descend_to` and `val_count` stay right) while
+    /// `next_items` picks the empty sentinel, so every stepping traversal
+    /// walks into nothing and reports the map as empty.
+    ///
+    /// Grafting is what puts the child in slot 0 and the value in slot 1;
+    /// built by insertion the two are the other way around, which took the
+    /// branch that already had this check.
+    #[test]
+    fn write_zipper_remove_val_beside_child_test() {
+        let leaf: PathMap<u64> = PathMap::from_iter([("x", 1u64)]);
+        let mut map = PathMap::<u64>::new();
+        {
+            let mut wz = map.write_zipper_at_path(b"a");
+            wz.graft(&leaf.read_zipper());  //the child at "a" goes to slot 0
+        }
+        map.set_val_at(b"a", 9);            //the value at "a" goes to slot 1
+        assert_eq!(map.val_count(), 2);
+
+        {
+            //`graft` removes the focus value this way when the source has none
+            let mut wz = map.write_zipper_at_path(b"a");
+            assert_eq!(wz.remove_val(false), Some(9));
+        }
+
+        //What the map holds, according to everything except iteration
+        assert_eq!(map.val_count(), 1);
+        assert_eq!(map.get_val_at(b"a"), None);
+        assert_eq!(map.get_val_at(b"ax"), Some(&1));
+
+        let mut visited = vec![];
+        let mut z = map.read_zipper();
+        while z.to_next_val() {
+            visited.push((z.path().to_vec(), *z.val().unwrap()));
+            assert!(visited.len() <= 1, "iteration must terminate");
+        }
+        assert_eq!(visited, vec![(b"ax".to_vec(), 1)],
+            "iteration must visit every value in the map");
+    }
+
+    /// The way the above shows up in practice: grafting into a path *inside*
+    /// an already-grafted subtrie.  `graft` removes the focus value when the
+    /// source has no root value, which is where the sentinel came from.
+    #[cfg(feature = "graft_root_vals")]
+    #[test]
+    fn write_zipper_graft_into_grafted_subtrie_test() {
+        //A leaf whose root carries a value, so grafting it makes a node with a
+        // value and an onward child under the same key
+        let leaf: PathMap<u64> = PathMap::from_iter([("", 9u64), ("x", 1)]);
+        let mut src = PathMap::<u64>::new();
+        {
+            let mut wz = src.write_zipper_at_path(b"a");
+            wz.graft(&leaf.read_zipper());
+        }
+        // src == {"a": 9, "ax": 1}
+
+        let mut map = PathMap::<u64>::new();
+        {
+            let mut wz = map.write_zipper_at_path(b"a");
+            wz.graft(&src.read_zipper());
+        }
+        {
+            //the second graft lands inside the subtrie the first one installed
+            let mut wz = map.write_zipper_at_path(b"aa");
+            wz.graft(&src.read_zipper());
+        }
+
+        assert_eq!(map.val_count(), 2);
+        assert_eq!(map.get_val_at(b"aaa"), Some(&9));
+        assert_eq!(map.get_val_at(b"aaax"), Some(&1));
+
+        let mut visited = vec![];
+        let mut z = map.read_zipper();
+        while z.to_next_val() {
+            visited.push((z.path().to_vec(), *z.val().unwrap()));
+            assert!(visited.len() <= 2, "iteration must terminate");
+        }
+        assert_eq!(visited, vec![
+            (b"aaa".to_vec(), 9),
+            (b"aaax".to_vec(), 1),
+        ], "iteration must visit every value in the map");
+    }
+
     #[test]
     fn write_zipper_set_val_test1() {
         let mut map = PathMap::<usize>::new();


### PR DESCRIPTION
There's a bug when doing `graft` on a `LineListNode`.
Grafting puts the child in slot 0; the value added afterwards lands in slot 1 under the same key.
That results in `LineListNode` iteration not getting the values/children properly.
This PR fixes the bug, and adds a check for `validate_node` to find similar issues.