### PR TITLE
zipper_algebra: further specialize grafting

### DIFF
--- a/src/dense_byte_node.rs
+++ b/src/dense_byte_node.rs
@@ -1121,7 +1121,10 @@ impl<V: Clone + Send + Sync, A: Allocator, Cf: CoFree<V=V, A=A>> TrieNode<V, A> 
     }
 
     fn node_remove_unmasked_branches(&mut self, key: &[u8], mask: ByteMask, _prune: bool) {
-        debug_assert!(key.len() == 0);
+        if key.len() > 0 {
+            //We're in a non-existent path below this node
+            return
+        }
         // in the future we can use `drain_filter`, but that's experimental
         let mut lead = 0;
         let mut differs = false;

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -515,13 +515,11 @@ where
         Out: ZipperWriting<V, A>,
     {
         if *lhs_grafts != ByteMask::EMPTY {
-            out.graft_masked_branches(lhs, *lhs_grafts, false);
-            *lhs_grafts = ByteMask::EMPTY;
+            do_graft(out, lhs, std::mem::take(lhs_grafts));
         }
 
         if *rhs_grafts != ByteMask::EMPTY {
-            out.graft_masked_branches(rhs, *rhs_grafts, false);
-            *rhs_grafts = ByteMask::EMPTY;
+            do_graft(out, rhs, std::mem::take(rhs_grafts));
         }
     }
 
@@ -731,18 +729,15 @@ where
         Out: ZipperWriting<V, A>,
     {
         if *lhs_grafts != ByteMask::EMPTY {
-            out.graft_masked_branches(lhs, *lhs_grafts, false);
-            *lhs_grafts = ByteMask::EMPTY;
+            do_graft(out, lhs, std::mem::take(lhs_grafts));
         }
 
         if *mid_grafts != ByteMask::EMPTY {
-            out.graft_masked_branches(mid, *mid_grafts, false);
-            *mid_grafts = ByteMask::EMPTY;
+            do_graft(out, mid, std::mem::take(mid_grafts));
         }
 
         if *rhs_grafts != ByteMask::EMPTY {
-            out.graft_masked_branches(rhs, *rhs_grafts, false);
-            *rhs_grafts = ByteMask::EMPTY;
+            do_graft(out, rhs, std::mem::take(rhs_grafts));
         }
     }
 
@@ -1016,23 +1011,19 @@ fn zipper_merge4<P, V, Z0, Z1, Z2, Z3, Out, A>(
         Out: ZipperWriting<V, A>,
     {
         if *z0_grafts != ByteMask::EMPTY {
-            out.graft_masked_branches(z0, *z0_grafts, false);
-            *z0_grafts = ByteMask::EMPTY;
+            do_graft(out, z0, std::mem::take(z0_grafts));
         }
 
         if *z1_grafts != ByteMask::EMPTY {
-            out.graft_masked_branches(z1, *z1_grafts, false);
-            *z1_grafts = ByteMask::EMPTY;
+            do_graft(out, z1, std::mem::take(z1_grafts));
         }
 
         if *z2_grafts != ByteMask::EMPTY {
-            out.graft_masked_branches(z2, *z2_grafts, false);
-            *z2_grafts = ByteMask::EMPTY;
+            do_graft(out, z2, std::mem::take(z2_grafts));
         }
 
         if *z3_grafts != ByteMask::EMPTY {
-            out.graft_masked_branches(z3, *z3_grafts, false);
-            *z3_grafts = ByteMask::EMPTY;
+            do_graft(out, z3, std::mem::take(z3_grafts));
         }
     }
 
@@ -1631,6 +1622,37 @@ fn with_k<const K: usize, T, R>(
     f(refs)
 }
 
+fn do_graft<V, A, Z, Out>(dst: &mut Out, src: &Z, grafts: ByteMask)
+where
+    V: Clone + Send + Sync,
+    A: Allocator,
+    Out: ZipperWriting<V, A>,
+    Z: ZipperInfallibleSubtries<V, A>,
+{
+    match grafts.count_bits() {
+        0 => {}
+        1 => {
+            let byte = grafts.indexed_bit::<true>(0).expect("one bit set");
+            dst.descend_to_byte(byte);
+            dst.graft_src_at(src, &[byte]);
+            dst.ascend_byte();
+        }
+        2 => {
+            let first_byte = grafts.indexed_bit::<true>(0).expect("some bit set");
+            dst.descend_to_byte(first_byte);
+            dst.graft_src_at(src, &[first_byte]);
+            dst.ascend_byte();
+            let second_byte = grafts.next_bit(first_byte).expect("two bits set");
+            dst.descend_to_byte(second_byte);
+            dst.graft_src_at(src, &[second_byte]);
+            dst.ascend_byte();
+        }
+        _ => {
+            dst.graft_masked_branches(src, grafts, false);
+        }
+    }
+}
+
 // - The function is fully monomorphized over `Z` and `N` and uses a bitmask (`active`)
 //   to track participating zippers.
 // - Small frontiers (`k ≤ 4`) are dispatched to specialized implementations
@@ -1674,8 +1696,7 @@ where
     {
         for_each_bit(active, |i| {
             if grafts[i] != ByteMask::EMPTY {
-                out.graft_masked_branches(&zs[i], grafts[i], false);
-                grafts[i] = ByteMask::EMPTY;
+                do_graft(out, &zs[i], std::mem::take(&mut grafts[i]));
             }
         });
     }

--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -515,11 +515,11 @@ where
         Out: ZipperWriting<V, A>,
     {
         if *lhs_grafts != ByteMask::EMPTY {
-            do_graft(out, lhs, std::mem::take(lhs_grafts));
+            out.graft_masked_branches(lhs, std::mem::take(lhs_grafts), false);
         }
 
         if *rhs_grafts != ByteMask::EMPTY {
-            do_graft(out, rhs, std::mem::take(rhs_grafts));
+            out.graft_masked_branches(rhs, std::mem::take(rhs_grafts), false);
         }
     }
 
@@ -729,15 +729,15 @@ where
         Out: ZipperWriting<V, A>,
     {
         if *lhs_grafts != ByteMask::EMPTY {
-            do_graft(out, lhs, std::mem::take(lhs_grafts));
+            out.graft_masked_branches(lhs, std::mem::take(lhs_grafts), false);
         }
 
         if *mid_grafts != ByteMask::EMPTY {
-            do_graft(out, mid, std::mem::take(mid_grafts));
+            out.graft_masked_branches(mid, std::mem::take(mid_grafts), false);
         }
 
         if *rhs_grafts != ByteMask::EMPTY {
-            do_graft(out, rhs, std::mem::take(rhs_grafts));
+            out.graft_masked_branches(rhs, std::mem::take(rhs_grafts), false);
         }
     }
 
@@ -1011,19 +1011,19 @@ fn zipper_merge4<P, V, Z0, Z1, Z2, Z3, Out, A>(
         Out: ZipperWriting<V, A>,
     {
         if *z0_grafts != ByteMask::EMPTY {
-            do_graft(out, z0, std::mem::take(z0_grafts));
+            out.graft_masked_branches(z0, std::mem::take(z0_grafts), false);
         }
 
         if *z1_grafts != ByteMask::EMPTY {
-            do_graft(out, z1, std::mem::take(z1_grafts));
+            out.graft_masked_branches(z1, std::mem::take(z1_grafts), false);
         }
 
         if *z2_grafts != ByteMask::EMPTY {
-            do_graft(out, z2, std::mem::take(z2_grafts));
+            out.graft_masked_branches(z2, std::mem::take(z2_grafts), false);
         }
 
         if *z3_grafts != ByteMask::EMPTY {
-            do_graft(out, z3, std::mem::take(z3_grafts));
+            out.graft_masked_branches(z3, std::mem::take(z3_grafts), false);
         }
     }
 
@@ -1622,37 +1622,6 @@ fn with_k<const K: usize, T, R>(
     f(refs)
 }
 
-fn do_graft<V, A, Z, Out>(dst: &mut Out, src: &Z, grafts: ByteMask)
-where
-    V: Clone + Send + Sync,
-    A: Allocator,
-    Out: ZipperWriting<V, A>,
-    Z: ZipperInfallibleSubtries<V, A>,
-{
-    match grafts.count_bits() {
-        0 => {}
-        1 => {
-            let byte = grafts.indexed_bit::<true>(0).expect("one bit set");
-            dst.descend_to_byte(byte);
-            dst.graft_src_at(src, &[byte]);
-            dst.ascend_byte();
-        }
-        2 => {
-            let first_byte = grafts.indexed_bit::<true>(0).expect("some bit set");
-            dst.descend_to_byte(first_byte);
-            dst.graft_src_at(src, &[first_byte]);
-            dst.ascend_byte();
-            let second_byte = grafts.next_bit(first_byte).expect("two bits set");
-            dst.descend_to_byte(second_byte);
-            dst.graft_src_at(src, &[second_byte]);
-            dst.ascend_byte();
-        }
-        _ => {
-            dst.graft_masked_branches(src, grafts, false);
-        }
-    }
-}
-
 // - The function is fully monomorphized over `Z` and `N` and uses a bitmask (`active`)
 //   to track participating zippers.
 // - Small frontiers (`k ≤ 4`) are dispatched to specialized implementations
@@ -1696,7 +1665,7 @@ where
     {
         for_each_bit(active, |i| {
             if grafts[i] != ByteMask::EMPTY {
-                do_graft(out, &zs[i], std::mem::take(&mut grafts[i]));
+                out.graft_masked_branches(&zs[i], std::mem::take(&mut grafts[i]), false);
             }
         });
     }

--- a/src/write_zipper.rs
+++ b/src/write_zipper.rs
@@ -1501,66 +1501,100 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
     }
     /// See [ZipperWriting::graft_masked_branches]
     pub fn graft_masked_branches<Z: ZipperInfallibleSubtries<V, A>>(&mut self, src: &Z, child_mask: ByteMask, remove_unset: bool) {
-        match src.get_focus().try_as_tagged() {
-            Some(src_tagged) => {
-                // Split the focus if we're in the middle of another node
-                let self_focus_node = match self.try_borrow_focus_mut() {
-                    Some(node) => node,
+        match child_mask.count_bits() {
+            0 => {
+                if remove_unset {
+                    self.remove_branches(false);
+                }
+            }
+            1 => {
+                if remove_unset {
+                    self.remove_branches(false);
+                }
+
+                let byte = child_mask.indexed_bit::<true>(0).expect("one bit set");
+                self.descend_to_byte(byte);
+                self.graft_src_at(src, &[byte]);
+                self.ascend_byte();
+            }
+            2 => {
+                if remove_unset {
+                    self.remove_branches(false);
+                }
+
+                let first_byte = child_mask.indexed_bit::<true>(0).expect("some bit set");
+                self.descend_to_byte(first_byte);
+                self.graft_src_at(src, &[first_byte]);
+                self.ascend_byte();
+
+                let second_byte = child_mask.next_bit(first_byte).expect("two bits set");
+                self.descend_to_byte(second_byte);
+                self.graft_src_at(src, &[second_byte]);
+                self.ascend_byte();
+            }
+            _ => {
+                match src.get_focus().try_as_tagged() {
+                    Some(src_tagged) => {
+                        // Split the focus if we're in the middle of another node
+                        let self_focus_node = match self.try_borrow_focus_mut() {
+                            Some(node) => node,
+                            None => {
+                                self.split_at_focus();
+                                self.try_borrow_focus_mut().unwrap()
+                            }
+                        };
+                        match src_tagged {
+                            TaggedNodeRef::DenseByteNode(src_node) => {
+                                if remove_unset {
+                                    Self::merge_branches_into_focus::<crate::dense_byte_node::OrdinaryCoFree<V, A>, true>(self_focus_node, src_node, child_mask);
+                                } else {
+                                    Self::merge_branches_into_focus::<crate::dense_byte_node::OrdinaryCoFree<V, A>, false>(self_focus_node, src_node, child_mask);
+                                }
+                            },
+                            TaggedNodeRef::CellByteNode(src_node) => {
+                                if remove_unset {
+                                    Self::merge_branches_into_focus::<crate::dense_byte_node::CellCoFree<V, A>, true>(self_focus_node, src_node, child_mask);
+                                } else {
+                                    Self::merge_branches_into_focus::<crate::dense_byte_node::CellCoFree<V, A>, false>(self_focus_node, src_node, child_mask);
+                                }
+                            },
+                            TaggedNodeRef::LineListNode(src_node) => {
+                                let mut src_node = src_node.clone();
+                                let src_dense = src_node.convert_to_dense::<crate::dense_byte_node::OrdinaryCoFree<V, A>>(3);
+                                let src_dense = src_dense.as_tagged().as_dense().unwrap();
+                                if remove_unset {
+                                    Self::merge_branches_into_focus::<crate::dense_byte_node::OrdinaryCoFree<V, A>, true>(self_focus_node, src_dense, child_mask);
+                                } else {
+                                    Self::merge_branches_into_focus::<crate::dense_byte_node::OrdinaryCoFree<V, A>, false>(self_focus_node, src_dense, child_mask);
+                                }
+                            },
+                            TaggedNodeRef::TinyRefNode(src_node) => {
+                                let mut src_node = src_node.into_full().unwrap();
+                                let src_dense = src_node.convert_to_dense::<crate::dense_byte_node::OrdinaryCoFree<V, A>>(3);
+                                let src_dense = src_dense.as_tagged().as_dense().unwrap();
+                                if remove_unset {
+                                    Self::merge_branches_into_focus::<crate::dense_byte_node::OrdinaryCoFree<V, A>, true>(self_focus_node, src_dense, child_mask);
+                                } else {
+                                    Self::merge_branches_into_focus::<crate::dense_byte_node::OrdinaryCoFree<V, A>, false>(self_focus_node, src_dense, child_mask);
+                                }
+                            },
+                            TaggedNodeRef::EmptyNode => {
+                                if remove_unset {
+                                    self.remove_branches(false);
+                                } else {
+                                    self.remove_unmasked_branches(child_mask.not(), false);
+                                }
+                            },
+                        }
+                    },
                     None => {
-                        self.split_at_focus();
-                        self.try_borrow_focus_mut().unwrap()
-                    }
-                };
-                match src_tagged {
-                    TaggedNodeRef::DenseByteNode(src_node) => {
-                        if remove_unset {
-                            Self::merge_branches_into_focus::<crate::dense_byte_node::OrdinaryCoFree<V, A>, true>(self_focus_node, src_node, child_mask);
-                        } else {
-                            Self::merge_branches_into_focus::<crate::dense_byte_node::OrdinaryCoFree<V, A>, false>(self_focus_node, src_node, child_mask);
-                        }
-                    },
-                    TaggedNodeRef::CellByteNode(src_node) => {
-                        if remove_unset {
-                            Self::merge_branches_into_focus::<crate::dense_byte_node::CellCoFree<V, A>, true>(self_focus_node, src_node, child_mask);
-                        } else {
-                            Self::merge_branches_into_focus::<crate::dense_byte_node::CellCoFree<V, A>, false>(self_focus_node, src_node, child_mask);
-                        }
-                    },
-                    TaggedNodeRef::LineListNode(src_node) => {
-                        let mut src_node = src_node.clone();
-                        let src_dense = src_node.convert_to_dense::<crate::dense_byte_node::OrdinaryCoFree<V, A>>(3);
-                        let src_dense = src_dense.as_tagged().as_dense().unwrap();
-                        if remove_unset {
-                            Self::merge_branches_into_focus::<crate::dense_byte_node::OrdinaryCoFree<V, A>, true>(self_focus_node, src_dense, child_mask);
-                        } else {
-                            Self::merge_branches_into_focus::<crate::dense_byte_node::OrdinaryCoFree<V, A>, false>(self_focus_node, src_dense, child_mask);
-                        }
-                    },
-                    TaggedNodeRef::TinyRefNode(src_node) => {
-                        let mut src_node = src_node.into_full().unwrap();
-                        let src_dense = src_node.convert_to_dense::<crate::dense_byte_node::OrdinaryCoFree<V, A>>(3);
-                        let src_dense = src_dense.as_tagged().as_dense().unwrap();
-                        if remove_unset {
-                            Self::merge_branches_into_focus::<crate::dense_byte_node::OrdinaryCoFree<V, A>, true>(self_focus_node, src_dense, child_mask);
-                        } else {
-                            Self::merge_branches_into_focus::<crate::dense_byte_node::OrdinaryCoFree<V, A>, false>(self_focus_node, src_dense, child_mask);
-                        }
-                    },
-                    TaggedNodeRef::EmptyNode => {
+                        debug_assert_eq!(src.child_count(), 0);
                         if remove_unset {
                             self.remove_branches(false);
                         } else {
                             self.remove_unmasked_branches(child_mask.not(), false);
                         }
-                    },
-                }
-            },
-            None => {
-                debug_assert_eq!(src.child_count(), 0);
-                if remove_unset {
-                    self.remove_branches(false);
-                } else {
-                    self.remove_unmasked_branches(child_mask.not(), false);
+                    }
                 }
             }
         }

--- a/src/write_zipper.rs
+++ b/src/write_zipper.rs
@@ -127,6 +127,10 @@ pub trait ZipperWriting<V: Clone + Send + Sync, A: Allocator = GlobalAlloc>: Wri
     ///
     /// Set bits that correspond to non-existent branches in `src` will be non-existent in `self` after this
     /// function completes.
+    ///
+    /// WARNING: The implementation may reserve space based on every set bit in `child_mask`, including for
+    /// branches that are absent from `src`. Don't use a mask with vastly more set bits than source branches to
+    /// avoid unnecessarily large allocations.
     fn graft_masked_branches<Z: ZipperInfallibleSubtries<V, A>>(&mut self, src: &Z, child_mask: ByteMask, remove_unset: bool) {
         if remove_unset {
             self.remove_branches(false);
@@ -4398,6 +4402,18 @@ mod tests {
         //Garfield was removed
         assert_eq!(wr.val(), None);
     }
+
+    #[test]
+    fn write_zipper_test_remove_unmasked_branches_non_existent_path() {
+        let mut map: PathMap<()> = PathMap::new();
+        for key in [b"a".as_slice(), b"b", b"c"] {
+            map.set_val_at(key, ());
+        }
+
+        let mut wz = map.write_zipper_at_path(b"a:x");
+        wz.remove_unmasked_branches(ByteMask::EMPTY, false);
+    }
+
     #[test]
     fn write_zipper_test_zipper_conversion() {
         let keys = [


### PR DESCRIPTION
This leads to a few percent speed-up in the benchmarks. For instance, for _symmetric difference_ simulation, before this we had:

```
ops               fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ xor                          │               │               │               │         │
├─ base_2b     84.04 ms      │ 85.36 ms      │ 84.28 ms      │ 84.47 ms      │ 5       │ 50
├─ base_4b     888.8 ms      │ 896.3 ms      │ 893.7 ms      │ 893 ms        │ 5       │ 50
├─ zipper2_2b  494.2 ms      │ 501 ms        │ 497.1 ms      │ 497.9 ms      │ 5       │ 50
├─ zipper2_4b  3.88 s        │ 3.897 s       │ 3.886 s       │ 3.887 s       │ 5       │ 50
├─ zipper4_2b  331.4 ms      │ 336.5 ms      │ 333 ms        │ 333.7 ms      │ 5       │ 50
╰─ zipper4_4b  2.4 s         │ 2.411 s       │ 2.403 s       │ 2.404 s       │ 5       │ 50
```

and now we have:

```
Timer precision: 33 ns
ops               fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ xor                          │               │               │               │         │
├─ base_2b     71.11 ms      │ 72.15 ms      │ 71.48 ms      │ 71.55 ms      │ 5       │ 50
├─ base_4b     838.6 ms      │ 858.7 ms      │ 840.8 ms      │ 844.1 ms      │ 5       │ 50
├─ zipper2_2b  308.1 ms      │ 312.8 ms      │ 310.3 ms      │ 310.2 ms      │ 5       │ 50
├─ zipper2_4b  2.625 s       │ 2.65 s        │ 2.635 s       │ 2.636 s       │ 5       │ 50
├─ zipper4_2b  158.1 ms      │ 159.3 ms      │ 158.7 ms      │ 158.7 ms      │ 5       │ 50
╰─ zipper4_4b  1.603 s       │ 1.617 s       │ 1.615 s       │ 1.612 s       │ 5       │ 50
```

so there is a quite considerable speed-up (especially for longer paths)



