### PR TITLE
Fix restrict dropping the value on a path that branches

### DIFF
--- a/src/line_list_node.rs
+++ b/src/line_list_node.rs
@@ -1639,18 +1639,28 @@ fn follow_path<'a, 'k, V: Clone + Send + Sync, A: Allocator + 'a>(mut node: Tagg
 
 /// Follows a path from a node, returning `(true, _)` if a value was encountered along the path, returns
 /// `(false, Some)` if the path continues, and `(false, None)` if the path does not descend from the node
+//
+//NOTE: the value check has to happen at every node along the way, before following an onward link.
+// A node can hold a value *and* a child under the same key -- a path that both ends there and
+// continues -- and it can hold a value at a prefix of the key it is being asked about.  Checking
+// only after the walk ran out of links missed both, which made `restrict` silently drop the value
+// on any path that branches: `restrict(a, a)` lost "ab" from {ab, abc, abd}.
 fn follow_path_to_value<'a, 'k, V: Clone + Send + Sync, A: Allocator + 'a>(mut node: TaggedNodeRef<'a, V, A>, mut key: &'k[u8]) -> (bool, Option<(&'k[u8], TaggedNodeRef<'a, V, A>)>) {
-    while let Some((consumed_byte_cnt, next_node)) = node.node_get_child(key) {
-        if consumed_byte_cnt < key.len() {
-            let next_node = next_node.as_tagged();
-            node = next_node;
-            key = &key[consumed_byte_cnt..]
-        } else {
-            return (false, Some((key, node)));
-        };
-    }
-    if let Some(_) = node.node_first_val_depth_along_key(key) {
-        return (true, None);
+    loop {
+        if node.node_first_val_depth_along_key(key).is_some() {
+            return (true, None);
+        }
+        match node.node_get_child(key) {
+            Some((consumed_byte_cnt, next_node)) => {
+                if consumed_byte_cnt < key.len() {
+                    node = next_node.as_tagged();
+                    key = &key[consumed_byte_cnt..]
+                } else {
+                    return (false, Some((key, node)));
+                }
+            },
+            None => break,
+        }
     }
     if node.node_contains_partial_key(key) {
         (false, Some((key, node)))

--- a/tests/pathmap_algebra_differential.rs
+++ b/tests/pathmap_algebra_differential.rs
@@ -198,3 +198,57 @@ fn seeded_prefix_heavy_dual_distributivity_matches_btreeset_oracle() {
         );
     }
 }
+
+/// The oracle for `restrict`: a path of `self` survives when some prefix of it -- the empty prefix
+/// and the path itself both count -- carries a value in `other`.
+fn restrict_oracle(left: &KeySet, right: &KeySet) -> KeySet {
+    left.iter()
+        .filter(|path| (0..=path.len()).any(|split| right.contains(&path[..split].to_vec())))
+        .cloned()
+        .collect()
+}
+
+/// `restrict(a, a)` must be `a`, since every path of `a` has a value at itself in `a`.
+///
+/// It did not hold when a path both carried a value and branched: `{ab, abc, abd}` lost `ab`, and
+/// `{a, ab, abc}` lost `a`. `follow_path_to_value` only looked for a value once its walk ran out of
+/// onward links, so a node holding a value *and* a child under the same key reported "no value,
+/// path continues" and `restrict` dropped the value.
+#[test]
+fn restrict_matches_btreeset_oracle() {
+    //the minimal shapes first, since they say more than the seeded sets do
+    for paths in [
+        &[b"ab".as_slice(), b"abc"][..],
+        &[b"ab".as_slice(), b"abc", b"abd"][..],
+        &[b"a".as_slice(), b"ab", b"abc"][..],
+        //the value sits at a prefix of the key the walk descends through, rather than at it
+        &[b"a".as_slice(), b"abc", b"abd"][..],
+        &[b"a".as_slice(), b"ab", b"abc", b"abd", b"xy"][..],
+    ] {
+        let set: KeySet = paths.iter().map(|p| p.to_vec()).collect();
+        let map = map_from_set(&set);
+        assert_eq!(set_from_map(&map.restrict(&map)), set, "restrict(a, a) should be a, for {paths:?}");
+    }
+
+    #[cfg(not(miri))]
+    const SEEDS: u64 = 64;
+    #[cfg(miri)]
+    const SEEDS: u64 = 2;
+
+    for seed in 0..SEEDS {
+        for (name, left, right) in [
+            ("prefix_free", fixed_width_set(seed, 0xA1), fixed_width_set(seed, 0xB2)),
+            ("prefix_heavy", prefix_heavy_set(seed, 0xC3), prefix_heavy_set(seed, 0xD4)),
+            //deliberately lopsided, so the two masks overlap without being equal
+            ("lopsided", prefix_heavy_set(seed, 0xE5), fixed_width_set(seed, 0xF6)),
+            ("self_restrict", prefix_heavy_set(seed, 0x17), prefix_heavy_set(seed, 0x17)),
+        ] {
+            let restricted = map_from_set(&left).restrict(&map_from_set(&right));
+            assert_eq!(
+                set_from_map(&restricted),
+                restrict_oracle(&left, &right),
+                "restrict mismatch for {name} at seed {seed}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
`restrict(a, b)` keeps the paths of `a` that lie at or below a value in `b`, so `restrict(a, a)` must be `a` -- every path of `a` has a value at itself in `a`. It did not hold when a path both carried a value and branched:

    {ab, abc}             -> {ab, abc}     ok
    {ab, abc, abd}        -> {abc, abd}    lost "ab"
    {a, ab, abc}          -> {ab, abc}     lost "a"

One child was fine, two or more and the value went.

`follow_path_to_value` walked the other operand following onward links and only looked for a value once the walk ran out of them. A node can hold a value *and* a child under the same key -- a path that both ends there and continues -- and in that case the walk took the link and returned "no value, path continues", so `restrict_slot_contents` discarded the value. That also explains the one-child boundary: with a single child the continuation is stored inline in a sibling slot rather than behind a link, so the walk fell through to the value check and worked. The check now happens at every node before the link is taken, which additionally covers a value sitting at a prefix of the key being followed. `follow_path_to_value` has one caller, so the change is contained to `restrict`.

Costs nothing measurable: interleaved against the untouched `meet` as a control, restrict moves -1.5% to +0.6% across five operand shapes, the control -1.4% to +1.6%.

`restrict` was the only one of the four algebraic operations without a differential test, which is how this survived. It now has a BTreeSet oracle -- a path of `self` survives when some prefix of it, the empty prefix and the path itself included, carries a value in `other` -- run over prefix-free, prefix-heavy, lopsided and self-restrict sets, plus the minimal shapes above. The oracle fails on the parent commit.