### PR TITLE
Make ACTZipper::reset return to an off-trie root instead of a real ancestor

### DIFF
--- a/src/arena_compact.rs
+++ b/src/arena_compact.rs
@@ -2307,9 +2307,11 @@ where Storage: AsRef<[u8]>
     cur_node: Node,
     stack: Vec<StackFrame>,
     path: Vec<u8>,
+    pub(crate) invalid: usize,
+    // origin_* fields are used to remember the position of zipper's root
     origin_depth: usize,
     origin_node_depth: usize,
-    pub invalid: usize,
+    origin_invalid: usize,
     _marker: PhantomData<Value>,
 }
 
@@ -2319,7 +2321,7 @@ where Storage: AsRef<[u8]>
     fn clone(&self) -> Self {
         let Self {
             tree, cur_node, stack, path,
-            origin_depth, origin_node_depth, invalid, ..
+            origin_depth, origin_node_depth, invalid, origin_invalid, ..
         } = self;
         Self {
             tree,
@@ -2329,6 +2331,7 @@ where Storage: AsRef<[u8]>
             origin_depth: *origin_depth,
             origin_node_depth: *origin_node_depth,
             invalid: *invalid,
+            origin_invalid: *origin_invalid,
             _marker: PhantomData,
         }
     }
@@ -2382,6 +2385,7 @@ where Storage: AsRef<[u8]>
             tree, cur_node,
             path: Vec::new(),
             invalid: 0,
+            origin_invalid: 0,
             origin_depth: 0,
             origin_node_depth: 0,
             stack: Vec::from([stack_frame]),
@@ -2391,6 +2395,7 @@ where Storage: AsRef<[u8]>
 
     fn with_root_here(mut self) -> Self {
         self.origin_depth = self.path.len();
+        self.origin_invalid = self.invalid;
         if self.stack.len() > 1 {
             let last = self.stack.len() - 1;
             self.stack.swap(0, last);
@@ -2922,9 +2927,10 @@ where Storage: AsRef<[u8]>
         let (cur_node, _) = self.tree.get_node(self.stack[0].node_id);
         self.cur_node = cur_node;
         self.stack.truncate(1);
+        // restore origin_* state
         self.stack[0].node_depth = self.origin_node_depth;
         self.path.truncate(self.origin_depth);
-        self.invalid = 0;
+        self.invalid = self.origin_invalid;
     }
 
     /// Returns the total number of values contained at and below the zipper's focus, including the focus itself
@@ -4146,5 +4152,43 @@ mod tests {
             assert!(az.descend_first_k_path(1) == pz.descend_first_k_path(1));
             assert_eq!(az.path(), pz.path());
         }
+    }
+
+    /// A zipper can be rooted at a path that does not exist -- `fork_read_zipper` at an
+    /// off-trie focus makes one.  `reset` put the path back but cleared `invalid`
+    /// unconditionally, so the zipper came back believing it was rooted at its deepest
+    /// real ancestor and answered `val()` with that ancestor's value.
+    #[test]
+    fn act_zipper_reset_returns_to_an_off_trie_root() {
+        use crate::zipper::*;
+        let mut m = PathMap::<u64>::new();
+        { let mut w = m.write_zipper(); w.set_val(38); }
+        m.insert(&[1u8, 0, 2], 22);
+        m.insert(&[1u8, 1], 72);
+        let t = ArenaCompactTree::from_zipper(m.read_zipper(), |&v| v);
+
+        for root in [&[1u8, 1, 3][..], &[9u8], &[1u8, 0, 2, 5, 5]] {
+            let mut az = t.read_zipper_u64();
+            az.descend_to(root);
+            assert!(!az.path_exists(), "{root:?}");
+            let mut fork = az.fork_read_zipper();
+            assert!(!fork.path_exists(), "{root:?}");
+            assert_eq!(fork.val(), None, "{root:?}");
+            fork.reset();
+            assert!(fork.at_root(), "{root:?}");
+            assert!(!fork.path_exists(), "{root:?} after reset");
+            assert_eq!(fork.val(), None, "{root:?} after reset");
+            assert_eq!(fork.val_count(), 0, "{root:?} after reset");
+            assert_eq!(fork.child_count(), 0, "{root:?} after reset");
+            assert!(!fork.to_next_val(), "{root:?} after reset");
+        }
+
+        //The same through a zipper created at an off-trie path
+        let mut az = t.read_zipper_at_path_u64(&[1u8, 1, 3]);
+        assert_eq!(az.val(), None);
+        az.descend_to(&[0u8]);
+        az.reset();
+        assert_eq!(az.val(), None);
+        assert!(!az.path_exists());
     }
 }


### PR DESCRIPTION
A zipper can be *rooted* at a path that does not exist: `fork_read_zipper` at an off-trie focus makes one, and so does `read_zipper_at_path` with such a path.  `reset` put the path back but then cleared `invalid` unconditionally, so the zipper came back believing it was rooted on the trie, at whatever real node the stack still pointed at, its deepest existing ancestor.  It then answered `val()` with that ancestor's value:

    trie: root=38, [1,0,2]=22, [1,1]=72
    fork at [1,1,3] (does not exist): val None  ->  after reset(): Some(72)
    fork at [9]     (does not exist): val None  ->  after reset(): Some(38)

The zipper knew where its root was (`origin_depth`, `origin_node_depth`) but not how far off the trie it was, so `reset` had nothing to restore. `origin_invalid` records that, `with_root_here` captures it when a fork takes the focus as its root, and `reset` restores it.

Regression test: `act_zipper_reset_returns_to_an_off_trie_root`, forks at three off-trie paths and a zipper created at one.  Fails before this change.