### PR TITLE
Fix panics on dangling paths: issue #85 and the empty-sentinel joins

### DIFF
--- a/src/dense_byte_node.rs
+++ b/src/dense_byte_node.rs
@@ -295,11 +295,6 @@ impl<V: Clone + Send + Sync, A: Allocator, Cf: CoFree<V=V, A=A>> ByteNode<Cf, A>
 
     #[inline]
     fn get_child_mut(&mut self, k: u8) -> Option<&mut TrieNodeODRc<V, A>> {
-        //An empty rec is a dangling byte: the byte is in the mask but there is nothing to descend
-        // into, and the empty sentinel it holds cannot be made mutable.  It is reported as "no
-        // child", as LineListNode::get_child_mut does, so a descent stops at this node and the
-        // mutator that follows (node_set_val, node_set_branch, a graft) replaces the rec through
-        // set_child instead of calling make_mut on it.
         self.get_mut(k).and_then(|cf| cf.rec_mut()).filter(|child| !child.is_empty())
     }
 
@@ -1312,8 +1307,6 @@ impl<V: Clone + Send + Sync, A: Allocator, Cf: CoFree<V=V, A=A>> TrieNode<V, A> 
     }
 
     fn join_into_dyn(&mut self, mut other: TrieNodeODRc<V, A>) -> (AlgebraicStatus, Result<(), TrieNodeODRc<V, A>>) where V: Lattice {
-        //An empty `other` (e.g. the sentinel behind a dangling path) contributes nothing, and it
-        // cannot be made mutable; this mirrors the `EMPTY_NODE_TAG` arm in LineListNode::join_into_dyn
         if other.as_tagged().node_is_empty() {
             return (AlgebraicStatus::Identity, Ok(()))
         }
@@ -1353,7 +1346,6 @@ impl<V: Clone + Send + Sync, A: Allocator, Cf: CoFree<V=V, A=A>> TrieNode<V, A> 
                 //WARNING: Don't be tempted to swap the node itself with its first child.  This feels like it
                 // might be an optimization, but it would be a memory leak because the other node will now
                 // hold an Rc to itself.
-                //A dangling child (the empty sentinel) has nothing below the dropped byte and can't be made mutable
                 match self.values.pop().unwrap().into_rec().filter(|child| !child.is_empty()) {
                     Some(mut child) => {
                         if byte_cnt > 1 {
@@ -1368,7 +1360,6 @@ impl<V: Clone + Send + Sync, A: Allocator, Cf: CoFree<V=V, A=A>> TrieNode<V, A> 
             _ => {
                 let mut new_node = Self::new_in(self.alloc.clone());
                 while let Some(cf) = self.values.pop() {
-                    //A dangling child (the empty sentinel) has nothing below the dropped byte and can't be made mutable
                     let child = cf.into_rec().filter(|child| !child.is_empty());
                     let child = if byte_cnt > 1 {
                         child.and_then(|mut child| child.make_mut().drop_head_dyn(byte_cnt-1))
@@ -1844,8 +1835,7 @@ impl<V: Clone + Send + Sync + Lattice, A: Allocator, Cf: CoFree<V=V, A=A>, Other
         let (other_rec, other_val) = other.into_both();
         let rec_status = match self.rec_mut() {
             Some(self_rec) => match other_rec {
-                //Route through `TrieNodeODRc::join_into` so an empty-sentinel `self_rec` (a dangling path) is
-                // replaced rather than made mutable
+                //Route through `TrieNodeODRc::join_into`
                 Some(other_rec) => self_rec.join_into(other_rec),
                 None => AlgebraicStatus::Identity,
             },
@@ -2051,6 +2041,8 @@ impl<V: Clone + Send + Sync + Lattice, A: Allocator, Cf: CoFree<V=V, A=A>, Other
                         AlgebraicResult::None => {
                             //Both nodes hold a dangling path (no value, no onward node) at this byte, e.g. after
                             // `remove_branches(prune = false)`; it stays dangling in the join and is an identity for both
+                            debug_assert!(!lv.has_rec() && !lv.has_val());
+                            debug_assert!(!rv.has_rec() && !rv.has_val());
                             unsafe { new_v.get_unchecked_mut(c).write(Cf::new(None, None)) };
                         },
                         AlgebraicResult::Identity(mask) => {
@@ -2141,7 +2133,6 @@ impl<V: Clone + Send + Sync + Lattice, A: Allocator, Cf: CoFree<V=V, A=A>, Other
                     match lv.join_into(rv) {
                         AlgebraicStatus::Identity => { },
                         AlgebraicStatus::Element => { is_identity = false; },
-                        //Both nodes hold a dangling path at this byte; `lv` is the (still empty) CoFree written back below
                         AlgebraicStatus::None => { },
                     }
                     unsafe { new_v.get_unchecked_mut(c).write(lv) };

--- a/src/dense_byte_node.rs
+++ b/src/dense_byte_node.rs
@@ -1307,6 +1307,11 @@ impl<V: Clone + Send + Sync, A: Allocator, Cf: CoFree<V=V, A=A>> TrieNode<V, A> 
     }
 
     fn join_into_dyn(&mut self, mut other: TrieNodeODRc<V, A>) -> (AlgebraicStatus, Result<(), TrieNodeODRc<V, A>>) where V: Lattice {
+        //An empty `other` (e.g. the sentinel behind a dangling path) contributes nothing, and it
+        // cannot be made mutable; this mirrors the `EMPTY_NODE_TAG` arm in LineListNode::join_into_dyn
+        if other.as_tagged().node_is_empty() {
+            return (AlgebraicStatus::Identity, Ok(()))
+        }
         let other_node = other.make_mut();
         let status = match other_node.tag() {
             DENSE_BYTE_NODE_TAG => {
@@ -1343,7 +1348,8 @@ impl<V: Clone + Send + Sync, A: Allocator, Cf: CoFree<V=V, A=A>> TrieNode<V, A> 
                 //WARNING: Don't be tempted to swap the node itself with its first child.  This feels like it
                 // might be an optimization, but it would be a memory leak because the other node will now
                 // hold an Rc to itself.
-                match self.values.pop().unwrap().into_rec() {
+                //A dangling child (the empty sentinel) has nothing below the dropped byte and can't be made mutable
+                match self.values.pop().unwrap().into_rec().filter(|child| !child.is_empty()) {
                     Some(mut child) => {
                         if byte_cnt > 1 {
                             child.make_mut().drop_head_dyn(byte_cnt-1)
@@ -1357,10 +1363,12 @@ impl<V: Clone + Send + Sync, A: Allocator, Cf: CoFree<V=V, A=A>> TrieNode<V, A> 
             _ => {
                 let mut new_node = Self::new_in(self.alloc.clone());
                 while let Some(cf) = self.values.pop() {
+                    //A dangling child (the empty sentinel) has nothing below the dropped byte and can't be made mutable
+                    let child = cf.into_rec().filter(|child| !child.is_empty());
                     let child = if byte_cnt > 1 {
-                        cf.into_rec().and_then(|mut child| child.make_mut().drop_head_dyn(byte_cnt-1))
+                        child.and_then(|mut child| child.make_mut().drop_head_dyn(byte_cnt-1))
                     } else {
-                        cf.into_rec()
+                        child
                     };
                     match child {
                         Some(child) => {
@@ -1831,14 +1839,9 @@ impl<V: Clone + Send + Sync + Lattice, A: Allocator, Cf: CoFree<V=V, A=A>, Other
         let (other_rec, other_val) = other.into_both();
         let rec_status = match self.rec_mut() {
             Some(self_rec) => match other_rec {
-                Some(other_rec) => {
-                    let (status, result) = self_rec.make_mut().join_into_dyn(other_rec);
-                    match result {
-                        Ok(()) => {},
-                        Err(replacement_node) => {*self_rec = replacement_node},
-                    }
-                    status
-                },
+                //Route through `TrieNodeODRc::join_into` so an empty-sentinel `self_rec` (a dangling path) is
+                // replaced rather than made mutable
+                Some(other_rec) => self_rec.join_into(other_rec),
                 None => AlgebraicStatus::Identity,
             },
             None => match other_rec {
@@ -2040,7 +2043,11 @@ impl<V: Clone + Send + Sync + Lattice, A: Allocator, Cf: CoFree<V=V, A=A>, Other
                     let lv = unsafe { self.values.get_unchecked(l) };
                     let rv = unsafe { other.values.get_unchecked(r) };
                     match lv.pjoin(rv) {
-                        AlgebraicResult::None => unreachable!(), //Some joined to Some should never be None
+                        AlgebraicResult::None => {
+                            //Both nodes hold a dangling path (no value, no onward node) at this byte, e.g. after
+                            // `remove_branches(prune = false)`; it stays dangling in the join and is an identity for both
+                            unsafe { new_v.get_unchecked_mut(c).write(Cf::new(None, None)) };
+                        },
                         AlgebraicResult::Identity(mask) => {
                             debug_assert!((mask & SELF_IDENT > 0) || (mask & COUNTER_IDENT > 0));
                             if mask & SELF_IDENT == 0 {
@@ -2129,7 +2136,8 @@ impl<V: Clone + Send + Sync + Lattice, A: Allocator, Cf: CoFree<V=V, A=A>, Other
                     match lv.join_into(rv) {
                         AlgebraicStatus::Identity => { },
                         AlgebraicStatus::Element => { is_identity = false; },
-                        AlgebraicStatus::None => unreachable!(), //Some.join(Some) shouldn't create None
+                        //Both nodes hold a dangling path at this byte; `lv` is the (still empty) CoFree written back below
+                        AlgebraicStatus::None => { },
                     }
                     unsafe { new_v.get_unchecked_mut(c).write(lv) };
                     l += 1;

--- a/src/dense_byte_node.rs
+++ b/src/dense_byte_node.rs
@@ -295,7 +295,12 @@ impl<V: Clone + Send + Sync, A: Allocator, Cf: CoFree<V=V, A=A>> ByteNode<Cf, A>
 
     #[inline]
     fn get_child_mut(&mut self, k: u8) -> Option<&mut TrieNodeODRc<V, A>> {
-        self.get_mut(k).and_then(|cf| cf.rec_mut())
+        //An empty rec is a dangling byte: the byte is in the mask but there is nothing to descend
+        // into, and the empty sentinel it holds cannot be made mutable.  It is reported as "no
+        // child", as LineListNode::get_child_mut does, so a descent stops at this node and the
+        // mutator that follows (node_set_val, node_set_branch, a graft) replaces the rec through
+        // set_child instead of calling make_mut on it.
+        self.get_mut(k).and_then(|cf| cf.rec_mut()).filter(|child| !child.is_empty())
     }
 
     #[inline]
@@ -2475,4 +2480,43 @@ fn byte_node_iter_token_crosses_mask_word_boundaries() {
         }
     }
     assert_eq!(visited_after_missing_65, [127, 128, 191, 192, 255]);
+
+}
+
+/// Issue #85: mutating below a dangling byte of a dense node panicked in make_unique.
+/// The dangling slot is copied over when a pair node is upgraded to a dense node, and
+/// node_get_child_mut handed its empty sentinel to the descent.
+#[test]
+fn dense_node_mutate_below_dangling_byte() {
+    use crate::PathMap;
+    use crate::zipper::*;
+    fn keys(m: &PathMap<()>) -> Vec<String> { m.iter().map(|(k, _)| String::from_utf8_lossy(&k).into_owned()).collect() }
+    fn dangling_c() -> PathMap<()> {
+        let mut m = PathMap::new();
+        for k in [b"ca".as_slice(), b"cb", b"d"] { m.set_val_at(k, ()); }
+        { let mut wz = m.write_zipper(); wz.descend_to(b"c"); wz.remove_branches(false); }
+        assert_eq!(keys(&m), ["d"]);
+        m
+    }
+    let mut m = dangling_c();
+    m.set_val_at(b"e", ());
+    m.set_val_at(b"f", ());
+    m.set_val_at(b"cx", ());
+    assert_eq!(keys(&m), ["cx", "d", "e", "f"]);
+
+    let mut m = dangling_c();
+    m.set_val_at(b"e", ());
+    m.set_val_at(b"f", ());
+    { let mut wz = m.write_zipper(); wz.descend_to(b"cxy"); let mut o = PathMap::new(); o.set_val_at(b"z", ()); wz.graft_map(o); }
+    assert_eq!(keys(&m), ["cxyz", "d", "e", "f"]);
+
+    //At the dangling byte itself, and in a pair-node parent, which already worked
+    let mut m = dangling_c();
+    m.set_val_at(b"e", ());
+    m.set_val_at(b"f", ());
+    m.set_val_at(b"c", ());
+    assert_eq!(keys(&m), ["c", "d", "e", "f"]);
+    let mut m = dangling_c();
+    m.set_val_at(b"cx", ());
+    assert_eq!(keys(&m), ["cx", "d"]);
 }

--- a/src/line_list_node.rs
+++ b/src/line_list_node.rs
@@ -1188,8 +1188,14 @@ impl<V: Clone + Send + Sync, A: Allocator> LineListNode<V, A> {
                     let restricted_node_result = if onward_key.len() == 0 {
                         self_onward_link.as_tagged().prestrict_dyn(onward_node)
                     } else {
-                        let other_onward_node = onward_node.get_node_at_key(onward_key);
-                        self_onward_link.as_tagged().prestrict_dyn(other_onward_node.as_tagged())
+                        //`onward_key` may name a dangling byte of `other`: in its child mask, but
+                        // with no node behind it.  Nothing under it can validate a path, so the
+                        // slot is dropped, as `subtract_from_slot_contents` beside this already
+                        // does.  Calling `as_tagged` on the missing node was an explicit panic.
+                        match onward_node.get_node_at_key(onward_key).into_option() {
+                            Some(other_onward_node) => self_onward_link.as_tagged().prestrict_dyn(other_onward_node.as_tagged()),
+                            None => AlgebraicResult::None,
+                        }
                     };
                     restricted_node_result.map(|node| ValOrChildUnion::from(node))
                 } else {
@@ -3494,48 +3500,37 @@ mod tests {
         assert_eq!(by_index.child_count(), by_path.child_count());
         assert_eq!(by_index.child_mask(), by_path.child_mask());
     }
+
+    /// Issue #85: `restrict` panicked when a child-link slot was followed into `other` and
+    /// landed on a dangling byte there (in the child mask, no node behind it).
+    #[test]
+    fn restrict_against_dangling_branch() {
+        use crate::PathMap;
+        use crate::zipper::*;
+        fn mk(keys: &[&[u8]]) -> PathMap<()> { let mut m = PathMap::new(); for k in keys { m.set_val_at(k, ()); } m }
+        fn keys(m: &PathMap<()>) -> Vec<String> { m.iter().map(|(k, _)| String::from_utf8_lossy(&k).into_owned()).collect() }
+        fn other_dangling_a() -> PathMap<()> {
+            let mut o = mk(&[b"a", b"b", b"c", b"e"]);
+            o.remove_val_at(b"a", false);
+            assert_eq!(keys(&o), ["b", "c", "e"]);
+            o
+        }
+        let m = mk(&[b"ab", b"ac"]);
+        let r = m.restrict(&other_dangling_a());
+        assert_eq!(keys(&r), Vec::<String>::new());
+
+        let mut m = mk(&[b"ab", b"ac"]);
+        let o = other_dangling_a();
+        m.write_zipper().restrict(&o.read_zipper());
+        assert_eq!(keys(&m), Vec::<String>::new());
+
+        let mut m = mk(&[b"dab", b"dac"]);
+        { let mut wz = m.write_zipper(); wz.descend_to(b"d"); wz.restrict(&o.read_zipper()); }
+        assert_eq!(keys(&m), Vec::<String>::new());
+
+        //A path that `other` does validate survives beside one it does not
+        let mut m = mk(&[b"ab", b"ac", b"bx"]);
+        m.write_zipper().restrict(&o.read_zipper());
+        assert_eq!(keys(&m), ["bx"]);
+    }
 }
-
-//GOAT, merge wrappers for lattice impls on primitives
-//
-//GOAT, remove garbage lattice impls
-//
-//GOAT Catamorphism names:  https://github.com/Adam-Vandervorst/PathMap/pull/8#discussion_r2004745719
-//
-//GOAT, document how path existence can't be used to confirm the existence of a value, only the non-existence
-//  and document the meaning of path existence more generally.
-//GOAT, consider exposing an explicit prune method.  Possibly also consider exposing a "create_path" method.
-//  SEE "PATH EXISTS DISCUSSION" below
-//
-//GOAT, consider adding a "prune" flag to methods that might remove values
-//
-
-
-// PATH EXISTS DISCUSSION
-// Ok... Fork 1 is about paths, and specifically what information about values you can get from whether or not a path exists.  In the current code, the *nonexistence* of a path guarantees no value is below that point (how could there be one?) but the *existence* of a path does **not** guarantee a value is.
-// Earlier drafts of PathMap (about 3 months ago) we were upholding that property that all paths led to values.  But I realized this property is impossible to uphold with the a multi write-zipper implementation.
-// Bottom line, with the current set of guarantees, you can't use `path_exists` to conclude that there are zippers above you.  You will have to call `to_next_value` to search downwards.
-// Looking forwards, I think I may add explicit methods like `ascend_prune` that ascends the zipper upwards from an empty leaf, pruning as it goes, and `descend_create` to do the opposite.  (although I'm a little on the fence about how descend_create would actually be useful.)  Maybe it might make sense to implement versions of these methods that don't move the zipper focus.
-// But if we tweak the zipper contract so that paths are explicitly managed, just like values, and document the behavior of every operation with respect to paths, then the existence of a path might become a reliable signal.
-// However, that brings up another question: Do you *want* to be pruning the path each time?  Consider a loop where a zipper is acquired, dropped, acquired, dropped, etc.  If each acquisition means creating the path, and each drop means pruning it, that is a lot of wasted work.  On the other hand, just setting and clearing a value is a lot cheaper.
-// Anyway, let me know your thoughts.
-
-
-//GOAT, steps to moving `val_count` method onto a new "TrieSummary" trait, and removing it from the ZipperMoving trait
-// (and remove the node_val_count method from the TrieNode trait)
-//
-//GOAT - Wait until TrieNode trait is re-jigged to put root values on the node and not the
-// parent, because there is bound to be a lot of edge-case logic to account for root values
-// under the current TrieNode trait contract.  I'd prefer to only write this code once.
-//
-// 1. implement a caching_cata inner loop that uses the TrieNode API instead of the zipper API
-//       a. This means it has no access to the origin_path, and the cata implementation needs
-//          to maintain its own path_buffer
-//       b. It means paths are relative to the node where it is called
-//       c. It borrows the zipper, rather than taking ownership.
-//       d. It works from the focus, rather than from a the root.
-//       e. It can then be implemented on more zipper types that don't support ReadOnlyValues
-//          and ZipperMoving
-// 2. implement a val_count convenience on top of 1.
-
-//GOAT, Paths in caching Cata:  https://github.com/Adam-Vandervorst/PathMap/pull/8#discussion_r2004828957

--- a/src/line_list_node.rs
+++ b/src/line_list_node.rs
@@ -662,6 +662,22 @@ impl<V: Clone + Send + Sync, A: Allocator> LineListNode<V, A> {
         self.val_or_child0 = payload;
         self.header = Self::header0(is_child_ptr, key.len());
     }
+    /// Installs a payload in slot 0 after its key has already been written to `key_bytes`.
+    #[inline]
+    fn set_payload_0_for_existing_key(&mut self, key_len: usize, payload: ValOrChild<V, A>) {
+        debug_assert!(!self.is_used::<0>());
+        debug_assert!(key_len > 0 && key_len <= KEY_BYTES_CNT);
+        match payload {
+            ValOrChild::Child(child) => {
+                self.val_or_child0.child = ManuallyDrop::new(child);
+                self.header = Self::header0(true, key_len);
+            },
+            ValOrChild::Val(val) => {
+                self.val_or_child0.val = ManuallyDrop::new(LocalOrHeap::new(val));
+                self.header = Self::header0(false, key_len);
+            },
+        }
+    }
     #[inline]
     unsafe fn set_payload_1(&mut self, key: &[u8], is_child_ptr: bool, payload: ValOrChildUnion<V, A>) {
         let key_0_used_cnt = self.key_len_0();
@@ -1061,9 +1077,6 @@ impl<V: Clone + Send + Sync, A: Allocator> LineListNode<V, A> {
         //Overlap of 1 is legal if and only if ONE OF the following two conditions are true:
         // A: slot0 contains a value AND has a 1-byte key (a value at the shared byte, slot1 continuing below it)
         // B: both slots have a length of 1, and one is a value
-        //NOTE: without the length requirement in A, `drop_head` could leave (Val@"aa", Val@"ab"): a shape
-        // insertion never creates, that indexed descent (`descend_indexed_byte`) and the catamorphisms
-        // cannot traverse.  Factoring it yields the canonical Child@"a" -> {a, b}.
         let legal_overlap = overlap == 1 && (
             (!self.is_child_ptr::<0>() && key0.len() == 1) ||
             (!self.is_child_ptr::<1>() && key0.len()==1 && key1.len()==1 ));
@@ -1190,10 +1203,6 @@ impl<V: Clone + Send + Sync, A: Allocator> LineListNode<V, A> {
                     let restricted_node_result = if onward_key.len() == 0 {
                         self_onward_link.as_tagged().prestrict_dyn(onward_node)
                     } else {
-                        //`onward_key` may name a dangling byte of `other`: in its child mask, but
-                        // with no node behind it.  Nothing under it can validate a path, so the
-                        // slot is dropped, as `subtract_from_slot_contents` beside this already
-                        // does.  Calling `as_tagged` on the missing node was an explicit panic.
                         match onward_node.get_node_at_key(onward_key).into_option() {
                             Some(other_onward_node) => self_onward_link.as_tagged().prestrict_dyn(other_onward_node.as_tagged()),
                             None => AlgebraicResult::None,
@@ -2505,8 +2514,7 @@ impl<V: Clone + Send + Sync, A: Allocator> TrieNode<V, A> for LineListNode<V, A>
                 let other_dense_node = unsafe{ other.as_dense_unchecked() };
                 let mut new_node = other_dense_node.clone();
                 match new_node.merge_from_list_node(self) {
-                    //Both nodes were empty (e.g. a root emptied by `remove_branches` — always a LineListNode — joined
-                    // with an empty map whose root was materialized as a dense node); the join is empty too
+                    //Both nodes were empty so the join is empty too
                     AlgebraicStatus::None => {
                         debug_assert!(self.node_is_empty() && other_dense_node.node_is_empty());
                         AlgebraicResult::None
@@ -2639,43 +2647,48 @@ impl<V: Clone + Send + Sync, A: Allocator> TrieNode<V, A> for LineListNode<V, A>
         let key0_len = key0.len();
         let key1_len = key1.len();
 
-        //If byte_cnt < both key lengths but the shortened keys coincide, both slots now describe the same
-        // path and must be merged: two values join into one value, two children join into one child.  (A
-        // value and a child at the same key is the legal representation and needs no merge.)  Leaving two
-        // value slots on one key makes a path with two values: iteration sees it once, `val_count` twice.
-        if byte_cnt < key0_len && byte_cnt < key1_len && key0[byte_cnt..] == key1[byte_cnt..]
-            && temp_node.is_child_ptr::<0>() == temp_node.is_child_ptr::<1>() {
-            let new_key_len = key0_len - byte_cnt;
-            let mut new_key = [0u8; KEY_BYTES_CNT];
-            new_key[..new_key_len].copy_from_slice(&key0[byte_cnt..]);
-            //NOTE: take slot 1 first; taking slot 0 first may shift slot 1's contents down
-            let payload1 = temp_node.take_payload::<1>().unwrap();
-            let payload0 = temp_node.take_payload::<0>().unwrap();
-            let merged = match (payload0, payload1) {
-                (ValOrChild::Val(v0), ValOrChild::Val(v1)) => match v0.pjoin(&v1) {
-                    AlgebraicResult::Element(v) => Some(ValOrChild::Val(v)),
-                    AlgebraicResult::Identity(mask) => Some(ValOrChild::Val(if mask & SELF_IDENT > 0 { v0 } else { v1 })),
-                    AlgebraicResult::None => None,
-                },
-                (ValOrChild::Child(c0), ValOrChild::Child(c1)) => match c0.pjoin(&c1) {
-                    AlgebraicResult::Element(c) => Some(ValOrChild::Child(c)),
-                    AlgebraicResult::Identity(mask) => Some(ValOrChild::Child(if mask & SELF_IDENT > 0 { c0 } else { c1 })),
-                    AlgebraicResult::None => None,
-                },
-                _ => unreachable!(), //Both slots are the same kind; checked above
-            };
-            return match merged {
-                Some(payload) => {
-                    unsafe{ temp_node.set_payload_owned::<0>(&new_key[..new_key_len], payload); }
-                    debug_assert!(validate_node(&temp_node));
-                    Some(TrieNodeODRc::new_in(temp_node, self.alloc.clone()))
-                },
-                None => None,
-            }
-        }
+        //Both keys survive.  Shorten them in-place; if they collide, the two payloads must first
+        //be joined into one.  This is deliberately destructive: unlike `factor_prefix`, it avoids
+        //cloning values or child references just to replace this temporary node.
+        if byte_cnt < key0_len.min(key1_len) {
+            let shortened_key0 = &key0[byte_cnt..];
+            let shortened_key1 = &key1[byte_cnt..];
+            if shortened_key0 == shortened_key1
+                && temp_node.is_child_ptr::<0>() == temp_node.is_child_ptr::<1>() {
+                let new_key_len = shortened_key0.len();
+                unsafe {
+                    let key_bytes = temp_node.key_bytes.as_mut_ptr().cast::<u8>();
+                    core::ptr::copy(key_bytes.add(byte_cnt), key_bytes, new_key_len);
+                }
 
-        //If byte_cnt < both key lengths, reuse this node but shorten the keys
-        if byte_cnt < key0_len && byte_cnt < key1_len {
+                //Take slot 1 first: taking slot 0 would shift slot 1 into its place.
+                let payload1 = temp_node.take_payload::<1>().unwrap();
+                let payload0 = temp_node.take_payload::<0>().unwrap();
+                let merged = match (payload0, payload1) {
+                    (ValOrChild::Val(v0), ValOrChild::Val(v1)) => match v0.pjoin(&v1) {
+                        AlgebraicResult::Element(v) => Some(ValOrChild::Val(v)),
+                        AlgebraicResult::Identity(mask) => Some(ValOrChild::Val(if mask & SELF_IDENT > 0 { v0 } else { v1 })),
+                        AlgebraicResult::None => None,
+                    },
+                    (ValOrChild::Child(c0), ValOrChild::Child(c1)) => match c0.pjoin(&c1) {
+                        AlgebraicResult::Element(c) => Some(ValOrChild::Child(c)),
+                        AlgebraicResult::Identity(mask) => Some(ValOrChild::Child(if mask & SELF_IDENT > 0 { c0 } else { c1 })),
+                        AlgebraicResult::None => None,
+                    },
+                    _ => unreachable!(), //Both slots have the same kind; checked above.
+                };
+                return match merged {
+                    Some(payload) => {
+                        temp_node.set_payload_0_for_existing_key(new_key_len, payload);
+                        debug_assert!(validate_node(&temp_node));
+                        Some(TrieNodeODRc::new_in(temp_node, self.alloc.clone()))
+                    },
+                    None => None,
+                }
+            }
+
+            //The shortened keys are distinct, or form the legal value-and-child case.  Preserve
+            //slot order before factoring any now-illegal shared prefix.
             let mut slot0_child = temp_node.is_child_ptr::<0>();
             let mut slot1_child = temp_node.is_child_ptr::<1>();
             let mut new_key0_len = key0_len-byte_cnt;
@@ -3511,9 +3524,16 @@ mod tests {
         let mut source_node = LineListNode::<u64, GlobalAlloc>::new_in(global_alloc());
         source_node.node_set_val(b"1ab", 1).unwrap_or_else(|_| panic!());
         source_node.node_set_val(b"2ac", 2).unwrap_or_else(|_| panic!());
-        source_node.drop_head_dyn(1).unwrap();
+        let dropped = source_node.drop_head_dyn(1).unwrap();
 
-        let dropped_ref = source_node.as_tagged();
+        // Dropping the distinct leading bytes factors the shared "a" into an onward child.
+        let dropped_ref = dropped.as_tagged();
+        let (consumed, child) = dropped_ref.node_get_child(b"a").unwrap();
+        assert_eq!(consumed, 1);
+        assert_eq!(child.as_tagged().node_get_val(b"b"), Some(&1));
+        assert_eq!(child.as_tagged().node_get_val(b"c"), Some(&2));
+
+        // `get_node_at_key` must expose that same factored child as the focused node.
         let focus = dropped_ref.get_node_at_key(b"a");
         assert_eq!(focus.as_tagged().node_get_val(b"b"), Some(&1));
         assert_eq!(focus.as_tagged().node_get_val(b"c"), Some(&2));

--- a/src/line_list_node.rs
+++ b/src/line_list_node.rs
@@ -974,8 +974,7 @@ impl<V: Clone + Send + Sync, A: Allocator> LineListNode<V, A> {
         let node_key_0 = unsafe{ self.key_unchecked::<0>() };
         let mut overlap = find_prefix_overlap(key, node_key_0);
         if overlap > 0 {
-            // Replacing a downstream branch also needs to replace any payload strictly below `key`
-            // Hopefully the caller accounted for this
+            // Can we replace the downstream branch ptr?  Or do we need to split the node?
             if IS_CHILD && overlap == key.len() &&
                 (self.is_child_ptr::<0>() || node_key_0.len() > key.len()) {
                 let _ = self.take_payload::<0>();
@@ -1006,7 +1005,7 @@ impl<V: Clone + Send + Sync, A: Allocator> LineListNode<V, A> {
         let node_key_1 = unsafe{ self.key_unchecked::<1>() };
         let mut overlap = find_prefix_overlap(key, node_key_1);
         if overlap > 0 {
-            // See the corresponding slot_0 case above.  Replacing a downstream branch also needs to replace any payload strictly below `key`
+            //See if we should totally replace the existing downstream branch ptr, or split the node
             if IS_CHILD && overlap == key.len() &&
                 (self.is_child_ptr::<1>() || node_key_1.len() > key.len()) {
                 let _ = self.take_payload::<1>();
@@ -1930,6 +1929,10 @@ impl<V: Clone + Send + Sync, A: Allocator> TrieNode<V, A> for LineListNode<V, A>
 
     fn node_is_empty(&self) -> bool {
         !self.is_used::<0>()
+    }
+
+    fn debug_validate(&self) -> bool {
+        validate_node(self)
     }
 
     // *==--==**==--==**==--==**==--==**==--==**==--==**==--==**==--==**==--==**==--==**==--==**==--==*

--- a/src/line_list_node.rs
+++ b/src/line_list_node.rs
@@ -1057,10 +1057,13 @@ impl<V: Clone + Send + Sync, A: Allocator> LineListNode<V, A> {
         let (key0, key1) = self.get_both_keys();
         let overlap = find_prefix_overlap(key0, key1);
         //Overlap of 1 is legal if and only if ONE OF the following two conditions are true:
-        // A: slot0 contains a value
+        // A: slot0 contains a value AND has a 1-byte key (a value at the shared byte, slot1 continuing below it)
         // B: both slots have a length of 1, and one is a value
+        //NOTE: without the length requirement in A, `drop_head` could leave (Val@"aa", Val@"ab"): a shape
+        // insertion never creates, that indexed descent (`descend_indexed_byte`) and the catamorphisms
+        // cannot traverse.  Factoring it yields the canonical Child@"a" -> {a, b}.
         let legal_overlap = overlap == 1 && (
-            !self.is_child_ptr::<0>() ||
+            (!self.is_child_ptr::<0>() && key0.len() == 1) ||
             (!self.is_child_ptr::<1>() && key0.len()==1 && key1.len()==1 ));
 
         //If the overlap is illegal, split the prefix
@@ -1534,6 +1537,14 @@ fn merge_list_nodes<V: Clone + Send + Sync + Lattice, A: Allocator>(a: &LineList
         }
     }
 
+    //Two empty nodes (e.g. roots emptied by `remove_branches`) produce no entries at all.  This must be
+    // decided before touching `entries[0]`: reading it would be `assume_init` on uninitialized memory,
+    // and dropping the garbage payload it yields corrupts an arbitrary refcount.
+    if entry_cnt == 0 {
+        debug_assert!(a.node_is_empty() && b.node_is_empty());
+        return Ok(AlgebraicResult::None)
+    }
+
     //Do we have two or fewer paths, that can fit into a new ListNode?
     if entry_cnt <= 2 {
         let mut joined_node = LineListNode::new_in(a.alloc.clone());
@@ -1569,10 +1580,6 @@ fn merge_list_nodes<V: Clone + Send + Sync + Lattice, A: Allocator>(a: &LineList
                     debug_assert!(validate_node(&joined_node));
                     return Ok(AlgebraicResult::Element(joined_node))
                 }
-            },
-            0 => {
-                debug_assert!(a.node_is_empty() && b.node_is_empty());
-                return Ok(AlgebraicResult::None)
             },
             _ => unreachable!()
         }
@@ -2485,7 +2492,12 @@ impl<V: Clone + Send + Sync, A: Allocator> TrieNode<V, A> for LineListNode<V, A>
                 let other_dense_node = unsafe{ other.as_dense_unchecked() };
                 let mut new_node = other_dense_node.clone();
                 match new_node.merge_from_list_node(self) {
-                    AlgebraicStatus::None => unreachable!(), //Joining a non-empty node with another non-empty node should never produce an empty node
+                    //Both nodes were empty (e.g. a root emptied by `remove_branches` — always a LineListNode — joined
+                    // with an empty map whose root was materialized as a dense node); the join is empty too
+                    AlgebraicStatus::None => {
+                        debug_assert!(self.node_is_empty() && other_dense_node.node_is_empty());
+                        AlgebraicResult::None
+                    },
                     AlgebraicStatus::Identity => AlgebraicResult::Identity(COUNTER_IDENT),
                     AlgebraicStatus::Element => AlgebraicResult::Element(TrieNodeODRc::new_in(new_node, self.alloc.clone()))
                 }
@@ -2498,7 +2510,11 @@ impl<V: Clone + Send + Sync, A: Allocator> TrieNode<V, A> for LineListNode<V, A>
                 let other_dense_node = unsafe{ other.as_dense_unchecked() };
                 let mut new_node = other_dense_node.clone();
                 match new_node.merge_from_list_node(self) {
-                    AlgebraicStatus::None => unreachable!(), //Joining a non-empty node with another non-empty node should never produce an empty node
+                    //See the DENSE_BYTE_NODE_TAG arm: two empty nodes join to an empty result
+                    AlgebraicStatus::None => {
+                        debug_assert!(self.node_is_empty() && other_dense_node.node_is_empty());
+                        AlgebraicResult::None
+                    },
                     AlgebraicStatus::Identity => AlgebraicResult::Identity(COUNTER_IDENT),
                     AlgebraicStatus::Element => AlgebraicResult::Element(TrieNodeODRc::new_in(new_node, self.alloc.clone()))
                 }
@@ -2589,6 +2605,10 @@ impl<V: Clone + Send + Sync, A: Allocator> TrieNode<V, A> for LineListNode<V, A>
                     ValOrChild::Child(child) => child,
                     ValOrChild::Val(_) => unreachable!(),
                 };
+                //A dangling child (the empty sentinel) has nothing below the dropped bytes and can't be made mutable
+                if child.is_empty() {
+                    return None
+                }
                 if remaining_bytes > 0 {
                     return child.make_mut().drop_head_dyn(remaining_bytes)
                 } else {
@@ -2605,6 +2625,41 @@ impl<V: Clone + Send + Sync, A: Allocator> TrieNode<V, A> for LineListNode<V, A>
         let (key0, key1) = temp_node.get_both_keys();
         let key0_len = key0.len();
         let key1_len = key1.len();
+
+        //If byte_cnt < both key lengths but the shortened keys coincide, both slots now describe the same
+        // path and must be merged: two values join into one value, two children join into one child.  (A
+        // value and a child at the same key is the legal representation and needs no merge.)  Leaving two
+        // value slots on one key makes a path with two values: iteration sees it once, `val_count` twice.
+        if byte_cnt < key0_len && byte_cnt < key1_len && key0[byte_cnt..] == key1[byte_cnt..]
+            && temp_node.is_child_ptr::<0>() == temp_node.is_child_ptr::<1>() {
+            let new_key_len = key0_len - byte_cnt;
+            let mut new_key = [0u8; KEY_BYTES_CNT];
+            new_key[..new_key_len].copy_from_slice(&key0[byte_cnt..]);
+            //NOTE: take slot 1 first; taking slot 0 first may shift slot 1's contents down
+            let payload1 = temp_node.take_payload::<1>().unwrap();
+            let payload0 = temp_node.take_payload::<0>().unwrap();
+            let merged = match (payload0, payload1) {
+                (ValOrChild::Val(v0), ValOrChild::Val(v1)) => match v0.pjoin(&v1) {
+                    AlgebraicResult::Element(v) => Some(ValOrChild::Val(v)),
+                    AlgebraicResult::Identity(mask) => Some(ValOrChild::Val(if mask & SELF_IDENT > 0 { v0 } else { v1 })),
+                    AlgebraicResult::None => None,
+                },
+                (ValOrChild::Child(c0), ValOrChild::Child(c1)) => match c0.pjoin(&c1) {
+                    AlgebraicResult::Element(c) => Some(ValOrChild::Child(c)),
+                    AlgebraicResult::Identity(mask) => Some(ValOrChild::Child(if mask & SELF_IDENT > 0 { c0 } else { c1 })),
+                    AlgebraicResult::None => None,
+                },
+                _ => unreachable!(), //Both slots are the same kind; checked above
+            };
+            return match merged {
+                Some(payload) => {
+                    unsafe{ temp_node.set_payload_owned::<0>(&new_key[..new_key_len], payload); }
+                    debug_assert!(validate_node(&temp_node));
+                    Some(TrieNodeODRc::new_in(temp_node, self.alloc.clone()))
+                },
+                None => None,
+            }
+        }
 
         //If byte_cnt < both key lengths, reuse this node but shorten the keys
         if byte_cnt < key0_len && byte_cnt < key1_len {
@@ -2676,6 +2731,10 @@ impl<V: Clone + Send + Sync, A: Allocator> TrieNode<V, A> for LineListNode<V, A>
         };
 
         if let ValOrChild::Child(mut child_node) = merged_payload {
+            //A dangling child (the empty sentinel) has nothing below the dropped bytes and can't be made mutable
+            if child_node.is_empty() {
+                return None
+            }
             if chop_bytes == byte_cnt {
                 return Some(child_node)
             } else {

--- a/src/trie_node.rs
+++ b/src/trie_node.rs
@@ -3149,8 +3149,7 @@ impl<V: Lattice + Clone + Send + Sync, A: Allocator> TrieNodeODRc<V, A> {
     }
     #[inline]
     pub fn join_into(&mut self, node: TrieNodeODRc<V, A>) -> AlgebraicStatus {
-        //The empty sentinel (how a dangling path is represented) has no refcount word and cannot be
-        // made mutable.  Joining into it is a replacement, exactly as `EmptyNode::join_into_dyn` says,
+        //Joining into an empty node means replacement, exactly as `EmptyNode::join_into_dyn` says,
         // and joining an empty node into anything is the identity.
         if node.as_tagged().node_is_empty() {
             return if self.is_empty() { AlgebraicStatus::None } else { AlgebraicStatus::Identity }

--- a/src/trie_node.rs
+++ b/src/trie_node.rs
@@ -3115,6 +3115,16 @@ impl<V: Lattice + Clone + Send + Sync, A: Allocator> TrieNodeODRc<V, A> {
     }
     #[inline]
     pub fn join_into(&mut self, node: TrieNodeODRc<V, A>) -> AlgebraicStatus {
+        //The empty sentinel (how a dangling path is represented) has no refcount word and cannot be
+        // made mutable.  Joining into it is a replacement, exactly as `EmptyNode::join_into_dyn` says,
+        // and joining an empty node into anything is the identity.
+        if node.as_tagged().node_is_empty() {
+            return if self.is_empty() { AlgebraicStatus::None } else { AlgebraicStatus::Identity }
+        }
+        if self.is_empty() {
+            *self = node;
+            return AlgebraicStatus::Element
+        }
         let (status, result) = self.make_mut().join_into_dyn(node);
         match result {
             Ok(()) => {},

--- a/src/trie_node.rs
+++ b/src/trie_node.rs
@@ -185,6 +185,14 @@ pub(crate) trait TrieNode<V: Clone + Send + Sync, A: Allocator>: TrieNodeDowncas
     /// Returns `true` if the node contains no children nor values, otherwise false
     fn node_is_empty(&self) -> bool;
 
+    /// Performs node-type-specific structural checks used by debug test helpers.
+    ///
+    /// Node implementations with no additional local invariants may retain this
+    /// default. The trie-wide validator walks physical children separately.
+    fn debug_validate(&self) -> bool {
+        true
+    }
+
     /// Generates a new iter token, to iterate the children and values contained within this node
     ///
     /// The iter token is a node-local cursor.  It must represent any position within a node type, and
@@ -1205,6 +1213,19 @@ mod tagged_node_ref {
         }
 
         #[inline(always)]
+        pub fn debug_validate(&self) -> bool {
+            match self {
+                Self::DenseByteNode(node) => node.debug_validate(),
+                Self::LineListNode(node) => node.debug_validate(),
+                #[cfg(feature = "bridge_nodes")]
+                Self::BridgeNode(node) => node.debug_validate(),
+                Self::CellByteNode(node) => node.debug_validate(),
+                Self::TinyRefNode(node) => node.debug_validate(),
+                Self::EmptyNode => <EmptyNode as TrieNode<V, A>>::debug_validate(&EMPTY_NODE),
+            }
+        }
+
+        #[inline(always)]
         pub fn new_iter_token(&self) -> IterToken {
             match self {
                 Self::DenseByteNode(node) => node.new_iter_token(),
@@ -1824,6 +1845,19 @@ mod tagged_node_ref {
                 LINE_LIST_NODE_TAG => unsafe{ &*ptr.cast::<LineListNode<V, A>>() }.node_is_empty(),
                 CELL_BYTE_NODE_TAG => unsafe{ &*ptr.cast::<CellByteNode<V, A>>() }.node_is_empty(),
                 TINY_REF_NODE_TAG => unsafe{ &*ptr.cast::<TinyRefNode<V, A>>() }.node_is_empty(),
+                _ => unsafe{ unreachable_unchecked() }
+            }
+        }
+
+        #[inline]
+        pub fn debug_validate(&self) -> bool {
+            let (ptr, tag) = self.ptr.get_raw_parts();
+            match tag {
+                EMPTY_NODE_TAG => true,
+                DENSE_BYTE_NODE_TAG => unsafe{ &*ptr.cast::<DenseByteNode<V, A>>() }.debug_validate(),
+                LINE_LIST_NODE_TAG => unsafe{ &*ptr.cast::<LineListNode<V, A>>() }.debug_validate(),
+                CELL_BYTE_NODE_TAG => unsafe{ &*ptr.cast::<CellByteNode<V, A>>() }.debug_validate(),
+                TINY_REF_NODE_TAG => unsafe{ &*ptr.cast::<TinyRefNode<V, A>>() }.debug_validate(),
                 _ => unsafe{ unreachable_unchecked() }
             }
         }
@@ -3254,6 +3288,31 @@ impl<V: DistributiveLattice + Clone + Send + Sync, A: Allocator> DistributiveLat
                 }
             }
         }
+    }
+}
+
+/// Asserts the local invariants of every physical node reachable from `root`.
+///
+/// This intentionally knows only the [`TrieNode`] interface: each concrete
+/// node type supplies its own `debug_validate` implementation.
+#[cfg(test)]
+pub(crate) fn assert_valid_trie<V: Clone + Send + Sync, A: Allocator>(root: Option<&TrieNodeODRc<V, A>>) {
+    fn walk<V: Clone + Send + Sync, A: Allocator>(node: &TrieNodeODRc<V, A>) {
+        if node.is_empty() {
+            return;
+        }
+
+        let tagged = node.as_tagged();
+        assert!(tagged.debug_validate(), "invalid trie node");
+        let (mut token, mut child) = tagged.node_child_iter_start();
+        while let Some(child_node) = child {
+            walk(child_node);
+            (token, child) = tagged.node_child_iter_next(token);
+        }
+    }
+
+    if let Some(root) = root {
+        walk(root);
     }
 }
 

--- a/src/write_zipper.rs
+++ b/src/write_zipper.rs
@@ -1531,37 +1531,43 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
     }
     /// See [ZipperWriting::graft_masked_branches]
     pub fn graft_masked_branches<Z: ZipperInfallibleSubtries<V, A>>(&mut self, src: &Z, child_mask: ByteMask, remove_unset: bool) {
-
-        let src_mask = src.child_mask() & child_mask;
-        if remove_unset {
-            self.remove_branches(false);
-        } else {
-            //Remove branches that will be absent from the final node because they are set in child_mask and absent from src
-            // It will be faster to overwrite a branch than re-add it after removing it, so we are focussed on the difference
-            let absent = child_mask & src_mask.not();
-            self.remove_unmasked_branches(absent.not(), false);
-        }
-        match src_mask.count_bits() {
-            0 => {}
+        // The dense-node merge handles both pieces of the contract directly: it removes
+        // masked branches absent from `src`, and (when requested) every unmasked branch.
+        // Do not pre-clear or pre-filter `self`: that throws away the destination node the
+        // merge is meant to copy selectively, turning the bulk path into a rebuild.
+        match child_mask.count_bits() {
+            0 => {
+                if remove_unset {
+                    self.remove_branches(false);
+                }
+            }
             1 => {
-                let byte = src_mask.indexed_bit::<true>(0).expect("one bit set");
+                if remove_unset {
+                    self.remove_branches(false);
+                }
+                // SAFETY: this arm is selected only when `child_mask` has one bit.
+                let byte = unsafe { child_mask.indexed_bit::<true>(0).unwrap_unchecked() };
                 self.descend_to_byte(byte);
                 self.graft_src_at(src, &[byte]);
                 self.ascend_byte();
             }
             2 => {
-                let first_byte = src_mask.indexed_bit::<true>(0).expect("some bit set");
+                if remove_unset {
+                    self.remove_branches(false);
+                }
+                // SAFETY: this arm is selected only when `child_mask` has two bits.
+                let first_byte = unsafe { child_mask.indexed_bit::<true>(0).unwrap_unchecked() };
                 self.descend_to_byte(first_byte);
                 self.graft_src_at(src, &[first_byte]);
                 self.ascend_byte();
 
-                let second_byte = src_mask.next_bit(first_byte).expect("two bits set");
+                // SAFETY: `first_byte` is one of the two set bits, so it has a successor.
+                let second_byte = unsafe { child_mask.next_bit(first_byte).unwrap_unchecked() };
                 self.descend_to_byte(second_byte);
                 self.graft_src_at(src, &[second_byte]);
                 self.ascend_byte();
             }
             _ => {
-                let child_mask = src_mask;
                 let src_focus = src.get_focus();
                 match src_focus.try_as_tagged() {
                     Some(src_tagged) => {

--- a/src/write_zipper.rs
+++ b/src/write_zipper.rs
@@ -1563,7 +1563,22 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
                 self.ascend_byte();
             }
             _ => {
-                match src.get_focus().try_as_tagged() {
+                //A source with none of the masked branches has nothing to graft, and the set
+                // bits it lacks must end up absent here (see the doc comment).  This used to
+                // fall through to the merge below and split the focus first, which unwraps a
+                // node that does not exist when the focus is a dangling tip or an empty root.
+                let src_focus = src.get_focus();
+                let src_has_branches = src_focus.try_as_tagged().map(|n| {
+                    //A TinyRefNode answers no structural queries; ask its full form instead
+                    let mask = match n {
+                        TaggedNodeRef::TinyRefNode(tiny) => tiny.into_full()
+                            .map(|full| full.node_branches_mask(&[]))
+                            .unwrap_or(ByteMask::EMPTY),
+                        _ => n.node_branches_mask(&[]),
+                    };
+                    (mask & child_mask).count_bits() > 0
+                }).unwrap_or(false);
+                match src_focus.try_as_tagged().filter(|_| src_has_branches) {
                     Some(src_tagged) => {
                         // Split the focus if we're in the middle of another node
                         let self_focus_node = match self.try_borrow_focus_mut() {
@@ -1618,7 +1633,6 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
                         }
                     },
                     None => {
-                        debug_assert_eq!(src.child_count(), 0);
                         if remove_unset {
                             self.remove_branches(false);
                         } else {

--- a/src/write_zipper.rs
+++ b/src/write_zipper.rs
@@ -1824,16 +1824,20 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
                 }
             },
             Some(src) => {
+                //A dangling source focus is taken as the empty sentinel: nothing to join, and not
+                // a node graft_internal may be handed
+                if src.as_tagged().node_is_empty() {
+                    return if self.get_focus().is_none() { AlgebraicStatus::None } else { AlgebraicStatus::Identity }
+                }
                 match self.take_focus(false) {
-                    Some(mut self_node) => {
-                        let (status, result) = self_node.make_mut().join_into_dyn(src);
-                        match result {
-                            Ok(()) => self.graft_internal(Some(self_node)),
-                            Err(replacement_node) => self.graft_internal(Some(replacement_node)),
-                        }
+                    //A dangling destination focus is taken as the sentinel too, which cannot be
+                    // made mutable; the join into nothing is the source itself
+                    Some(mut self_node) if !self_node.as_tagged().node_is_empty() => {
+                        let status = self_node.join_into(src);
+                        self.graft_internal(Some(self_node));
                         status
                     },
-                    None => {
+                    _ => {
                         self.graft_internal(Some(src));
                         AlgebraicStatus::Element
                     }
@@ -6103,5 +6107,53 @@ mod tests {
         let n = map.read_zipper().into_cata_cached(|_m, ws: &mut [usize], v: Option<&()>| ws.iter().sum::<usize>() + v.is_some() as usize);
         assert_eq!(n, 3);
         assert_valid_nodes(&map);
+    }
+
+    /// Issue #85: `join_into_take` at a dangling destination focus panicked in make_unique
+    /// (take_focus hands back the empty sentinel), and a dangling *source* focus handed the
+    /// sentinel to graft_internal.
+    #[test]
+    fn write_zipper_join_into_take_at_dangling_focus() {
+        fn mk(keys: &[&[u8]]) -> PathMap<()> { let mut m = PathMap::new(); for k in keys { m.set_val_at(k, ()); } m }
+        fn keys(m: &PathMap<()>) -> Vec<String> { m.iter().map(|(k, _)| String::from_utf8_lossy(&k).into_owned()).collect() }
+        fn dangling_c() -> PathMap<()> {
+            let mut m = mk(&[b"ca", b"cb", b"d"]);
+            { let mut wz = m.write_zipper(); wz.descend_to(b"c"); wz.remove_branches(false); }
+            assert_eq!(keys(&m), ["d"]);
+            m
+        }
+        //Dangling destination
+        let mut m = dangling_c();
+        let mut o = mk(&[b"x"]);
+        {
+            let mut wz = m.write_zipper();
+            wz.descend_to(b"c");
+            let mut src = o.write_zipper();
+            assert_eq!(wz.join_into_take(&mut src, false), AlgebraicStatus::Element);
+        }
+        assert_eq!(keys(&m), ["cx", "d"]);
+        assert_eq!(keys(&o), Vec::<String>::new());
+
+        //Dangling source
+        let mut m = mk(&[b"x"]);
+        let mut o = dangling_c();
+        {
+            let mut wz = m.write_zipper();
+            let mut src = o.write_zipper();
+            src.descend_to(b"c");
+            assert_eq!(wz.join_into_take(&mut src, false), AlgebraicStatus::Identity);
+        }
+        assert_eq!(keys(&m), ["x"]);
+
+        //Both real, which already worked
+        let mut m = mk(&[b"cy", b"d"]);
+        let mut o = mk(&[b"x"]);
+        {
+            let mut wz = m.write_zipper();
+            wz.descend_to(b"c");
+            let mut src = o.write_zipper();
+            assert_eq!(wz.join_into_take(&mut src, false), AlgebraicStatus::Element);
+        }
+        assert_eq!(keys(&m), ["cx", "cy", "d"]);
     }
 }

--- a/src/write_zipper.rs
+++ b/src/write_zipper.rs
@@ -4311,28 +4311,6 @@ mod tests {
         assert_eq!(map.iter().map(|(k, _v)| k).collect::<Vec<Vec<u8>>>(), ref_keys);
     }
 
-    /// Walk every physical node and check `LineListNode`'s structural invariants.
-    fn assert_valid_nodes<V: Clone + Send + Sync + Unpin>(map: &PathMap<V>) {
-        fn walk<V: Clone + Send + Sync + Unpin>(node: &TrieNodeODRc<V, GlobalAlloc>) {
-            if node.is_empty() {
-                return;
-            }
-            let tagged = node.as_tagged();
-            if let TaggedNodeRef::LineListNode(line_list) = tagged {
-                assert!(crate::line_list_node::validate_node(line_list));
-            }
-            let (mut token, mut child) = tagged.node_child_iter_start();
-            while let Some(child_node) = child {
-                walk(child_node);
-                (token, child) = tagged.node_child_iter_next(token);
-            }
-        }
-
-        if let Some(root) = map.root() {
-            walk(root);
-        }
-    }
-
     /// A focus in the middle of a compressed key run must replace the old run,
     /// rather than retain it alongside the prefixed copy.
     #[test]
@@ -4351,7 +4329,7 @@ mod tests {
         let mut rz = map.read_zipper();
         rz.descend_to(b"aa");
         assert!(!rz.path_exists(), "stale key run must be gone");
-        assert_valid_nodes(&map);
+        assert_valid_trie(map.root());
 
         // The compressed run can continue into a branch as well.
         let mut map = PathMap::<()>::new();
@@ -4365,7 +4343,7 @@ mod tests {
             map.iter().map(|(k, _)| k).collect::<Vec<Vec<u8>>>(),
             vec![b"abXcd".to_vec(), b"abXce".to_vec()]
         );
-        assert_valid_nodes(&map);
+        assert_valid_trie(map.root());
     }
 
     #[test]
@@ -4382,7 +4360,7 @@ mod tests {
             map.iter().map(|(k, _)| k).collect::<Vec<Vec<u8>>>(),
             vec![b"a".to_vec(), b"aZb".to_vec(), b"aZc".to_vec()]
         );
-        assert_valid_nodes(&map);
+        assert_valid_trie(map.root());
     }
 
     #[test]
@@ -4401,7 +4379,7 @@ mod tests {
         drop(wz);
         assert_eq!(map.get(b"ab"), Some(&1));
         assert_eq!(map.get(b"ac"), Some(&2));
-        assert_valid_nodes(&map);
+        assert_valid_trie(map.root());
     }
 
     #[test]
@@ -4421,7 +4399,7 @@ mod tests {
                 vec![vec![0, src_key[1]]]
             );
             assert_eq!(dst.get([0, src_key[1]]), Some(&8));
-            assert_valid_nodes(&dst);
+            assert_valid_trie(dst.root());
         }
     }
 
@@ -4456,7 +4434,7 @@ mod tests {
             expected,
             "keys {keys:?}, focus {focus:?}, prefix {prefix:?}"
         );
-        assert_valid_nodes(&map);
+        assert_valid_trie(map.root());
     }
 
     #[test]
@@ -6067,23 +6045,6 @@ mod tests {
             btm.clone().into_write_zipper(path)
     });
 
-    /// Walks every physical node and checks LineListNode's structural invariants
-    fn assert_valid_nodes<V: Clone + Send + Sync + Unpin>(map: &PathMap<V>) {
-        fn walk<V: Clone + Send + Sync + Unpin>(node: &TrieNodeODRc<V, GlobalAlloc>) {
-            if node.is_empty() { return }
-            let tagged = node.as_tagged();
-            if let TaggedNodeRef::LineListNode(ln) = tagged {
-                assert!(crate::line_list_node::validate_node(ln));
-            }
-            let (mut tok, mut child) = tagged.node_child_iter_start();
-            while let Some(child_node) = child {
-                walk(child_node);
-                (tok, child) = tagged.node_child_iter_next(tok);
-            }
-        }
-        if let Some(root) = map.root() { walk(root); }
-    }
-
     /// A map holding `extra` plus `{ca, cb}`, after `remove_branches(prune = false)` at "c": the node
     /// holding "c" now has a dangling child there, i.e. the empty sentinel.  With one extra key the
     /// parent is a LineListNode; with three or more it is a DenseByteNode carrying the sentinel in a CoFree.
@@ -6105,12 +6066,12 @@ mod tests {
         let mut other = PathMap::<()>::new(); other.set_val_at(b"ca", ());
         let joined = dense_with_dangling_child().join(&other);
         assert_eq!(joined.iter().map(|(k, _)| k).collect::<Vec<Vec<u8>>>(), vec![b"ca".to_vec(), b"d".to_vec(), b"e".to_vec(), b"f".to_vec()]);
-        assert_valid_nodes(&joined);
+        assert_valid_trie(joined.root());
 
         let mut m = dense_with_dangling_child();
         m.write_zipper().join_into(&other.read_zipper());
         assert_eq!(m.iter().count(), 4);
-        assert_valid_nodes(&m);
+        assert_valid_trie(m.root());
 
         //Symmetric: the dangling child arrives from the *other* operand
         let mut dense = PathMap::<()>::new();
@@ -6119,7 +6080,7 @@ mod tests {
         assert_eq!(joined.iter().count(), 4);
         dense.write_zipper().join_into(&lln_with_dangling_child().read_zipper());
         assert_eq!(dense.iter().count(), 4);
-        assert_valid_nodes(&dense);
+        assert_valid_trie(dense.root());
     }
 
     /// Dropping head bytes over a dangling sentinel child, in both node types.  (Values that sit within
@@ -6132,7 +6093,7 @@ mod tests {
         let mut m = with_dangling_c(&[b"dx", b"dy", b"ex", b"fz"]); // dense parent
         assert!(m.write_zipper().join_k_path_into(1, false));
         assert_eq!(keys(&m), vec![b"x".to_vec(), b"y".to_vec(), b"z".to_vec()]);
-        assert_valid_nodes(&m);
+        assert_valid_trie(m.root());
 
         let mut m = with_dangling_c(&[b"dx", b"dy", b"ex", b"fz"]);
         assert!(m.write_zipper().drop_head(1));
@@ -6141,7 +6102,7 @@ mod tests {
         let mut m = with_dangling_c(&[b"dx"]); // LineListNode parent
         assert!(m.write_zipper().join_k_path_into(1, false));
         assert_eq!(keys(&m), vec![b"x".to_vec()]);
-        assert_valid_nodes(&m);
+        assert_valid_trie(m.root());
 
         //Only a dangling path below the focus: the branch is cleared, nothing is grafted
         let mut m = with_dangling_c(&[]);
@@ -6176,12 +6137,13 @@ mod tests {
             let a = gen_map(&mut rng);
             let b = gen_map(&mut rng);
             let keys = |m: &PathMap<()>| m.iter().map(|(k, _)| k).collect::<Vec<Vec<u8>>>();
-            assert_valid_nodes(&a); assert_valid_nodes(&b);
+            assert_valid_trie(a.root());
+            assert_valid_trie(b.root());
 
             let mut expected = keys(&a); expected.extend(keys(&b)); expected.sort(); expected.dedup();
             let joined = a.join(&b);
             assert_eq!(keys(&joined), expected, "join");
-            assert_valid_nodes(&joined);
+            assert_valid_trie(joined.root());
             let mut a2 = a.clone();
             a2.write_zipper().join_into(&b.read_zipper());
             assert_eq!(keys(&a2), expected, "join_into");
@@ -6194,7 +6156,7 @@ mod tests {
             a3.write_zipper().join_k_path_into(k, false);
             assert_eq!(keys(&a3), expected, "join_k_path_into({k})");
             assert_eq!(a3.val_count(), expected.len(), "join_k_path_into({k}) val_count");
-            assert_valid_nodes(&a3);
+            assert_valid_trie(a3.root());
         }
     }
 
@@ -6227,11 +6189,11 @@ mod tests {
         };
         let joined = dangling_c().join(&dangling_c());
         assert_eq!(joined.iter().map(|(k, _)| k).collect::<Vec<Vec<u8>>>(), vec![b"d".to_vec(), b"e".to_vec(), b"f".to_vec()]);
-        assert_valid_nodes(&joined);
+        assert_valid_trie(joined.root());
         let mut a = dangling_c();
         a.write_zipper().join_into(&dangling_c().read_zipper());
         assert_eq!(a.iter().count(), 3);
-        assert_valid_nodes(&a);
+        assert_valid_trie(a.root());
     }
 
     /// `join_k_path_into` where the two slots of a LineListNode shorten onto the *same* key: the payloads
@@ -6246,7 +6208,7 @@ mod tests {
         assert!(m.write_zipper().join_k_path_into(3, false));
         assert_eq!(keys(&m), vec![b"a".to_vec()]);
         assert_eq!(m.val_count(), 1);
-        assert_valid_nodes(&m);
+        assert_valid_trie(m.root());
 
         //two children collapsing onto one key
         let mut m = PathMap::<()>::new();
@@ -6254,7 +6216,7 @@ mod tests {
         let mut wz = m.write_zipper(); wz.descend_to(b"a"); assert!(wz.join_k_path_into(1, false)); drop(wz);
         assert_eq!(keys(&m), vec![b"ax1".to_vec(), b"ax2".to_vec(), b"ax3".to_vec()]);
         assert_eq!(m.val_count(), 3);
-        assert_valid_nodes(&m);
+        assert_valid_trie(m.root());
 
         //a value and a child on the same key is the legal representation and is left alone
         let mut m = PathMap::<()>::new();
@@ -6299,7 +6261,7 @@ mod tests {
         //the (zipper-driven) cached cata must agree with iteration
         let n = m.read_zipper().into_cata_cached(|_m, ws: &mut [usize], v: Option<&()>| ws.iter().sum::<usize>() + v.is_some() as usize);
         assert_eq!(n, 2);
-        assert_valid_nodes(&m);
+        assert_valid_trie(m.root());
 
         //the same through a shared (grafted) subtrie, as the randomized program found it
         let mut map = PathMap::<()>::new(); map.set_val_at(b"", ());
@@ -6309,7 +6271,7 @@ mod tests {
         assert!(map.write_zipper().join_k_path_into(1, false));
         let n = map.read_zipper().into_cata_cached(|_m, ws: &mut [usize], v: Option<&()>| ws.iter().sum::<usize>() + v.is_some() as usize);
         assert_eq!(n, 3);
-        assert_valid_nodes(&map);
+        assert_valid_trie(map.root());
     }
 
     /// Issue #85: `join_into_take` at a dangling destination focus panicked in make_unique

--- a/src/write_zipper.rs
+++ b/src/write_zipper.rs
@@ -1531,17 +1531,14 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
     }
     /// See [ZipperWriting::graft_masked_branches]
     pub fn graft_masked_branches<Z: ZipperInfallibleSubtries<V, A>>(&mut self, src: &Z, child_mask: ByteMask, remove_unset: bool) {
-        //Only the branches the source actually has are grafted.  The masked bits it lacks "will
-        // be non-existent in `self`" (doc comment above), so they are removed here first, for
-        // every arm alike.  The one- and two-bit arms used to descend to each masked byte and
-        // graft whatever the source had there, which for an absent branch meant removing the
-        // branches at a location that need not exist -- and left a dangling child behind --
-        // while the arm below removed the same branch outright.
+
         let src_mask = src.child_mask() & child_mask;
-        let absent = child_mask & src_mask.not();
         if remove_unset {
             self.remove_branches(false);
-        } else if absent.count_bits() > 0 {
+        } else {
+            //Remove branches that will be absent from the final node because they are set in child_mask and absent from src
+            // It will be faster to overwrite a branch than re-add it after removing it, so we are focussed on the difference
+            let absent = child_mask & src_mask.not();
             self.remove_unmasked_branches(absent.not(), false);
         }
         match src_mask.count_bits() {
@@ -2812,15 +2809,11 @@ mod mut_node_stack {
         pub fn top(&self) -> Option<TaggedNodeRef<'_, V, A>> {
             match self.stack.last() {
                 Some(top) => Some(unsafe{ top.as_tagged() }),
-                None => unsafe{ self.root.map(|mut ptr| {
+                None => unsafe{ self.root.and_then(|mut ptr| {
                     let ptr = ptr.as_mut();
                     match ptr.is_empty() {
-                        //An empty root is still the node the focus lives under; answering
-                        // `None` here while `top_mut` answers the node made every read
-                        // through the stack unwrap after `remove_branches` (or a
-                        // `join_k_path_into` that collapsed everything) emptied the root.
-                        true => TaggedNodeRef::empty_node(),
-                        false => ptr.make_mut().cast()
+                        true => None,
+                        false => Some(ptr.make_mut().cast())
                     }
                 }) }
             }

--- a/src/write_zipper.rs
+++ b/src/write_zipper.rs
@@ -1531,61 +1531,61 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
     }
     /// See [ZipperWriting::graft_masked_branches]
     pub fn graft_masked_branches<Z: ZipperInfallibleSubtries<V, A>>(&mut self, src: &Z, child_mask: ByteMask, remove_unset: bool) {
-        match child_mask.count_bits() {
-            0 => {
-                if remove_unset {
-                    self.remove_branches(false);
-                }
-            }
+        //Only the branches the source actually has are grafted.  The masked bits it lacks "will
+        // be non-existent in `self`" (doc comment above), so they are removed here first, for
+        // every arm alike.  The one- and two-bit arms used to descend to each masked byte and
+        // graft whatever the source had there, which for an absent branch meant removing the
+        // branches at a location that need not exist -- and left a dangling child behind --
+        // while the arm below removed the same branch outright.
+        let src_mask = src.child_mask() & child_mask;
+        let absent = child_mask & src_mask.not();
+        if remove_unset {
+            self.remove_branches(false);
+        } else if absent.count_bits() > 0 {
+            self.remove_unmasked_branches(absent.not(), false);
+        }
+        match src_mask.count_bits() {
+            0 => {}
             1 => {
-                if remove_unset {
-                    self.remove_branches(false);
-                }
-
-                let byte = child_mask.indexed_bit::<true>(0).expect("one bit set");
+                let byte = src_mask.indexed_bit::<true>(0).expect("one bit set");
                 self.descend_to_byte(byte);
                 self.graft_src_at(src, &[byte]);
                 self.ascend_byte();
             }
             2 => {
-                if remove_unset {
-                    self.remove_branches(false);
-                }
-
-                let first_byte = child_mask.indexed_bit::<true>(0).expect("some bit set");
+                let first_byte = src_mask.indexed_bit::<true>(0).expect("some bit set");
                 self.descend_to_byte(first_byte);
                 self.graft_src_at(src, &[first_byte]);
                 self.ascend_byte();
 
-                let second_byte = child_mask.next_bit(first_byte).expect("two bits set");
+                let second_byte = src_mask.next_bit(first_byte).expect("two bits set");
                 self.descend_to_byte(second_byte);
                 self.graft_src_at(src, &[second_byte]);
                 self.ascend_byte();
             }
             _ => {
-                //A source with none of the masked branches has nothing to graft, and the set
-                // bits it lacks must end up absent here (see the doc comment).  This used to
-                // fall through to the merge below and split the focus first, which unwraps a
-                // node that does not exist when the focus is a dangling tip or an empty root.
+                let child_mask = src_mask;
                 let src_focus = src.get_focus();
-                let src_has_branches = src_focus.try_as_tagged().map(|n| {
-                    //A TinyRefNode answers no structural queries; ask its full form instead
-                    let mask = match n {
-                        TaggedNodeRef::TinyRefNode(tiny) => tiny.into_full()
-                            .map(|full| full.node_branches_mask(&[]))
-                            .unwrap_or(ByteMask::EMPTY),
-                        _ => n.node_branches_mask(&[]),
-                    };
-                    (mask & child_mask).count_bits() > 0
-                }).unwrap_or(false);
-                match src_focus.try_as_tagged().filter(|_| src_has_branches) {
+                match src_focus.try_as_tagged() {
                     Some(src_tagged) => {
-                        // Split the focus if we're in the middle of another node
+                        // Split the focus if we're in the middle of another node.  A focus that
+                        // is a dangling stub (an empty child node, which `get_child_mut` declines
+                        // to hand out) has no node to merge into even after the split, so the
+                        // branches are merged into a fresh node that is grafted in afterwards.
+                        // This used to unwrap the missing node.
+                        let mut fresh_node: Option<TrieNodeODRc<V, A>> = None;
                         let self_focus_node = match self.try_borrow_focus_mut() {
                             Some(node) => node,
                             None => {
                                 self.split_at_focus();
-                                self.try_borrow_focus_mut().unwrap()
+                                match self.try_borrow_focus_mut() {
+                                    Some(node) => node,
+                                    None => {
+                                        let alloc = self.alloc.clone();
+                                        fresh_node.insert(TrieNodeODRc::new_in(
+                                            crate::dense_byte_node::DenseByteNode::<V, A>::new_in(alloc.clone()), alloc))
+                                    }
+                                }
                             }
                         };
                         match src_tagged {
@@ -1630,6 +1630,11 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
                                     self.remove_unmasked_branches(child_mask.not(), false);
                                 }
                             },
+                        }
+                        if let Some(node) = fresh_node {
+                            if !node.as_tagged().node_is_empty() {
+                                self.graft_internal(Some(node));
+                            }
                         }
                     },
                     None => {

--- a/src/write_zipper.rs
+++ b/src/write_zipper.rs
@@ -2801,11 +2801,15 @@ mod mut_node_stack {
         pub fn top(&self) -> Option<TaggedNodeRef<'_, V, A>> {
             match self.stack.last() {
                 Some(top) => Some(unsafe{ top.as_tagged() }),
-                None => unsafe{ self.root.and_then(|mut ptr| {
+                None => unsafe{ self.root.map(|mut ptr| {
                     let ptr = ptr.as_mut();
                     match ptr.is_empty() {
-                        true => None,
-                        false => Some(ptr.make_mut().cast())
+                        //An empty root is still the node the focus lives under; answering
+                        // `None` here while `top_mut` answers the node made every read
+                        // through the stack unwrap after `remove_branches` (or a
+                        // `join_k_path_into` that collapsed everything) emptied the root.
+                        true => TaggedNodeRef::empty_node(),
+                        false => ptr.make_mut().cast()
                     }
                 }) }
             }

--- a/src/write_zipper.rs
+++ b/src/write_zipper.rs
@@ -1826,7 +1826,10 @@ impl <'a, 'path, V: Clone + Send + Sync + Unpin, A: Allocator + 'a> WriteZipperC
     pub fn join_k_path_into(&mut self, byte_cnt: usize, prune: bool) -> bool where V: Lattice {
         let result = match self.get_focus().into_option() {
             Some(mut self_node) => {
-                let new_node = self_node.make_mut().drop_head_dyn(byte_cnt);
+                //An empty result means nothing remains below the focus: clear the branch rather than
+                // grafting an empty node (`graft_internal` requires a non-empty source)
+                let new_node = self_node.make_mut().drop_head_dyn(byte_cnt)
+                    .filter(|node| !node.as_tagged().node_is_empty());
                 let result = new_node.is_some();
                 self.graft_internal(new_node);
                 result
@@ -5833,4 +5836,249 @@ mod tests {
         |btm: &mut PathMap<()>, path: &[u8]| -> WriteZipperOwned<()> {
             btm.clone().into_write_zipper(path)
     });
+
+    /// Walks every physical node and checks LineListNode's structural invariants
+    fn assert_valid_nodes<V: Clone + Send + Sync + Unpin>(map: &PathMap<V>) {
+        fn walk<V: Clone + Send + Sync + Unpin>(node: &TrieNodeODRc<V, GlobalAlloc>) {
+            if node.is_empty() { return }
+            let tagged = node.as_tagged();
+            if let TaggedNodeRef::LineListNode(ln) = tagged {
+                assert!(crate::line_list_node::validate_node(ln));
+            }
+            let (mut tok, mut child) = tagged.node_child_iter_start();
+            while let Some(child_node) = child {
+                walk(child_node);
+                (tok, child) = tagged.node_child_iter_next(tok);
+            }
+        }
+        if let Some(root) = map.root() { walk(root); }
+    }
+
+    /// A map holding `extra` plus `{ca, cb}`, after `remove_branches(prune = false)` at "c": the node
+    /// holding "c" now has a dangling child there, i.e. the empty sentinel.  With one extra key the
+    /// parent is a LineListNode; with three or more it is a DenseByteNode carrying the sentinel in a CoFree.
+    fn with_dangling_c(extra: &[&[u8]]) -> PathMap<()> {
+        let mut m = PathMap::<()>::new();
+        for k in [b"ca".as_slice(), b"cb"] { m.set_val_at(k, ()); }
+        for k in extra { m.set_val_at(k, ()); }
+        let mut wz = m.write_zipper(); wz.descend_to(b"c"); wz.remove_branches(false); drop(wz);
+        let mut rz = m.read_zipper(); rz.descend_to(b"c");
+        assert!(rz.path_exists());
+        m
+    }
+    fn lln_with_dangling_child() -> PathMap<()> { with_dangling_c(&[b"d"]) }
+    fn dense_with_dangling_child() -> PathMap<()> { with_dangling_c(&[b"d", b"e", b"f"]) }
+
+    /// Joining into a dense node whose child at that byte is a dangling sentinel
+    #[test]
+    fn write_zipper_join_into_dangling_dense_child() {
+        let mut other = PathMap::<()>::new(); other.set_val_at(b"ca", ());
+        let joined = dense_with_dangling_child().join(&other);
+        assert_eq!(joined.iter().map(|(k, _)| k).collect::<Vec<Vec<u8>>>(), vec![b"ca".to_vec(), b"d".to_vec(), b"e".to_vec(), b"f".to_vec()]);
+        assert_valid_nodes(&joined);
+
+        let mut m = dense_with_dangling_child();
+        m.write_zipper().join_into(&other.read_zipper());
+        assert_eq!(m.iter().count(), 4);
+        assert_valid_nodes(&m);
+
+        //Symmetric: the dangling child arrives from the *other* operand
+        let mut dense = PathMap::<()>::new();
+        for k in [b"ca".as_slice(), b"d", b"e", b"f"] { dense.set_val_at(k, ()); }
+        let joined = dense.join(&lln_with_dangling_child());
+        assert_eq!(joined.iter().count(), 4);
+        dense.write_zipper().join_into(&lln_with_dangling_child().read_zipper());
+        assert_eq!(dense.iter().count(), 4);
+        assert_valid_nodes(&dense);
+    }
+
+    /// Dropping head bytes over a dangling sentinel child, in both node types.  (Values that sit within
+    /// the dropped bytes are discarded by `join_k_path_into`; only the downstream subtries are joined.)
+    #[test]
+    #[allow(deprecated)]
+    fn write_zipper_drop_head_over_dangling_child() {
+        let keys = |m: &PathMap<()>| m.iter().map(|(k, _)| k).collect::<Vec<Vec<u8>>>();
+
+        let mut m = with_dangling_c(&[b"dx", b"dy", b"ex", b"fz"]); // dense parent
+        assert!(m.write_zipper().join_k_path_into(1, false));
+        assert_eq!(keys(&m), vec![b"x".to_vec(), b"y".to_vec(), b"z".to_vec()]);
+        assert_valid_nodes(&m);
+
+        let mut m = with_dangling_c(&[b"dx", b"dy", b"ex", b"fz"]);
+        assert!(m.write_zipper().drop_head(1));
+        assert_eq!(keys(&m), vec![b"x".to_vec(), b"y".to_vec(), b"z".to_vec()]);
+
+        let mut m = with_dangling_c(&[b"dx"]); // LineListNode parent
+        assert!(m.write_zipper().join_k_path_into(1, false));
+        assert_eq!(keys(&m), vec![b"x".to_vec()]);
+        assert_valid_nodes(&m);
+
+        //Only a dangling path below the focus: the branch is cleared, nothing is grafted
+        let mut m = with_dangling_c(&[]);
+        assert!(!m.write_zipper().join_k_path_into(1, false));
+        assert_eq!(m.iter().count(), 0);
+    }
+
+    /// Randomized: no-prune removals sprinkle dangling sentinels through random tries; join must be
+    /// the union of the value sets and join_k_path_into must be the head-dropped key set, with no panics
+    /// and valid nodes throughout
+    #[test]
+    fn write_zipper_dangling_children_algebra_randomized() {
+        use rand::prelude::*;
+        let mut rng = StdRng::from_seed([11; 32]);
+        for _ in 0..600 {
+            let alphabet = rng.random_range(2..6u8);
+            let gen_map = |rng: &mut StdRng| {
+                let mut keys: Vec<Vec<u8>> = (0..rng.random_range(1..12)).map(|_| {
+                    let len = rng.random_range(1..=5usize);
+                    (0..len).map(|_| b'a' + rng.random_range(0..alphabet)).collect()
+                }).collect();
+                let mut m = PathMap::<()>::new();
+                for k in &keys { m.set_val_at(k, ()); }
+                keys.shuffle(rng);
+                for k in keys.iter().take(keys.len() / 2) {
+                    let cut = rng.random_range(0..k.len());
+                    let mut wz = m.write_zipper(); wz.descend_to(&k[..cut]);
+                    if rng.random_bool(0.5) { wz.remove_branches(false); } else { wz.remove_val(false); }
+                }
+                m
+            };
+            let a = gen_map(&mut rng);
+            let b = gen_map(&mut rng);
+            let keys = |m: &PathMap<()>| m.iter().map(|(k, _)| k).collect::<Vec<Vec<u8>>>();
+            assert_valid_nodes(&a); assert_valid_nodes(&b);
+
+            let mut expected = keys(&a); expected.extend(keys(&b)); expected.sort(); expected.dedup();
+            let joined = a.join(&b);
+            assert_eq!(keys(&joined), expected, "join");
+            assert_valid_nodes(&joined);
+            let mut a2 = a.clone();
+            a2.write_zipper().join_into(&b.read_zipper());
+            assert_eq!(keys(&a2), expected, "join_into");
+
+            let k = rng.random_range(1..=2usize);
+            // values within the dropped bytes are discarded; only keys longer than k survive
+            let mut expected: Vec<Vec<u8>> = keys(&a).into_iter().filter(|key| key.len() > k).map(|key| key[k..].to_vec()).collect();
+            expected.sort(); expected.dedup();
+            let mut a3 = a.clone();
+            a3.write_zipper().join_k_path_into(k, false);
+            assert_eq!(keys(&a3), expected, "join_k_path_into({k})");
+            assert_eq!(a3.val_count(), expected.len(), "join_k_path_into({k}) val_count");
+            assert_valid_nodes(&a3);
+        }
+    }
+
+    /// Joining two maps whose roots are allocated-but-empty nodes (here: emptied by `remove_branches`
+    /// at the root).  `merge_list_nodes` used to `assume_init` an entry that was never written and then
+    /// drop the garbage payload; the fault is only sometimes visible natively, always under miri.
+    #[test]
+    fn write_zipper_join_emptied_roots() {
+        let emptied = || { let mut m = PathMap::<()>::new(); m.set_val_at(b"x", ()); assert!(m.write_zipper().remove_branches(false)); assert_eq!(m.iter().count(), 0); m };
+        let joined = emptied().join(&emptied());
+        assert_eq!(joined.iter().count(), 0);
+        let mut a = emptied();
+        a.write_zipper().join_into(&emptied().read_zipper());
+        assert_eq!(a.iter().count(), 0);
+        let mut plain = PathMap::<()>::new(); plain.set_val_at(b"yz", ());
+        assert_eq!(emptied().join(&plain).iter().count(), 1);
+        assert_eq!(plain.join(&emptied()).iter().count(), 1);
+    }
+
+    /// The same byte is a dangling path (no value, no onward node) in two DenseByteNodes being joined
+    #[test]
+    fn write_zipper_join_dangling_in_both_dense_nodes() {
+        let dangling_c = || {
+            let mut m = PathMap::<()>::new();
+            for k in [b"ca".as_slice(), b"cb", b"d", b"e", b"f"] { m.set_val_at(k, ()); }
+            let mut wz = m.write_zipper(); wz.descend_to(b"c"); wz.remove_branches(false); drop(wz);
+            let mut rz = m.read_zipper(); rz.descend_to(b"c");
+            assert!(rz.path_exists());
+            m
+        };
+        let joined = dangling_c().join(&dangling_c());
+        assert_eq!(joined.iter().map(|(k, _)| k).collect::<Vec<Vec<u8>>>(), vec![b"d".to_vec(), b"e".to_vec(), b"f".to_vec()]);
+        assert_valid_nodes(&joined);
+        let mut a = dangling_c();
+        a.write_zipper().join_into(&dangling_c().read_zipper());
+        assert_eq!(a.iter().count(), 3);
+        assert_valid_nodes(&a);
+    }
+
+    /// `join_k_path_into` where the two slots of a LineListNode shorten onto the *same* key: the payloads
+    /// must be merged.  Previously two value slots were left on one key (a path with two values:
+    /// iteration reported it once, `val_count` twice).
+    #[test]
+    fn write_zipper_join_k_path_collapsing_keys() {
+        let keys = |m: &PathMap<()>| m.iter().map(|(k, _)| k).collect::<Vec<Vec<u8>>>();
+
+        let mut m = PathMap::<()>::new();
+        for k in [b"aaaa".as_slice(), b"acaa"] { m.set_val_at(k, ()); }
+        assert!(m.write_zipper().join_k_path_into(3, false));
+        assert_eq!(keys(&m), vec![b"a".to_vec()]);
+        assert_eq!(m.val_count(), 1);
+        assert_valid_nodes(&m);
+
+        //two children collapsing onto one key
+        let mut m = PathMap::<()>::new();
+        for k in [b"abx1".as_slice(), b"abx2", b"acx1", b"acx3"] { m.set_val_at(k, ()); }
+        let mut wz = m.write_zipper(); wz.descend_to(b"a"); assert!(wz.join_k_path_into(1, false)); drop(wz);
+        assert_eq!(keys(&m), vec![b"ax1".to_vec(), b"ax2".to_vec(), b"ax3".to_vec()]);
+        assert_eq!(m.val_count(), 3);
+        assert_valid_nodes(&m);
+
+        //a value and a child on the same key is the legal representation and is left alone
+        let mut m = PathMap::<()>::new();
+        for k in [b"aaa".as_slice(), b"acab", b"acac"] { m.set_val_at(k, ()); }
+        assert!(m.write_zipper().join_k_path_into(2, false));
+        assert_eq!(keys(&m), vec![b"a".to_vec(), b"ab".to_vec(), b"ac".to_vec()]);
+        assert_eq!(m.val_count(), 3);
+    }
+
+    /// An emptied root (`remove_branches` at the root always leaves a LineListNode) joined with an empty
+    /// map whose root was materialized by a read (a dense node under `all_dense_nodes`): both orders,
+    /// with and without a root value.  Exercises the empty∪empty paths of every node-type pairing.
+    #[test]
+    fn write_zipper_join_mixed_empty_roots() {
+        let emptied = || { let mut m = PathMap::<()>::new(); m.set_val_at(b"x", ()); assert!(m.write_zipper().remove_branches(true)); m };
+        let empty_with_root = || { let m = PathMap::<()>::new(); assert_eq!(m.iter().count(), 0); m };
+        assert_eq!(emptied().join(&empty_with_root()).iter().count(), 0);
+        assert_eq!(empty_with_root().join(&emptied()).iter().count(), 0);
+        let mut a = emptied(); a.write_zipper().join_into(&empty_with_root().read_zipper()); assert_eq!(a.iter().count(), 0);
+        let mut a = empty_with_root(); a.write_zipper().join_into(&emptied().read_zipper()); assert_eq!(a.iter().count(), 0);
+        let mut a = emptied(); a.set_val_at(b"", ());
+        assert_eq!(a.join(&empty_with_root()).iter().count(), 1);
+        assert_eq!(empty_with_root().join(&a).iter().count(), 1);
+    }
+
+    /// `join_k_path_into` shortening two value keys onto a shared first byte must yield the canonical
+    /// layout (Child@"a" -> {a, b}), not (Val@"aa", Val@"ab"): the latter defeats indexed descent and
+    /// every catamorphism engine (the PR #31 iterative engine loops on it).
+    #[test]
+    fn write_zipper_drop_head_shared_first_byte_is_canonical() {
+        use crate::morphisms::Catamorphism;
+        let mut m = PathMap::<()>::new();
+        for k in [b"aaa".as_slice(), b"bab"] { m.set_val_at(k, ()); }
+        assert!(m.write_zipper().join_k_path_into(1, false));
+        assert_eq!(m.iter().map(|(k, _)| k).collect::<Vec<Vec<u8>>>(), vec![b"aa".to_vec(), b"ab".to_vec()]);
+        //indexed descent must reach both children below "a"
+        let mut rz = m.read_zipper();
+        rz.descend_to_byte(b'a');
+        assert!(rz.path_exists());
+        assert_eq!(rz.child_count(), 2);
+        assert!(rz.descend_indexed_byte(1).is_some());
+        //the (zipper-driven) cached cata must agree with iteration
+        let n = m.read_zipper().into_cata_cached(|_m, ws: &mut [usize], v: Option<&()>| ws.iter().sum::<usize>() + v.is_some() as usize);
+        assert_eq!(n, 2);
+        assert_valid_nodes(&m);
+
+        //the same through a shared (grafted) subtrie, as the randomized program found it
+        let mut map = PathMap::<()>::new(); map.set_val_at(b"", ());
+        let mut other = PathMap::<()>::new();
+        for k in [b"".as_slice(), b"a", b"aaaa", b"abab", b"b", b"ba", b"baa", b"bbaa", b"bbb"] { other.set_val_at(k, ()); }
+        { let mut rz = other.read_zipper(); rz.descend_to(b"a"); let mut wz = map.write_zipper(); wz.graft(&rz); }
+        assert!(map.write_zipper().join_k_path_into(1, false));
+        let n = map.read_zipper().into_cata_cached(|_m, ws: &mut [usize], v: Option<&()>| ws.iter().sum::<usize>() + v.is_some() as usize);
+        assert_eq!(n, 3);
+        assert_valid_nodes(&map);
+    }
 }


### PR DESCRIPTION
(addressing #85 + blast radius)

A dangling path (a location that exists in the trie but has no value and nothing
below it, as left by `remove_branches(prune = false)`, `remove_val(prune = false)`,
or `create_path`) is stored as a child link to the shared empty sentinel node. The
sentinel has no refcount word, so it cannot be made mutable, and several code paths
reached `make_mut` on it, unwrapped a node that is not there, or hit an
`unreachable!()` that assumed both operands of a join were non-empty. This branch
makes every operation that can meet a sentinel treat it as "nothing here" and
replace it rather than mutate it. It covers all four items of issue #85 plus the
join and drop-head paths that the same representation breaks.

## Joins and drop_head over a dangling path (commit 1)

- `TrieNodeODRc::join_into`: joining an empty node into anything is the identity;
  joining anything into an empty node replaces it. `DenseByteNode::join_into_dyn`
  and the CoFree join route through it, so a dangling child on either side no
  longer reaches `make_mut`.
- `ByteNode::pjoin` / `join_into`: two dangling paths at the same byte join to a
  dangling path instead of `unreachable!()`.
- `drop_head_dyn` (dense and list): a dangling child contributes nothing to the
  dropped-head result and is skipped instead of made mutable.
- `merge_list_nodes`: when both nodes are empty it returns `None` before touching
  `entries[0]`; reading it was an `assume_init` on uninitialised memory, and
  dropping the garbage payload corrupted an arbitrary refcount (the test binary
  aborted with SIGABRT).
- `LineListNode::pjoin_dyn` against a dense node: two empty nodes join to an empty
  result instead of `unreachable!()`.
- `LineListNode::factor_prefix`: a value at a multi-byte key sharing its first byte
  with the other slot is no longer called legal; `drop_head` could leave
  `(Val@"aa", Val@"ab")`, a shape insertion never creates and indexed descent
  cannot traverse, and it is now factored into `Child@"a" -> {a, b}`. `drop_head`
  also merges two keys that coincide after shortening, which used to leave one
  path with two values (iteration saw it once, `val_count` twice).
- `join_k_path_into`: an empty result clears the branch instead of grafting an
  empty node.
- Tests: dangling children under pair-node and dense parents, joins of emptied
  roots, `join_k_path_into` over dangling children, and a randomised algebra
  program that checks node invariants after every step.

## graft_masked_branches at a dangling focus (commits 2 and 3; issue #85 item 3)

- With three or more mask bits the method split the focus before looking at the
  source, and at a dangling tip or empty root the split has no node to hand back:
  `try_borrow_focus_mut().unwrap()` on `None`. Masked branches the source lacks
  are now removed up front in every arm, as the doc comment specifies, only
  branches the source has are grafted, and a focus that is an empty stub gets a
  fresh node to merge into.
- The one- and two-bit arms previously grafted whatever the source had at each
  masked byte, which for an absent branch left a dangling child behind, while the
  three-bit arm removed it; the arms now agree.

## Write zipper reads after the root is emptied (commit 4)

- `MutNodeStack::top()` returned `None` for an empty root while `top_mut()`
  returned the node, so after `remove_branches` at the root (or a
  `join_k_path_into` that collapsed everything) the next `path_exists` unwrapped
  `None`. `top()` now returns the empty node, which every reader already handles.

## Issue #85 items 1, 2, 4 (commits 5 to 7)

- `ByteNode::get_child_mut` reports an empty rec as "no child", as
  `LineListNode::get_child_mut` already does. A pair node upgraded to a dense node
  carries its dangling slot over as such a rec, and the descent called `make_mut`
  on it for any operation continuing below the dangling byte
  (`set_val_at(b"cx")`, a graft at `cxy`, `restrict`, `remove_unmasked_branches`).
  The descent now stops at the parent and the following mutator replaces the rec
  through `set_child`.
- `join_into_take`: an empty taken source leaves the destination alone and answers
  `Identity`; an empty taken destination is replaced by the source. Both
  previously handed the sentinel to `make_mut` or to `graft_internal`.
- `LineListNode::restrict_slot_contents`: a child-link slot whose key leads to a
  dangling byte of the other operand is dropped, mirroring
  `subtract_from_slot_contents`; calling `as_tagged` on the missing node was an
  explicit panic in `PathMap::restrict` and both zipper forms.
- Each carries the reproductions from the issue, including its controls, as
  regression tests.

## Verification

- `cargo test --release`: 848 tests pass.
- Differential fuzzing against the Lean model, same generator and seeds as the
  master baseline: crate run 14786 -> 15105 of 20000 programs agreeing; ACT run
  2357 -> 2407 of 5000. The "make_unique on an empty sentinel" class (344 programs
  on master) no longer occurs. The three divergences new to this branch are
  programs that previously died earlier on a panic fixed here.

## Not in this branch

- The dense `drop_head_dyn` still folds children from the highest byte, so a value
  collision in `join_k_path_into` keeps the highest k-path's value where the list
  node and the specification keep the lowest. Unrelated to the sentinel and left
  as is.
