### PR TITLE
zipper_algebra: pass a more reasonable child mask

### DIFF
--- a/src/experimental/zipper_algebra.rs
+++ b/src/experimental/zipper_algebra.rs
@@ -515,11 +515,11 @@ where
         Out: ZipperWriting<V, A>,
     {
         if *lhs_grafts != ByteMask::EMPTY {
-            out.graft_masked_branches(lhs, std::mem::take(lhs_grafts), false);
+            out.graft_masked_branches(lhs, std::mem::take(lhs_grafts) & lhs.child_mask(), false);
         }
 
         if *rhs_grafts != ByteMask::EMPTY {
-            out.graft_masked_branches(rhs, std::mem::take(rhs_grafts), false);
+            out.graft_masked_branches(rhs, std::mem::take(rhs_grafts) & rhs.child_mask(), false);
         }
     }
 
@@ -729,15 +729,15 @@ where
         Out: ZipperWriting<V, A>,
     {
         if *lhs_grafts != ByteMask::EMPTY {
-            out.graft_masked_branches(lhs, std::mem::take(lhs_grafts), false);
+            out.graft_masked_branches(lhs, std::mem::take(lhs_grafts) & lhs.child_mask(), false);
         }
 
         if *mid_grafts != ByteMask::EMPTY {
-            out.graft_masked_branches(mid, std::mem::take(mid_grafts), false);
+            out.graft_masked_branches(mid, std::mem::take(mid_grafts) & mid.child_mask(), false);
         }
 
         if *rhs_grafts != ByteMask::EMPTY {
-            out.graft_masked_branches(rhs, std::mem::take(rhs_grafts), false);
+            out.graft_masked_branches(rhs, std::mem::take(rhs_grafts) & rhs.child_mask(), false);
         }
     }
 
@@ -1011,19 +1011,19 @@ fn zipper_merge4<P, V, Z0, Z1, Z2, Z3, Out, A>(
         Out: ZipperWriting<V, A>,
     {
         if *z0_grafts != ByteMask::EMPTY {
-            out.graft_masked_branches(z0, std::mem::take(z0_grafts), false);
+            out.graft_masked_branches(z0, std::mem::take(z0_grafts) & z0.child_mask(), false);
         }
 
         if *z1_grafts != ByteMask::EMPTY {
-            out.graft_masked_branches(z1, std::mem::take(z1_grafts), false);
+            out.graft_masked_branches(z1, std::mem::take(z1_grafts) & z1.child_mask(), false);
         }
 
         if *z2_grafts != ByteMask::EMPTY {
-            out.graft_masked_branches(z2, std::mem::take(z2_grafts), false);
+            out.graft_masked_branches(z2, std::mem::take(z2_grafts) & z2.child_mask(), false);
         }
 
         if *z3_grafts != ByteMask::EMPTY {
-            out.graft_masked_branches(z3, std::mem::take(z3_grafts), false);
+            out.graft_masked_branches(z3, std::mem::take(z3_grafts) & z3.child_mask(), false);
         }
     }
 
@@ -1665,7 +1665,12 @@ where
     {
         for_each_bit(active, |i| {
             if grafts[i] != ByteMask::EMPTY {
-                out.graft_masked_branches(&zs[i], std::mem::take(&mut grafts[i]), false);
+                let z = &zs[i];
+                out.graft_masked_branches(
+                    z,
+                    std::mem::take(&mut grafts[i]) & z.child_mask(),
+                    false,
+                );
             }
         });
     }


### PR DESCRIPTION
This leads to a few percent speed-up in the benchmarks. For instance, for symmetric difference simulation, before this we had:

```
Timer precision: 33 ns
ops               fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ xor                          │               │               │               │         │
├─ base_2b     71.11 ms      │ 72.15 ms      │ 71.48 ms      │ 71.55 ms      │ 5       │ 50
├─ base_4b     838.6 ms      │ 858.7 ms      │ 840.8 ms      │ 844.1 ms      │ 5       │ 50
├─ zipper2_2b  308.1 ms      │ 312.8 ms      │ 310.3 ms      │ 310.2 ms      │ 5       │ 50
├─ zipper2_4b  2.625 s       │ 2.65 s        │ 2.635 s       │ 2.636 s       │ 5       │ 50
├─ zipper4_2b  158.1 ms      │ 159.3 ms      │ 158.7 ms      │ 158.7 ms      │ 5       │ 50
╰─ zipper4_4b  1.603 s       │ 1.617 s       │ 1.615 s       │ 1.612 s       │ 5       │ 50
```

and now we have

```
Timer precision: 31 ns
ops               fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ xor                          │               │               │               │         │
├─ base_2b     75.49 ms      │ 75.92 ms      │ 75.67 ms      │ 75.67 ms      │ 5       │ 50
├─ base_4b     850.8 ms      │ 868.2 ms      │ 857.7 ms      │ 858.6 ms      │ 5       │ 50
├─ zipper2_2b  315.6 ms      │ 320.1 ms      │ 317.7 ms      │ 317.7 ms      │ 5       │ 50
├─ zipper2_4b  2.147 s       │ 2.194 s       │ 2.15 s        │ 2.167 s       │ 5       │ 50
├─ zipper4_2b  155.8 ms      │ 158.4 ms      │ 155.9 ms      │ 156.5 ms      │ 5       │ 50
╰─ zipper4_4b  1.285 s       │ 1.312 s       │ 1.286 s       │ 1.296 s       │ 5       │ 50
```

so there is another quite considerable speed-up (especially for longer paths)