### PR TITLE
Add self-hosted CI: tests and A/B benches on PRs

### DIFF
--- a/.github/scripts/bench_ab.sh
+++ b/.github/scripts/bench_ab.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# A/B benchmark of two commits on the same machine.
+#
+# Builds the bench binaries for BASE and HEAD once each (separate target
+# dirs), then runs them for ROUNDS rounds, alternating which side goes first
+# and pinning every run to one core.  Per-bench results are averaged over the
+# rounds with benches/bench_avg_files.py and compared with benches/bench_cmp.py.
+#
+# usage: bench_ab.sh <base-sha> <head-sha>
+#
+# env:  BENCH_ROUNDS       rounds per side                (default 3)
+#       BENCHES            space separated bench targets  (default: the set used in BENCH_BUGFIXES)
+#       BENCH_CPU          core to pin to                 (default 3)
+#       BENCH_OUT          output directory               (default ./bench-out)
+#       DIVAN_SAMPLE_COUNT sample count for benches that do not set their own (default 40)
+#       CARGO_TARGET_DIR   parent of the two per-side target dirs (default ./target)
+set -euo pipefail
+
+BASE_SHA=${1:?usage: bench_ab.sh <base-sha> <head-sha>}
+HEAD_SHA=${2:?usage: bench_ab.sh <base-sha> <head-sha>}
+ROUNDS=${BENCH_ROUNDS:-3}
+BENCHES=${BENCHES:-"shakespeare cities sparse_keys binary_keys superdense_keys act_paths zipper_head_owned product_zipper"}
+CPU=${BENCH_CPU:-3}
+OUT=$(realpath -m "${BENCH_OUT:-$PWD/bench-out}")
+TARGET=$(realpath -m "${CARGO_TARGET_DIR:-$PWD/target}")
+export DIVAN_SAMPLE_COUNT=${DIVAN_SAMPLE_COUNT:-40}
+
+repo=$PWD
+base_src=$OUT/src-base
+mkdir -p "$OUT"
+rm -f "$OUT"/*.txt "$OUT"/*.log
+
+cleanup() { git -C "$repo" worktree remove --force "$base_src" 2>/dev/null || true; }
+trap cleanup EXIT
+cleanup
+git worktree add --detach "$base_src" "$BASE_SHA" >/dev/null
+
+# build_side <side> <src-dir> : writes "<bench> <executable>" lines to $OUT/bins-<side>.txt
+build_side() {
+    local side=$1 src=$2 args=()
+    for b in $BENCHES; do args+=(--bench "$b"); done
+    echo "== building $side ($(git -C "$src" rev-parse --short HEAD)) into $TARGET/ab-$side"
+    (cd "$src" && cargo bench --no-run --message-format=json "${args[@]}" \
+        --target-dir "$TARGET/ab-$side" 2>"$OUT/build-$side.log") \
+    | python3 -c '
+import json, sys
+for line in sys.stdin:
+    m = json.loads(line)
+    if m.get("reason") == "compiler-artifact" and m.get("executable") and "bench" in m["target"]["kind"]:
+        print(m["target"]["name"], m["executable"])
+' > "$OUT/bins-$side.txt"
+    for b in $BENCHES; do
+        grep -q "^$b " "$OUT/bins-$side.txt" || { echo "no executable for bench $b on $side" >&2; exit 1; }
+    done
+}
+
+build_side base "$base_src"
+build_side head "$repo"
+
+exe_for() { awk -v n="$2" '$1 == n { print $2 }' "$OUT/bins-$1.txt"; }
+
+for ((r = 1; r <= ROUNDS; r++)); do
+    if (( r % 2 )); then order="base head"; else order="head base"; fi
+    for b in $BENCHES; do
+        for side in $order; do
+            echo "== round $r/$ROUNDS $b $side"
+            taskset -c "$CPU" "$(exe_for "$side" "$b")" --bench \
+                > "$OUT/$side-$b-r$r.txt" 2>> "$OUT/run-$side.log"
+        done
+    done
+done
+
+strip_ansi() { sed 's/\x1b\[[0-9;]*m//g'; }
+: > "$OUT/compare.txt"
+for b in $BENCHES; do
+    for side in base head; do
+        python3 "$repo/benches/bench_avg_files.py" "$OUT/$side-$b-r"*.txt -o "$OUT/$side-$b-avg.txt"
+    done
+    {
+        echo "$b  (base $(git rev-parse --short "$BASE_SHA")  head $(git rev-parse --short "$HEAD_SHA")  rounds $ROUNDS  median ns)"
+        python3 "$repo/benches/bench_cmp.py" --base "$OUT/base-$b-avg.txt" --other "$OUT/head-$b-avg.txt" | strip_ansi
+        echo
+    } >> "$OUT/compare.txt"
+done
+cat "$OUT/compare.txt"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,109 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+  workflow_dispatch:
+    inputs:
+      base:
+        description: base ref to benchmark against
+        default: master
+      rounds:
+        description: bench rounds per side
+        default: "3"
+      benches:
+        description: space separated bench targets (empty = default set)
+        default: ""
+
+permissions:
+  contents: read
+
+# One workflow run per PR / branch; a new push cancels the one in progress.
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: never
+  # Persistent across jobs on the runner (outside its _work dir), so builds are incremental.
+  CARGO_TARGET_DIR: /home/gh-runner/cache/target
+
+jobs:
+  test:
+    name: tests
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+      - name: toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustc --version && cargo --version
+      - name: build
+        run: cargo build --release --all-targets
+      - name: unit + integration tests
+        run: cargo test --release
+      - name: tests with arena_compact + random
+        run: cargo test --release --features arena_compact,random
+      - name: doc tests + docs
+        run: cargo doc --no-deps
+
+  bench:
+    name: bench A/B vs base
+    # PRs and manual runs only; a push to master has nothing to compare against.
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    runs-on: [self-hosted, linux, x64, bench]
+    timeout-minutes: 300
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+      - name: resolve base
+        id: base
+        run: |
+          if [ "${{ github.event_name }}" = pull_request ]; then
+            sha=${{ github.event.pull_request.base.sha }}
+          else
+            sha=$(git rev-parse "origin/${{ inputs.base }}" 2>/dev/null || git rev-parse "${{ inputs.base }}")
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+      - name: A/B bench
+        env:
+          BENCH_ROUNDS: ${{ inputs.rounds || '3' }}
+          BENCHES: ${{ inputs.benches }}
+          BENCH_OUT: ${{ runner.temp }}/bench-out
+        run: |
+          # an empty BENCHES must fall through to the script's default set
+          [ -n "$BENCHES" ] || unset BENCHES
+          .github/scripts/bench_ab.sh "${{ steps.base.outputs.sha }}" "${{ github.sha }}"
+      - name: summary
+        if: always()
+        run: |
+          out="${{ runner.temp }}/bench-out"
+          if [ -s "$out/compare.txt" ]; then
+            { echo '```'; cat "$out/compare.txt"; echo '```'; } > "$out/compare.md"
+            cat "$out/compare.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: bench-out
+          path: ${{ runner.temp }}/bench-out/*.txt
+          if-no-files-found: ignore
+      - name: comment on PR
+        # The token is read-only for PRs from forks, so only comment on same-repo PRs.
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: bench
+          path: ${{ runner.temp }}/bench-out/compare.md


### PR DESCRIPTION
Workflow runs on the self-hosted runner: a test job (release build, cargo test with default and arena_compact+random features, docs) and a bench job that benchmarks the PR head against its base on the same machine.  bench_ab.sh builds both sides once, runs them in alternating order pinned to one core, averages the rounds with bench_avg_files.py and posts the bench_cmp.py table to the step summary and the PR.